### PR TITLE
fix: fix multiple overlay nesting scenarios

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,10 +1,10 @@
 {
-  "name": "clarity",
+  "name": "@clr/angular",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
-      "name": "clarity",
+      "name": "@clr/angular",
       "devDependencies": {
         "@amanda-mitchell/semantic-release-npm-multiple": "2.17.0",
         "@angular-devkit/build-angular": "~13.0.0",

--- a/projects/angular/src/utils/variables/_variables.global.scss
+++ b/projects/angular/src/utils/variables/_variables.global.scss
@@ -274,9 +274,9 @@ $clr-layers: (
   sidepanel: 1039,
   modal-bg: 1040,
   modal: 1050,
-  dropdown-menu: 1060,
-  column-switch: 1060,
-  tooltips: 1070,
-  smart-popover: 5000,
+  dropdown-menu: 1050,
+  column-switch: 1050,
+  tooltips: 1050,
+  smart-popover: 1050,
   draggable-ghost: 2147483647,
 ) !default;

--- a/projects/demo/src/app/app.routing.ts
+++ b/projects/demo/src/app/app.routing.ts
@@ -144,6 +144,7 @@ export const APP_ROUTES: Routes = [
     loadChildren: () => import('./virtual-scroll/virtual-scroll.demo.module').then(m => m.VirtualScrollDemoModule),
   },
   { path: 'wizard', loadChildren: () => import('./wizard/wizard.demo.module').then(m => m.WizardDemoModule) },
+  { path: 'z-index', loadChildren: () => import('./z-index/z-index.demo.module').then(m => m.ZIndexDemoModule) },
 ];
 
 export const ROUTING: ModuleWithProviders<RouterModule> = RouterModule.forRoot(APP_ROUTES);

--- a/projects/demo/src/app/z-index/custom-filter.demo.ts
+++ b/projects/demo/src/app/z-index/custom-filter.demo.ts
@@ -1,0 +1,41 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+import { ClrDatagridFilter, ClrDatagridFilterInterface } from '@clr/angular';
+import { Observable, Subject } from 'rxjs';
+
+@Component({
+  selector: 'z-index-custom-filter',
+  template: `<z-index-various-content></z-index-various-content>`,
+})
+export class ZIndexCustomFilter<T> implements ClrDatagridFilterInterface<T> {
+  constructor(protected filterContainer: ClrDatagridFilter) {
+    filterContainer.setFilter(this);
+  }
+
+  /**
+   * The Observable required as part of the Filter interface
+   */
+  private changesSubject: Subject<T> = new Subject<T>();
+  public get changes(): Observable<T> {
+    return this.changesSubject.asObservable();
+  }
+
+  /**
+   * Tests if an item matches a search text
+   */
+  public accepts(): boolean {
+    return false;
+  }
+
+  /**
+   * Indicates if the filter is currently active, (at least one input is set)
+   */
+  public isActive(): boolean {
+    return false;
+  }
+}

--- a/projects/demo/src/app/z-index/various-content/various-content.html
+++ b/projects/demo/src/app/z-index/various-content/various-content.html
@@ -1,0 +1,44 @@
+<h5>Button group overflow</h5>
+<clr-button-group class="btn-primary">
+  <clr-button>Create</clr-button>
+  <clr-button>Favorite</clr-button>
+  <clr-button [clrInMenu]="true">Assign</clr-button>
+  <clr-button [clrInMenu]="true">Download</clr-button>
+  <clr-button [clrInMenu]="true">Delete</clr-button>
+</clr-button-group>
+
+<form clrForm>
+  <clr-date-container>
+    <label>Datepicker</label>
+    <input type="date" clrDate name="demo" [(ngModel)]="demo" />
+  </clr-date-container>
+</form>
+
+<form clrForm>
+  <clr-combobox-container>
+    <label>Combobox</label>
+    <clr-combobox [(ngModel)]="selected" name="two" required placeholder="Select a number">
+      <clr-options>
+        <clr-option clrValue="1">1</clr-option>
+        <clr-option clrValue="2">2</clr-option>
+        <clr-option clrValue="3">3</clr-option>
+      </clr-options>
+    </clr-combobox>
+  </clr-combobox-container>
+</form>
+
+<h5>Datagrid with filter, action, column select</h5>
+<clr-datagrid style="width: 300px">
+  <clr-dg-column [clrDgField]="'name'">
+    <ng-container *clrDgHideableColumn="{hidden: false}"> Name </ng-container>
+  </clr-dg-column>
+
+  <clr-dg-row *clrDgItems="let user of [{name: 'Binky'}]">
+    <clr-dg-action-overflow>
+      <button class="action-item">Do something</button>
+    </clr-dg-action-overflow>
+    <clr-dg-cell>{{user.name}}</clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer></clr-dg-footer>
+</clr-datagrid>

--- a/projects/demo/src/app/z-index/various-content/various-content.ts
+++ b/projects/demo/src/app/z-index/various-content/various-content.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+
+@Component({ selector: 'z-index-various-content', templateUrl: './various-content.html' })
+export class ZIndexVariousContent {
+  demo: any;
+  selected: any;
+}

--- a/projects/demo/src/app/z-index/z-index.demo.html
+++ b/projects/demo/src/app/z-index/z-index.demo.html
@@ -1,0 +1,38 @@
+<h3>Component nesting z-index visual tests</h3>
+
+<h5>Datagrid with filter</h5>
+<clr-datagrid style="width: 300px">
+  <clr-dg-column>
+    Name
+    <clr-dg-filter>
+      <z-index-custom-filter></z-index-custom-filter>
+    </clr-dg-filter>
+  </clr-dg-column>
+
+  <clr-dg-row *clrDgItems="let user of [{name: 'Binky'}]">
+    <clr-dg-cell>{{user.name}}</clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer></clr-dg-footer>
+</clr-datagrid>
+
+<h5>Modal</h5>
+<clr-modal [(clrModalOpen)]="open">
+  <h3 class="modal-title">I have a nice title</h3>
+  <div class="modal-body">
+    <z-index-various-content></z-index-various-content>
+  </div>
+  <div class="modal-footer">
+    <button type="button" class="btn btn-outline" (click)="open = false">Cancel</button>
+    <button type="button" class="btn btn-primary" (click)="open = false">Ok</button>
+  </div>
+</clr-modal>
+<button type="button" class="btn btn-outline" (click)="open = true">Open modal</button>
+
+<h5>Signpost</h5>
+<clr-signpost>
+  <clr-signpost-content *clrIfOpen>
+    <h3>Default Signpost</h3>
+    <z-index-various-content></z-index-various-content>
+  </clr-signpost-content>
+</clr-signpost>

--- a/projects/demo/src/app/z-index/z-index.demo.module.ts
+++ b/projects/demo/src/app/z-index/z-index.demo.module.ts
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+
+import { ClarityModule } from '@clr/angular';
+import { ZIndexCustomFilter } from './custom-filter.demo';
+import { ZIndexVariousContent } from './various-content/various-content';
+import { ZIndexDemo } from './z-index.demo';
+import { ROUTING } from './z-index.routing';
+
+@NgModule({
+  imports: [CommonModule, FormsModule, ClarityModule, ROUTING],
+  declarations: [ZIndexDemo, ZIndexVariousContent, ZIndexCustomFilter],
+  exports: [ZIndexDemo],
+})
+export class ZIndexDemoModule {}

--- a/projects/demo/src/app/z-index/z-index.demo.ts
+++ b/projects/demo/src/app/z-index/z-index.demo.ts
@@ -1,0 +1,12 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+
+@Component({ selector: 'z-index-demo', templateUrl: './z-index.demo.html' })
+export class ZIndexDemo {
+  open = false;
+}

--- a/projects/demo/src/app/z-index/z-index.routing.ts
+++ b/projects/demo/src/app/z-index/z-index.routing.ts
@@ -1,0 +1,14 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ModuleWithProviders } from '@angular/core';
+import { RouterModule, Routes } from '@angular/router';
+
+import { ZIndexDemo } from './z-index.demo';
+
+const ROUTES: Routes = [{ path: '', component: ZIndexDemo }];
+
+export const ROUTING: ModuleWithProviders<RouterModule> = RouterModule.forChild(ROUTES);


### PR DESCRIPTION
closes #111
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

We have hard coded z-index positions for too many types of elements. This statically fixes what is displayed over and under other elements. In some cases, this is necessary. But for many nesting scenarios, it leads to failures.

Issue Number: #111

## What is the new behavior?

Several types of elements were reworked to use the same level of z-index. This leads to the browser more flexibly overlaying different elements, based on their position in the DOM tree.

I have added visual pages (for which automated visual regression tests may be done once we create such) for the following scenarios and combinations:

Nested elements (which have their own overlays):
- button group overflow
- datagrid with action overflow, column toggle, dg filters
- combobox
- datepicker

Containers:
- in datagrid filter
- in modal
- in signpost

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
