### PR TITLE
fix(navigation): visibility of close button in tablet and mobile view

### DIFF
--- a/projects/angular/src/layout/nav/_responsive-nav.clarity.scss
+++ b/projects/angular/src/layout/nav/_responsive-nav.clarity.scss
@@ -523,6 +523,7 @@
         .sub-nav.clr-nav-level-1,
         .sidenav.clr-nav-level-1,
         .clr-vertical-nav.clr-nav-level-1 {
+          overflow: inherit;
           width: $clr-sliding-panel-width;
           max-width: $clr-sliding-panel-width;
         }
@@ -582,6 +583,7 @@
         .sub-nav.clr-nav-level-1,
         .sidenav.clr-nav-level-1,
         .clr-vertical-nav.clr-nav-level-1 {
+          overflow: inherit;
           width: $clr-sliding-panel-width-sm;
           max-width: $clr-sliding-panel-width-sm;
         }


### PR DESCRIPTION
Because the button is positioned outside of the area of the navigation overflow hides the button.

Signed-off-by: Bogdan Bogdanov <bbogdanov@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #97 

## What is the new behavior?

The Close button is now visible because of the overflow updated value.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
