### PR TITLE
fix(password-container): remove show/hide icon title

### DIFF
--- a/projects/angular/src/forms/password/password-container.ts
+++ b/projects/angular/src/forms/password/password-container.ts
@@ -38,11 +38,7 @@ export const TOGGLE_SERVICE_PROVIDER = { provide: TOGGLE_SERVICE, useFactory: To
             class="clr-input-group-icon-action"
             type="button"
           >
-            <cds-icon
-              status="info"
-              [attr.shape]="show ? 'eye-hide' : 'eye'"
-              [attr.title]="show ? commonStrings.keys.hide : commonStrings.keys.show"
-            ></cds-icon>
+            <cds-icon status="info" [attr.shape]="show ? 'eye-hide' : 'eye'"></cds-icon>
             <span class="clr-sr-only">{{
               show ? commonStrings.keys.passwordHide : commonStrings.keys.passwordShow
             }}</span>


### PR DESCRIPTION
Fixes VPAT-667

Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

VPAT-667. The show/hide password icon has a title which is a violation since it isn't accessible to keyboard users. It also results in double reading of the icon, when used with the sr-only text.

## What is the new behavior?

No more title

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
