### PR TITLE
fix(datagrid): update detail pane close icon color to match modal

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1740,10 +1740,13 @@
       justify-content: flex-end;
 
       .btn.btn-link {
-        @include css-var(color, clr-modal-close-color, $clr-modal-close-color, $clr-use-custom-properties);
         margin-top: $clr_baselineRem_0_667;
         margin-bottom: 0;
         padding-right: 0;
+
+        cds-icon {
+          @include css-var(color, clr-modal-close-color, $clr-modal-close-color, $clr-use-custom-properties);
+        }
       }
     }
   }


### PR DESCRIPTION
It should be grey, not blue

Fixes #130

Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

![image](https://user-images.githubusercontent.com/9469374/170315980-1d4ab373-3279-4356-ae14-b004b890d099.png)

