### PR TITLE
fix(combobox): backport combobox a11y changes

### DIFF
--- a/projects/angular/src/forms/combobox/combobox.html
+++ b/projects/angular/src/forms/combobox/combobox.html
@@ -48,12 +48,11 @@
     </span>
   </span>
 
-  <span class="clr-combobox-input-wrapper">
+  <span class="clr-combobox-input-wrapper" role="combobox">
     <input
       #textboxInput
       type="text"
       [id]="inputId()"
-      role="combobox"
       class="clr-input clr-combobox-input"
       [(ngModel)]="searchText"
       (blur)="onBlur()"
@@ -67,7 +66,6 @@
       [disabled]="control?.disabled? true: null"
       [attr.aria-activedescendant]="getActiveDescendant()"
       [attr.placeholder]="placeholder"
-      aria-multiline="false"
     />
   </span>
 


### PR DESCRIPTION
removed aria-multiline. moved role attr to wrapper. per a11y. see vpat-2939

Signed-off-by: Scott Mathis <smathis@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

backport of https://github.com/vmware-clarity/ng-clarity/pull/85

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
