### PR TITLE
fix(dropdown): icon trigger alignment with label

### DIFF
--- a/projects/angular/src/popover/dropdown/_dropdown.clarity.scss
+++ b/projects/angular/src/popover/dropdown/_dropdown.clarity.scss
@@ -19,7 +19,9 @@
     display: inline-block;
 
     .dropdown-toggle {
-      display: inline-block;
+      display: inline-flex;
+      align-items: center;
+      justify-content: center;
       position: relative;
       margin: 0;
       white-space: nowrap;
@@ -28,8 +30,6 @@
       clr-icon[shape^='caret'],
       clr-icon[shape^='angle'] {
         position: absolute;
-        top: 50%;
-        transform: translateY(-50%);
         color: inherit;
         @include min-equilateral($clr-dropdown-caret-icon-dimension);
       }
@@ -41,7 +41,6 @@
       cds-icon[shape^='angle'] {
         margin-top: unset;
         position: absolute;
-        top: 35%;
         color: inherit;
         @include equilateral($clr-dropdown-caret-icon-dimension);
         // need custom property override here to force minimum size of
@@ -53,6 +52,13 @@
         padding-right: $clr-btn-horizontal-padding + $clr-dropdown-caret-icon-dimension +
           $clr-dropdown-caret-left-margin;
         text-overflow: unset;
+
+        clr-icon {
+          /**
+           * The .btn applies some transform settings that we need to remove in here to align the icon correctly
+           */
+          transform: none;
+        }
 
         cds-icon[shape^='caret'],
         clr-icon[shape^='caret'],


### PR DESCRIPTION
Closes #36

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #36 

## What is the new behavior?

The alignment with `cds-icon` and `clr-icon` with the label is correctly. 

<img width="727" alt="image" src="https://user-images.githubusercontent.com/15037947/159677194-23deddf9-72d5-4db0-bfde-07f1fd277f5f.png">


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
