### PR TITLE
chore: match dot folders with stylelint

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "_lint:format:fix": "npm run --silent _lint:format -- -w",
     "_lint:format:changed": "node ./scripts/get-changed-files.js --command \"prettier -c --loglevel warn --ignore-unknown\" --filter \"**\"",
     "_lint:format:changed:fix": "node ./scripts/get-changed-files.js --command \"prettier -w --loglevel warn --ignore-unknown\" --filter \"**\"",
-    "_lint:styles": "stylelint \"**/*.{css,scss,sass}\"",
+    "_lint:styles": "stylelint \"**/*.{css,scss,sass}\" \"**/.*/**/*.{css,scss,sass}\"",
     "_lint:styles:fix": "npm run --silent _lint:styles -- --fix",
     "_lint:styles:changed": "node ./scripts/get-changed-files.js --command \"stylelint\" --filter \"**/*.{css,scss,sass}\"",
     "_lint:styles:changed:fix": "node ./scripts/get-changed-files.js --command \"stylelint --fix\" --filter \"**/*.{css,scss,sass}\""


### PR DESCRIPTION
Stylelint ignores dot folders such as ".storybook". This PR makes it so any dot folders that aren't specifically excluded are picked up. This keeps the build process in sync with the changes we're making to the Core repo.

## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
