### PR TITLE
fix: datepicker 'days' row is not set as table header

### DIFF
--- a/projects/angular/src/forms/datepicker/calendar.html
+++ b/projects/angular/src/forms/datepicker/calendar.html
@@ -1,8 +1,8 @@
 <table class="calendar-table">
   <tr class="calendar-row weekdays">
-    <td *ngFor="let day of localeDays" class="calendar-cell weekday" role="heading" [attr.aria-label]="day.day">
+    <th *ngFor="let day of localeDays" class="calendar-cell weekday" role="heading" [attr.aria-label]="day.day">
       {{day.narrow}}
-    </td>
+    </th>
   </tr>
   <tr class="calendar-row" *ngFor="let row of calendarViewModel.calendarView">
     <td *ngFor="let dayView of row" class="calendar-cell">


### PR DESCRIPTION
The first half of the vpat-661 for providing headers for days inside the calendar.