### PR TITLE
feat(nav): add clrAriaCurrentLink directive for nav links

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -39,6 +39,7 @@ import { OnInit } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { Renderer2 } from '@angular/core';
 import { RendererFactory2 } from '@angular/core';
+import { RouterLinkActive } from '@angular/router';
 import { SelectMultipleControlValueAccessor } from '@angular/forms';
 import { SimpleChange } from '@angular/core';
 import { SimpleChanges } from '@angular/core';
@@ -262,7 +263,7 @@ export class ClrAccordionModule {
     // Warning: (ae-forgotten-export) The symbol "i7" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrAccordionModule, [typeof i1_46.ClrAccordion, typeof i2_36.ClrAccordionPanel, typeof i3_28.ClrAccordionTitle, typeof i4_19.ClrAccordionDescription, typeof i5_15.ClrAccordionContent, typeof i6_11.AccordionOompaLoompa, typeof i7_10.AccordionWillyWonka], [typeof i6.CommonModule, typeof i3_2.ClrIconModule], [typeof i1_46.ClrAccordion, typeof i2_36.ClrAccordionPanel, typeof i3_28.ClrAccordionTitle, typeof i4_19.ClrAccordionDescription, typeof i5_15.ClrAccordionContent, typeof i6_11.AccordionOompaLoompa, typeof i7_10.AccordionWillyWonka]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrAccordionModule, [typeof i1_46.ClrAccordion, typeof i2_36.ClrAccordionPanel, typeof i3_28.ClrAccordionTitle, typeof i4_19.ClrAccordionDescription, typeof i5_16.ClrAccordionContent, typeof i6_11.AccordionOompaLoompa, typeof i7_10.AccordionWillyWonka], [typeof i6.CommonModule, typeof i3_2.ClrIconModule], [typeof i1_46.ClrAccordion, typeof i2_36.ClrAccordionPanel, typeof i3_28.ClrAccordionTitle, typeof i4_19.ClrAccordionDescription, typeof i5_16.ClrAccordionContent, typeof i6_11.AccordionOompaLoompa, typeof i7_10.AccordionWillyWonka]>;
 }
 
 // @public (undocumented)
@@ -470,6 +471,21 @@ export enum ClrAlignment {
     END = 1,
     // (undocumented)
     START = 0
+}
+
+// @public (undocumented)
+export class ClrAriaCurrentLink implements OnInit, OnDestroy {
+    constructor(rla: RouterLinkActive);
+    // (undocumented)
+    ariaCurrent: string | undefined;
+    // (undocumented)
+    ngOnDestroy(): void;
+    // (undocumented)
+    ngOnInit(): void;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<ClrAriaCurrentLink, "[clrAriaCurrentLink]", never, {}, {}, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<ClrAriaCurrentLink, never>;
 }
 
 // @public (undocumented)
@@ -2982,9 +2998,10 @@ export class ClrNavigationModule {
     // Warning: (ae-forgotten-export) The symbol "i2" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "i3" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "i4" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "i5" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrNavigationModule, [typeof i1_38.ClrHeader, typeof i2_28.ClrNavLevel, typeof i3_19.NavDetectionOompaLoompa, typeof i4_13.MainContainerWillyWonka], [typeof i6.CommonModule, typeof i3_2.ClrIconModule, typeof i8.ClrDropdownModule], [typeof i1_38.ClrHeader, typeof i2_28.ClrNavLevel, typeof i3_19.NavDetectionOompaLoompa, typeof i4_13.MainContainerWillyWonka]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrNavigationModule, [typeof i1_38.ClrHeader, typeof i2_28.ClrNavLevel, typeof i3_19.ClrAriaCurrentLink, typeof i4_13.NavDetectionOompaLoompa, typeof i5_11.MainContainerWillyWonka], [typeof i6.CommonModule, typeof i3_2.ClrIconModule, typeof i8.ClrDropdownModule], [typeof i1_38.ClrHeader, typeof i2_28.ClrNavLevel, typeof i3_19.ClrAriaCurrentLink, typeof i4_13.NavDetectionOompaLoompa, typeof i5_11.MainContainerWillyWonka]>;
 }
 
 // @public (undocumented)
@@ -3941,7 +3958,7 @@ export class ClrStepperModule {
     // Warning: (ae-forgotten-export) The symbol "i8" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrStepperModule, [typeof i1_45.ClrStepper, typeof i2_35.ClrStepButton, typeof i3_27.ClrStepperPanel, typeof i4_18.StepperOompaLoompa, typeof i5_14.StepperWillyWonka], [typeof i6.CommonModule, typeof i3_2.ClrIconModule, typeof i8_8.ClrAccordionModule], [typeof i1_45.ClrStepper, typeof i2_35.ClrStepButton, typeof i3_27.ClrStepperPanel, typeof i4_18.StepperOompaLoompa, typeof i5_14.StepperWillyWonka, typeof i8_8.ClrAccordionModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrStepperModule, [typeof i1_45.ClrStepper, typeof i2_35.ClrStepButton, typeof i3_27.ClrStepperPanel, typeof i4_18.StepperOompaLoompa, typeof i5_15.StepperWillyWonka], [typeof i6.CommonModule, typeof i3_2.ClrIconModule, typeof i8_8.ClrAccordionModule], [typeof i1_45.ClrStepper, typeof i2_35.ClrStepButton, typeof i3_27.ClrStepperPanel, typeof i4_18.StepperOompaLoompa, typeof i5_15.StepperWillyWonka, typeof i8_8.ClrAccordionModule]>;
 }
 
 // @public (undocumented)
@@ -4131,7 +4148,7 @@ export class ClrTabsModule {
     // Warning: (ae-forgotten-export) The symbol "i11" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrTabsModule, [typeof i1_39.ClrTabContent, typeof i2_29.ClrTab, typeof i3_21.ClrTabs, typeof i4_14.ClrTabOverflowContent, typeof i5_11.ClrTabLink, typeof i6_9.TabsWillyWonka, typeof i7_8.ActiveOompaLoompa], [typeof i6.CommonModule, typeof i6_2.ClrConditionalModule, typeof i3_2.ClrIconModule, typeof i11_4.ClrTemplateRefModule, typeof i10_4.ClrKeyFocusModule], [typeof i1_39.ClrTabContent, typeof i2_29.ClrTab, typeof i3_21.ClrTabs, typeof i4_14.ClrTabOverflowContent, typeof i5_11.ClrTabLink, typeof i6_9.TabsWillyWonka, typeof i7_8.ActiveOompaLoompa, typeof i6_2.ClrConditionalModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrTabsModule, [typeof i1_39.ClrTabContent, typeof i2_29.ClrTab, typeof i3_21.ClrTabs, typeof i4_14.ClrTabOverflowContent, typeof i5_12.ClrTabLink, typeof i6_9.TabsWillyWonka, typeof i7_8.ActiveOompaLoompa], [typeof i6.CommonModule, typeof i6_2.ClrConditionalModule, typeof i3_2.ClrIconModule, typeof i11_4.ClrTemplateRefModule, typeof i10_4.ClrKeyFocusModule], [typeof i1_39.ClrTabContent, typeof i2_29.ClrTab, typeof i3_21.ClrTabs, typeof i4_14.ClrTabOverflowContent, typeof i5_12.ClrTabLink, typeof i6_9.TabsWillyWonka, typeof i7_8.ActiveOompaLoompa, typeof i6_2.ClrConditionalModule]>;
 }
 
 // @public (undocumented)
@@ -4213,7 +4230,7 @@ export class ClrTimelineModule {
     // Warning: (ae-forgotten-export) The symbol "i5" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrTimelineModule, [typeof i1_48.ClrTimeline, typeof i2_37.ClrTimelineStep, typeof i3_29.ClrTimelineStepDescription, typeof i4_20.ClrTimelineStepHeader, typeof i5_16.ClrTimelineStepTitle], [typeof i6.CommonModule, typeof i3_2.ClrIconModule, typeof i16_2.ClrSpinnerModule], [typeof i1_48.ClrTimeline, typeof i2_37.ClrTimelineStep, typeof i3_29.ClrTimelineStepDescription, typeof i4_20.ClrTimelineStepHeader, typeof i5_16.ClrTimelineStepTitle, typeof i3_2.ClrIconModule, typeof i16_2.ClrSpinnerModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrTimelineModule, [typeof i1_48.ClrTimeline, typeof i2_37.ClrTimelineStep, typeof i3_29.ClrTimelineStepDescription, typeof i4_20.ClrTimelineStepHeader, typeof i5_17.ClrTimelineStepTitle], [typeof i6.CommonModule, typeof i3_2.ClrIconModule, typeof i16_2.ClrSpinnerModule], [typeof i1_48.ClrTimeline, typeof i2_37.ClrTimelineStep, typeof i3_29.ClrTimelineStepDescription, typeof i4_20.ClrTimelineStepHeader, typeof i5_17.ClrTimelineStepTitle, typeof i3_2.ClrIconModule, typeof i16_2.ClrSpinnerModule]>;
 }
 
 // @public (undocumented)
@@ -4559,7 +4576,7 @@ export class ClrVerticalNavModule {
     // Warning: (ae-forgotten-export) The symbol "i5" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrVerticalNavModule, [typeof i1_41.ClrVerticalNav, typeof i2_30.ClrVerticalNavLink, typeof i3_22.ClrVerticalNavGroup, typeof i4_16.ClrVerticalNavGroupChildren, typeof i5_12.ClrVerticalNavIcon], [typeof i6.CommonModule, typeof i3_2.ClrIconModule, typeof i6_2.ClrConditionalModule, typeof i8_6.ClrFocusOnViewInitModule], [typeof i1_41.ClrVerticalNav, typeof i2_30.ClrVerticalNavLink, typeof i3_22.ClrVerticalNavGroup, typeof i4_16.ClrVerticalNavGroupChildren, typeof i5_12.ClrVerticalNavIcon, typeof i6_2.ClrConditionalModule, typeof i3_2.ClrIconModule, typeof i8_6.ClrFocusOnViewInitModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrVerticalNavModule, [typeof i1_41.ClrVerticalNav, typeof i2_30.ClrVerticalNavLink, typeof i3_22.ClrVerticalNavGroup, typeof i4_16.ClrVerticalNavGroupChildren, typeof i5_13.ClrVerticalNavIcon], [typeof i6.CommonModule, typeof i3_2.ClrIconModule, typeof i6_2.ClrConditionalModule, typeof i8_6.ClrFocusOnViewInitModule], [typeof i1_41.ClrVerticalNav, typeof i2_30.ClrVerticalNavLink, typeof i3_22.ClrVerticalNavGroup, typeof i4_16.ClrVerticalNavGroupChildren, typeof i5_13.ClrVerticalNavIcon, typeof i6_2.ClrConditionalModule, typeof i3_2.ClrIconModule, typeof i8_6.ClrFocusOnViewInitModule]>;
 }
 
 // @public (undocumented)
@@ -4743,7 +4760,7 @@ export class ClrWizardModule {
     // Warning: (ae-forgotten-export) The symbol "i11" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrWizardModule, [typeof i1_44.ClrWizard, typeof i2_34.ClrWizardPage, typeof i3_26.ClrWizardStepnav, typeof i4_17.ClrWizardStepnavItem, typeof i5_13.ClrWizardButton, typeof i6_10.ClrWizardHeaderAction, typeof i7_9.ClrWizardCustomTags, typeof i8_7.ClrWizardPageTitle, typeof i9_5.ClrWizardPageNavTitle, typeof i10_6.ClrWizardPageButtons, typeof i11_5.ClrWizardPageHeaderActions], [typeof i6.CommonModule, typeof i4_12.ClrModalModule, typeof i1_2.ClrAlertModule], [typeof i1_44.ClrWizard, typeof i2_34.ClrWizardPage, typeof i3_26.ClrWizardStepnav, typeof i4_17.ClrWizardStepnavItem, typeof i5_13.ClrWizardButton, typeof i6_10.ClrWizardHeaderAction, typeof i7_9.ClrWizardCustomTags, typeof i8_7.ClrWizardPageTitle, typeof i9_5.ClrWizardPageNavTitle, typeof i10_6.ClrWizardPageButtons, typeof i11_5.ClrWizardPageHeaderActions]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrWizardModule, [typeof i1_44.ClrWizard, typeof i2_34.ClrWizardPage, typeof i3_26.ClrWizardStepnav, typeof i4_17.ClrWizardStepnavItem, typeof i5_14.ClrWizardButton, typeof i6_10.ClrWizardHeaderAction, typeof i7_9.ClrWizardCustomTags, typeof i8_7.ClrWizardPageTitle, typeof i9_5.ClrWizardPageNavTitle, typeof i10_6.ClrWizardPageButtons, typeof i11_5.ClrWizardPageHeaderActions], [typeof i6.CommonModule, typeof i4_12.ClrModalModule, typeof i1_2.ClrAlertModule], [typeof i1_44.ClrWizard, typeof i2_34.ClrWizardPage, typeof i3_26.ClrWizardStepnav, typeof i4_17.ClrWizardStepnavItem, typeof i5_14.ClrWizardButton, typeof i6_10.ClrWizardHeaderAction, typeof i7_9.ClrWizardCustomTags, typeof i8_7.ClrWizardPageTitle, typeof i9_5.ClrWizardPageNavTitle, typeof i10_6.ClrWizardPageButtons, typeof i11_5.ClrWizardPageHeaderActions]>;
 }
 
 // @public

--- a/projects/angular/src/layout/nav/aria-current-link.spec.ts
+++ b/projects/angular/src/layout/nav/aria-current-link.spec.ts
@@ -1,0 +1,76 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { By } from '@angular/platform-browser';
+import { Router } from '@angular/router';
+import { RouterTestingModule } from '@angular/router/testing';
+
+import { MainContainerWillyWonka } from './chocolate/main-container-willy-wonka';
+import { ClrNavigationModule } from './navigation.module';
+import { ClrAriaCurrentLink } from './aria-current-link';
+@Component({
+  template: `
+    <clr-header class="header">
+      <div class="header-nav">
+        <a clrAriaCurrentLink class="nav-link" id="link1" routerLink="/home" routerLinkActive="active"
+          ><span class="nav-text">Components</span></a
+        >
+        <a clrAriaCurrentLink class="nav-link" id="link2" routerLink="/patterns" routerLinkActive="active"
+          ><span class="nav-text">Patterns</span></a
+        >
+      </div>
+    </clr-header>
+  `,
+})
+class TestComponent {}
+
+describe('AriaCurrentLink Directive', () => {
+  let fixture: ComponentFixture<any>;
+  let router: Router;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [
+        ClrNavigationModule,
+        RouterTestingModule.withRoutes([
+          { path: 'home', component: TestComponent },
+          { path: 'patterns', component: TestComponent },
+        ]),
+      ],
+      declarations: [TestComponent, ClrAriaCurrentLink],
+      providers: [MainContainerWillyWonka],
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    router = TestBed.inject(Router);
+    fixture.detectChanges();
+  });
+
+  afterEach(() => {
+    fixture.destroy();
+  });
+
+  it('decorates the active link with aria-current', fakeAsync(() => {
+    router.navigate(['/home']);
+    tick();
+    fixture.detectChanges();
+
+    const link1 = fixture.debugElement.query(By.css('#link1'));
+    const link2 = fixture.debugElement.query(By.css('#link2'));
+
+    expect(link1.nativeElement.getAttribute('aria-current')).toEqual('page');
+    expect(link2.nativeElement.getAttribute('aria-current')).toBeNull();
+
+    router.navigate(['/patterns']);
+    tick();
+    fixture.detectChanges();
+
+    expect(link1.nativeElement.getAttribute('aria-current')).toBeNull();
+    expect(link2.nativeElement.getAttribute('aria-current')).toEqual('page');
+  }));
+});

--- a/projects/angular/src/layout/nav/aria-current-link.ts
+++ b/projects/angular/src/layout/nav/aria-current-link.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Directive, OnDestroy, OnInit } from '@angular/core';
+import { RouterLinkActive } from '@angular/router';
+import { Subscription } from 'rxjs';
+
+@Directive({ selector: '[clrAriaCurrentLink]', host: { '[attr.aria-current]': 'ariaCurrent' } })
+export class ClrAriaCurrentLink implements OnInit, OnDestroy {
+  public ariaCurrent: string | undefined;
+  private subscription: Subscription;
+
+  constructor(private rla: RouterLinkActive) {}
+
+  ngOnInit() {
+    this.subscription = this.rla.isActiveChange.subscribe(isActive => {
+      this.ariaCurrent = isActive ? 'page' : undefined;
+    });
+  }
+
+  ngOnDestroy() {
+    this.subscription.unsubscribe();
+  }
+}

--- a/projects/angular/src/layout/nav/index.ts
+++ b/projects/angular/src/layout/nav/index.ts
@@ -7,4 +7,5 @@
 export * from './chocolate/index';
 export * from './header';
 export * from './nav-level';
+export * from './aria-current-link';
 export * from './navigation.module';

--- a/projects/angular/src/layout/nav/navigation.module.ts
+++ b/projects/angular/src/layout/nav/navigation.module.ts
@@ -14,10 +14,12 @@ import { MainContainerWillyWonka } from './chocolate/main-container-willy-wonka'
 import { NavDetectionOompaLoompa } from './chocolate/nav-detection-oompa-loompa';
 import { ClrHeader } from './header';
 import { ClrNavLevel } from './nav-level';
+import { ClrAriaCurrentLink } from './aria-current-link';
 
 export const CLR_NAVIGATION_DIRECTIVES: Type<any>[] = [
   ClrHeader,
   ClrNavLevel,
+  ClrAriaCurrentLink,
   NavDetectionOompaLoompa,
   MainContainerWillyWonka,
 ];

--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -13,7 +13,9 @@
       </a>
     </div>
     <div class="header-nav" [clr-nav-level]="1">
-      <a class="active nav-link" href="javascript://"><span class="nav-text">Components</span></a>
+      <a class="nav-link" routerLink="/" routerLinkActive="active" clrAriaCurrentLink
+        ><span class="nav-text">Components</span></a
+      >
       <a class="nav-link" href="javascript://"><span class="nav-text">Patterns</span></a>
     </div>
     <form class="search">
@@ -28,7 +30,7 @@
           <cds-icon shape="angle" inverse direction="down"></cds-icon>
         </button>
         <clr-dropdown-menu clrPosition="bottom-right" *clrIfOpen>
-          <a href="javascript://" clrDropdownItem><cds-icon shape="user"></cds-icon> About</a>
+          <a href="javascript://" clrDropdownItem> <cds-icon shape="user"></cds-icon> About </a>
           <a href="javascript://" clrDropdownItem>Preferences</a>
           <a href="javascript://" clrDropdownItem>Log out</a>
         </clr-dropdown-menu>

--- a/projects/demo/src/app/content-container.component.ts
+++ b/projects/demo/src/app/content-container.component.ts
@@ -24,6 +24,7 @@ import { APP_ROUTES } from './app.routing';
             <li *ngFor="let route of routes">
               <a
                 *ngIf="route.path != ''"
+                clrAriaCurrentLink
                 class="nav-link"
                 [routerLink]="[route.path]"
                 [routerLinkActive]="['active']"


### PR DESCRIPTION
Addresses VPAT-628 to programmatically add aria-current="page" to the current nav link

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

**Enable  aria-current functionality for nav links using by introducing the  `clrAriaCurrentLink` directive.** 

`clrAriaCurrentLink` directive works as utility to denote the current link with `aria-current="page"` if it matches the active router link. It uses the `RouterLinkActive` director to subscribe to the change in active status.

It can be appended to any nav link that uses the `routerLink` and `routerLinkActive` directive. Works with the header, subheader, sidenav and vertical nav
<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
