### PR TITLE
fix: update required Clarity Core version with v13

### DIFF
--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -20,6 +20,6 @@
   "peerDependencies": {
     "@angular/common": "^13.0.0",
     "@angular/core": "^13.0.0",
-    "@cds/core": "next || ^6.0.0 || ^5.6.0"
+    "@cds/core": "next || <6.0.0 || ^5.6.0"
   }
 }


### PR DESCRIPTION
Since after 6.0.0.beta.1 release the old focus trap has been removed, if we add a version that is using some version related to @cds/core@6.0.0 the compiler will throw an error that some files are missing.

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [x] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
