### PR TITLE
(backport) fix(vertical-nav): use sr-only css for collapsed link text

### DIFF
--- a/projects/angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
+++ b/projects/angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
@@ -489,7 +489,7 @@
 
         .nav-group-text,
         .nav-text {
-          display: none;
+          @include screen-reader-only();
         }
       }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The link text is set to display:none when collapsed, which is invisible to screen readers

## What is the new behavior?

use the screen-reader-only mixin so the link text is visible to screen readers

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
