### PR TITLE
(backport) fix(password): add screen-reader only text for password

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -753,6 +753,9 @@ export interface ClrCommonStrings {
     next: string;
     nextPage: string;
     open: string;
+    passwordHide: string;
+    // (undocumented)
+    passwordShow: string;
     pickColumns: string;
     previous: string;
     previousPage: string;
@@ -785,6 +788,8 @@ export interface ClrCommonStrings {
     // (undocumented)
     verticalNavToggle: string;
     warning: string;
+    wizardStepError: string;
+    wizardStepSuccess: string;
 }
 
 // @public (undocumented)

--- a/projects/angular/src/forms/password/password-container.spec.ts
+++ b/projects/angular/src/forms/password/password-container.spec.ts
@@ -96,6 +96,13 @@ export default function (): void {
         fixture.detectChanges();
         expect(containerEl.querySelector('button')).toBeFalsy();
       });
+      it('should provide screen-reader only text for toggle button', () => {
+        const button: HTMLButtonElement = containerEl.querySelector('button');
+        expect(button.textContent).toEqual('Show password');
+        button.click();
+        fixture.detectChanges();
+        expect(button.textContent).toEqual('Hide password');
+      });
     });
   });
 }

--- a/projects/angular/src/forms/password/password-container.ts
+++ b/projects/angular/src/forms/password/password-container.ts
@@ -43,6 +43,9 @@ export const TOGGLE_SERVICE_PROVIDER = { provide: TOGGLE_SERVICE, useFactory: To
               [attr.shape]="show ? 'eye-hide' : 'eye'"
               [attr.title]="show ? commonStrings.keys.hide : commonStrings.keys.show"
             ></cds-icon>
+            <span class="clr-sr-only">{{
+              show ? commonStrings.keys.passwordHide : commonStrings.keys.passwordShow
+            }}</span>
           </button>
         </div>
         <cds-icon

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -91,4 +91,14 @@ export const commonStringsDefault: ClrCommonStrings = {
   datagridExpandableEndOf: 'End of',
   datagridExpandableRowContent: 'Expandable row content',
   datagridExpandableRowsHelperText: `Screen reader table commands may not work for viewing expanded content, please use your screen reader's browse mode to read the content exposed by this button`,
+  // Wizard
+  wizardStepSuccess: 'Completed',
+  wizardStepError: 'Error',
+
+  /**
+   * Password Input
+   * Screen-reader text for the hide/show password field button
+   */
+  passwordHide: 'Hide password',
+  passwordShow: 'Show password',
 };

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -265,4 +265,21 @@ export interface ClrCommonStrings {
   comboboxSelected: string;
   comboboxNoResults: string;
   comboboxOpen: string;
+
+  /**
+   * Wizard: Screen-reader text for completed step.
+   */
+  wizardStepSuccess: string;
+
+  /**
+   * Wizard: Screen-reader text for step with error.
+   */
+  wizardStepError: string;
+
+  /**
+   * Password Input
+   * Screen-reader text for the hide/show password field button.
+   */
+  passwordHide: string;
+  passwordShow: string;
 }


### PR DESCRIPTION
Signed-off-by: Ashley Ryan <asryan@vmware.com>

Backport https://github.com/vmware/clarity/pull/6648

I'm fixing a related VPAT, so backporting this to v12

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] clarity.design website / infrastructure changes
- [ ] Other... Please describe:

## What is the new behavior?

Fixes VPAT-667, VPAT-5242

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
