### PR TITLE
fix(combobox): update aria attrs for clr-combobox

### DIFF
--- a/projects/angular/src/forms/combobox/combobox.html
+++ b/projects/angular/src/forms/combobox/combobox.html
@@ -48,12 +48,11 @@
     </span>
   </span>
 
-  <span class="clr-combobox-input-wrapper">
+  <span class="clr-combobox-input-wrapper" role="combobox">
     <input
       #textboxInput
       type="text"
       [id]="inputId()"
-      role="combobox"
       class="clr-input clr-combobox-input"
       [(ngModel)]="searchText"
       (blur)="onBlur()"
@@ -67,7 +66,6 @@
       [disabled]="control?.disabled? true: null"
       [attr.aria-activedescendant]="getActiveDescendant()"
       [attr.placeholder]="placeholder"
-      aria-multiline="false"
     />
   </span>
 

--- a/projects/angular/src/utils/popover/popover-content.spec.ts
+++ b/projects/angular/src/utils/popover/popover-content.spec.ts
@@ -97,13 +97,14 @@ export default function (): void {
       it('responds to openChange events from the toggleService', function (this: Context) {
         this.testComponent.openState = true; // Add content to the DOM
         this.fixture.detectChanges();
-        const content = document.body.getElementsByClassName('clr-popover-content');
+        let content = document.body.querySelectorAll('div.clr-popover-content');
         // Popovers are not getting cleaned up here.
         expect(content.length).toBe(1);
         expect(content[0].textContent.trim()).toBe('Popover content');
 
         this.testComponent.openState = false; // Remove content from the DOM
         this.fixture.detectChanges();
+        content = document.body.querySelectorAll('div.clr-popover-content');
         expect(content.length).toBe(0);
       });
 


### PR DESCRIPTION
• moved combobox role to span wrapper
• removed aria-multiline
• see VPAT-2939
• also fixed breaking popover test.

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Moves the `role="comobox"` off the combobox `input` element and onto a wrapper (per a11y). Removes the `aria-multiline` attribute (also per a11y).

Also fixes a failing `popover-content` unit test. A datepicker test wasn't cleaned up so it was confusing the lookup in the test. I made the lookup in the popover-content test more specific but also had to re-lookup after change. 

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

see VPAT-2939

Issue Number: VPAT-2939

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
