### PR TITLE
Adding utils for key navigation in list/menu 

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -48,6 +48,7 @@ import { Subscription } from 'rxjs';
 import { TemplateRef } from '@angular/core';
 import { TrackByFunction } from '@angular/core';
 import { Type } from '@angular/core';
+import { ValueProvider } from '@angular/core';
 import { ViewContainerRef } from '@angular/core';
 
 // @public (undocumented)
@@ -112,6 +113,12 @@ export const CLR_ICON_DIRECTIVES: Type<any>[];
 
 // @public (undocumented)
 export const CLR_LAYOUT_DIRECTIVES: Type<any>[];
+
+// @public (undocumented)
+export const CLR_LIST_KEY_NAVIGATION_COFNIG_PROVIDER: ValueProvider;
+
+// @public (undocumented)
+export const CLR_LIST_KEY_NAVIGATION_CONFIG: InjectionToken<unknown>;
 
 // @public (undocumented)
 export const CLR_LOADING_BUTTON_DIRECTIVES: Type<any>[];
@@ -2790,6 +2797,35 @@ class ClrKeyFocusModule {
 }
 
 // @public (undocumented)
+export class ClrKeyNavigationList implements AfterViewInit {
+    constructor(host: ElementRef<HTMLElement>, defaultConfig: KeyNavigationListConfig, focusableElementSelectors: string[]);
+    // (undocumented)
+    set configuration(config: Partial<KeyNavigationListConfig>);
+    // (undocumented)
+    ngAfterViewInit(): void;
+    // (undocumented)
+    onClick(e: Event): void;
+    // (undocumented)
+    onKeyDown(e: KeyboardEvent): void;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<ClrKeyNavigationList, "[clrKeyNavigationList]", never, { "configuration": "configuration"; }, {}, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<ClrKeyNavigationList, never>;
+}
+
+// @public (undocumented)
+export class ClrKeyNavigationListModule {
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<ClrKeyNavigationListModule, never>;
+    // (undocumented)
+    static ɵinj: i0.ɵɵInjectorDeclaration<ClrKeyNavigationListModule>;
+    // Warning: (ae-forgotten-export) The symbol "i1" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrKeyNavigationListModule, [typeof i1_50.ClrKeyNavigationList], never, [typeof i1_50.ClrKeyNavigationList]>;
+}
+
+// @public (undocumented)
 export class ClrLabel implements OnInit, OnDestroy {
     constructor(controlIdService: ControlIdService, layoutService: LayoutService, ngControlService: NgControlService, renderer: Renderer2, el: ElementRef);
     // (undocumented)
@@ -5139,6 +5175,12 @@ export const FOCUS_ON_VIEW_INIT_DIRECTIVES: Type<any>[];
 const FOCUS_TRAP_DIRECTIVES: Type<any>[];
 
 // @public (undocumented)
+export const FOCUSABLE_ELEMENT_SELECTORS: InjectionToken<unknown>;
+
+// @public (undocumented)
+export const FOCUSABLE_ELEMENT_SELECTORS_PROVIDER: ValueProvider;
+
+// @public (undocumented)
 const FOCUSABLES = "[href]:not([tabindex=\"-1\"]), button:not([disabled]):not([tabindex=\"-1\"]), input:not([disabled]):not([tabindex=\"-1\"]), select:not([disabled]):not([tabindex=\"-1\"]), textarea:not([disabled]):not([tabindex=\"-1\"]), [contenteditable=\"true\"]:not([tabindex=\"-1\"]), [tabindex]:not([tabindex=\"-1\"]) ";
 
 // @public (undocumented)
@@ -5152,6 +5194,22 @@ export const IS_TOGGLE_PROVIDER: {
 
 // @public (undocumented)
 export function isToggleFactory(): BehaviorSubject<boolean>;
+
+// @public (undocumented)
+export interface KeyNavigationListConfig {
+    // (undocumented)
+    dir: string | null;
+    // (undocumented)
+    keyListItems: string;
+    // (undocumented)
+    layout: 'both' | 'horizontal' | 'vertical';
+    // (undocumented)
+    loop: boolean;
+    // (undocumented)
+    manageFocus: boolean;
+    // (undocumented)
+    manageTabindex: boolean;
+}
 
 // @public
 export abstract class LoadingListener {

--- a/projects/angular/src/data/datagrid/datagrid-action-overflow.ts
+++ b/projects/angular/src/data/datagrid/datagrid-action-overflow.ts
@@ -42,7 +42,6 @@ let clrDgActionId = 0;
 
     <div
       class="datagrid-action-overflow"
-      role="menu"
       [id]="popoverId"
       [attr.aria-hidden]="!open"
       [attr.id]="popoverId"

--- a/projects/angular/src/utils/index.ts
+++ b/projects/angular/src/utils/index.ts
@@ -15,3 +15,4 @@ export * from './focus/focus-on-view-init/index';
 export * from './focus-trap/index';
 export * from './destroy';
 export * from './for-type-ahead/index';
+export * from './list-key-navigation/index';

--- a/projects/angular/src/utils/list-key-navigation/index.ts
+++ b/projects/angular/src/utils/list-key-navigation/index.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export * from './key-navigation-list';
+export * from './key-navigation-list.module';
+export * from './providers/focusable-items';
+export * from './providers/key-navigation-list.config';

--- a/projects/angular/src/utils/list-key-navigation/key-navigation-list.module.ts
+++ b/projects/angular/src/utils/list-key-navigation/key-navigation-list.module.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { NgModule } from '@angular/core';
+
+import { ClrKeyNavigationList } from './key-navigation-list';
+import { FOCUSABLE_ELEMENT_SELECTORS_PROVIDER } from './providers/focusable-items';
+import { CLR_LIST_KEY_NAVIGATION_COFNIG_PROVIDER } from './providers/key-navigation-list.config';
+
+@NgModule({
+  declarations: [ClrKeyNavigationList],
+  exports: [ClrKeyNavigationList],
+  providers: [CLR_LIST_KEY_NAVIGATION_COFNIG_PROVIDER, FOCUSABLE_ELEMENT_SELECTORS_PROVIDER],
+})
+export class ClrKeyNavigationListModule {}

--- a/projects/angular/src/utils/list-key-navigation/key-navigation-list.spec.ts
+++ b/projects/angular/src/utils/list-key-navigation/key-navigation-list.spec.ts
@@ -1,0 +1,114 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ClrKeyNavigationList } from './key-navigation-list';
+import { ClrKeyNavigationListModule } from './key-navigation-list.module';
+
+@Component({
+  template: `
+    <section clrKeyNavigationList>
+      <div><button>0</button></div>
+      <div><button>1</button></div>
+      <div><button>2</button></div>
+      <div><button>3</button></div>
+      <div><button>4</button></div>
+      <div><button>5</button></div>
+    </section>
+  `,
+})
+class ListTest {
+  @ViewChild(ClrKeyNavigationList) keyNav: ClrKeyNavigationList;
+}
+
+describe('ClrKeyNaviationList', function () {
+  describe('key-navigation-list', () => {
+    let fixture: ComponentFixture<ListTest>;
+    let componentHTML: HTMLElement;
+    let keyListItems: NodeListOf<HTMLElement>;
+
+    beforeEach(async () => {
+      TestBed.configureTestingModule({
+        imports: [ClrKeyNavigationListModule],
+        declarations: [ListTest],
+      });
+      fixture = TestBed.createComponent(ListTest);
+      await fixture.whenStable();
+      componentHTML = fixture.nativeElement.querySelector('section');
+      keyListItems = componentHTML.querySelectorAll('button');
+      fixture.detectChanges();
+    });
+
+    afterEach(() => {
+      fixture.destroy();
+    });
+
+    it('should initialize first item if focus management is enabled', async () => {
+      expect(keyListItems[0].tabIndex).toBe(0);
+      expect(keyListItems[1].tabIndex).toBe(-1);
+    });
+
+    it('should set activate a item on click', async () => {
+      keyListItems[2].click();
+
+      fixture.detectChanges();
+
+      expect(keyListItems[0].tabIndex).toBe(-1);
+      expect(keyListItems[1].tabIndex).toBe(-1);
+      expect(keyListItems[2].tabIndex).toBe(0);
+    });
+
+    it('should support horizontal arrow key navigation', async () => {
+      fixture.componentInstance.keyNav.configuration = { layout: 'horizontal' };
+      fixture.detectChanges();
+
+      keyListItems[0].dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowRight', bubbles: true }));
+      keyListItems[1].dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowRight', bubbles: true }));
+
+      fixture.detectChanges();
+
+      expect(keyListItems[0].getAttribute('tabindex')).toBe('-1');
+      expect(keyListItems[1].getAttribute('tabindex')).toBe('-1');
+      expect(keyListItems[2].getAttribute('tabindex')).toBe('0');
+
+      keyListItems[2].dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowLeft', bubbles: true }));
+      keyListItems[1].dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowLeft', bubbles: true }));
+
+      fixture.detectChanges();
+
+      expect(keyListItems[0].getAttribute('tabindex')).toBe('0');
+      expect(keyListItems[1].getAttribute('tabindex')).toBe('-1');
+      expect(keyListItems[2].getAttribute('tabindex')).toBe('-1');
+    });
+
+    it('should support vertical arrow key navigation', async () => {
+      await fixture.whenStable();
+
+      fixture.componentInstance.keyNav.configuration = { layout: 'vertical' };
+      fixture.detectChanges();
+
+      keyListItems[0].dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown', bubbles: true }));
+      keyListItems[1].dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowDown', bubbles: true }));
+
+      fixture.detectChanges();
+
+      expect(keyListItems[0].getAttribute('tabindex')).toBe('-1');
+      expect(keyListItems[1].getAttribute('tabindex')).toBe('-1');
+      expect(keyListItems[2].getAttribute('tabindex')).toBe('0');
+
+      keyListItems[2].dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowUp', bubbles: true }));
+      keyListItems[1].dispatchEvent(new KeyboardEvent('keydown', { code: 'ArrowUp', bubbles: true }));
+
+      fixture.detectChanges();
+
+      expect(keyListItems[0].getAttribute('tabindex')).toBe('0');
+      expect(keyListItems[1].getAttribute('tabindex')).toBe('-1');
+      expect(keyListItems[2].getAttribute('tabindex')).toBe('-1');
+    });
+  });
+});

--- a/projects/angular/src/utils/list-key-navigation/key-navigation-list.ts
+++ b/projects/angular/src/utils/list-key-navigation/key-navigation-list.ts
@@ -1,0 +1,142 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { AfterViewInit, Directive, ElementRef, HostListener, Inject, Input } from '@angular/core';
+import {
+  focusElement,
+  getFlattenedFocusableItems,
+  initializeKeyListItems,
+  KeyNavigationCode,
+  setActiveKeyListItem,
+  validKeyNavigationCode,
+} from '@cds/core/internal';
+
+import { FOCUSABLE_ELEMENT_SELECTORS } from './providers/focusable-items';
+import { CLR_LIST_KEY_NAVIGATION_CONFIG } from './providers/key-navigation-list.config';
+import { getNextKeyListItem } from './utils';
+
+export interface KeyNavigationListConfig {
+  keyListItems: string;
+  layout: 'both' | 'horizontal' | 'vertical';
+  manageFocus: boolean;
+  manageTabindex: boolean;
+  loop: boolean;
+  dir: string | null;
+}
+
+@Directive({
+  selector: '[clrKeyNavigationList]',
+})
+export class ClrKeyNavigationList implements AfterViewInit {
+  private config: KeyNavigationListConfig;
+
+  @Input()
+  set configuration(config: Partial<KeyNavigationListConfig>) {
+    this.config = {
+      ...this.defaultConfig,
+      dir: this.getClosestDirAttribute(),
+      ...config,
+    };
+  }
+
+  constructor(
+    private host: ElementRef<HTMLElement>,
+    @Inject(CLR_LIST_KEY_NAVIGATION_CONFIG) private defaultConfig: KeyNavigationListConfig,
+    @Inject(FOCUSABLE_ELEMENT_SELECTORS) private focusableElementSelectors: string[]
+  ) {
+    this.config = {
+      ...this.defaultConfig,
+      dir: this.getClosestDirAttribute(),
+    };
+  }
+
+  ngAfterViewInit() {
+    this.initializeTabIndex();
+  }
+
+  @HostListener('click', ['$event'])
+  onClick(e: Event) {
+    this.clickItem(e);
+  }
+
+  @HostListener('keydown', ['$event'])
+  onKeyDown(e: KeyboardEvent) {
+    this.focusItem(e);
+  }
+
+  private initializeTabIndex() {
+    if (this.config.manageFocus && this.config.manageTabindex) {
+      initializeKeyListItems(this.getListItems());
+    }
+  }
+
+  private clickItem(e: Event) {
+    const activeItem = this.getActiveItem(e);
+    if (activeItem) {
+      this.setActiveItem(e, activeItem);
+    }
+  }
+
+  private focusItem(e: KeyboardEvent) {
+    if (validKeyNavigationCode(e)) {
+      const activeItem = this.getActiveItem(e);
+      if (activeItem) {
+        const listItems = this.getListItems();
+        const { next, previous } = getNextKeyListItem(activeItem, Array.from(listItems), {
+          ...this.config,
+          dir: this.getClosestDirAttribute(),
+          code: e.code as KeyNavigationCode,
+        });
+
+        if (next !== previous) {
+          this.setActiveItem(e, listItems[next], listItems[previous]);
+        }
+      }
+    }
+  }
+
+  private getActiveItem(e: Event) {
+    const listItems = this.getListItems();
+    return Array.from(listItems).find(
+      c => c === (e.target as HTMLElement).closest(listItems[0].tagName.toLocaleLowerCase()) ?? c === e.target
+    );
+  }
+
+  private setActiveItem(e: any, activeItem: HTMLElement, previousItem?: HTMLElement) {
+    if (this.config.manageFocus) {
+      if (this.config.manageTabindex) {
+        setActiveKeyListItem(this.getListItems(), activeItem);
+      }
+
+      const items = getFlattenedFocusableItems(activeItem);
+      const item = items[0] ?? activeItem;
+      focusElement(item);
+      e.preventDefault();
+    }
+
+    activeItem.dispatchEvent(
+      new CustomEvent('cdsKeyChange', {
+        bubbles: true,
+        detail: {
+          activeItem,
+          previousItem,
+          code: e.code,
+          metaKey: e.ctrlKey || e.metaKey,
+          keyListItems: this.config.keyListItems,
+        },
+      })
+    );
+  }
+
+  private getListItems(): NodeListOf<HTMLElement> {
+    return this.host.nativeElement.querySelectorAll(this.focusableElementSelectors.join(','));
+  }
+
+  private getClosestDirAttribute() {
+    const el = this.host.nativeElement.closest('[dir]');
+    return el ? el.getAttribute('dir') : null;
+  }
+}

--- a/projects/angular/src/utils/list-key-navigation/providers/focusable-items.ts
+++ b/projects/angular/src/utils/list-key-navigation/providers/focusable-items.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { InjectionToken, ValueProvider } from '@angular/core';
+
+export const FOCUSABLE_ELEMENT_SELECTORS = new InjectionToken('FocusableElements');
+
+export const FOCUSABLE_ELEMENT_SELECTORS_PROVIDER: ValueProvider = {
+  provide: FOCUSABLE_ELEMENT_SELECTORS,
+  useValue: [
+    'a[href]',
+    'area[href]',
+    'input:not([disabled])',
+    'button:not([disabled])',
+    'select:not([disabled])',
+    'textarea:not([disabled])',
+    'iframe',
+    'object',
+    'embed',
+    '*[tabindex]', // -1 tabindex is a focusable element and needed for keyboard navigation
+    '*[contenteditable=true]',
+    '[role=button]:not([disabled])',
+  ],
+};

--- a/projects/angular/src/utils/list-key-navigation/providers/key-navigation-list.config.ts
+++ b/projects/angular/src/utils/list-key-navigation/providers/key-navigation-list.config.ts
@@ -1,0 +1,21 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { InjectionToken, ValueProvider } from '@angular/core';
+
+export const CLR_LIST_KEY_NAVIGATION_CONFIG = new InjectionToken('ClrListKeyNavigationConfig');
+
+export const CLR_LIST_KEY_NAVIGATION_COFNIG_PROVIDER: ValueProvider = {
+  provide: CLR_LIST_KEY_NAVIGATION_CONFIG,
+  useValue: {
+    keyListItems: 'keyListItems',
+    layout: 'vertical',
+    manageFocus: true,
+    manageTabindex: true,
+    loop: false,
+    dir: null,
+  },
+};

--- a/projects/angular/src/utils/list-key-navigation/utils.ts
+++ b/projects/angular/src/utils/list-key-navigation/utils.ts
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { KeyNavigationCode } from '@cds/core/internal';
+
+export interface KeyListConfig {
+  code: KeyNavigationCode;
+  loop?: boolean;
+  layout?: 'horizontal' | 'vertical' | 'both';
+  dir: string | null | undefined;
+}
+
+export function getNextKeyListItem(item: HTMLElement, items: HTMLElement[], config: KeyListConfig) {
+  const { code, layout, loop, dir } = config;
+  let i = items.indexOf(item);
+  const previous = i;
+  const inlineStart = dir === 'rtl' ? KeyNavigationCode.ArrowRight : KeyNavigationCode.ArrowLeft;
+  const inlineEnd = dir === 'rtl' ? KeyNavigationCode.ArrowLeft : KeyNavigationCode.ArrowRight;
+  const numOfItems = items.length - 1;
+
+  if (layout !== 'horizontal' && code === KeyNavigationCode.ArrowUp && i !== 0) {
+    i = i - 1;
+  } else if (layout !== 'horizontal' && code === KeyNavigationCode.ArrowUp && i === 0 && loop) {
+    i = numOfItems;
+  } else if (layout !== 'horizontal' && code === KeyNavigationCode.ArrowDown && i < numOfItems) {
+    i = i + 1;
+  } else if (layout !== 'horizontal' && code === KeyNavigationCode.ArrowDown && i === numOfItems && loop) {
+    i = 0;
+  } else if (layout !== 'vertical' && code === inlineStart && i !== 0) {
+    i = i - 1;
+  } else if (layout !== 'vertical' && code === inlineEnd && i < numOfItems) {
+    i = i + 1;
+  } else if (code === KeyNavigationCode.End) {
+    i = numOfItems;
+  } else if (code === KeyNavigationCode.Home) {
+    i = 0;
+  } else if (code === KeyNavigationCode.PageUp) {
+    i = i - 4 > 0 ? i - 4 : 0;
+  } else if (code === KeyNavigationCode.PageDown) {
+    i = i + 4 < numOfItems ? i + 4 : numOfItems;
+  }
+
+  return { next: i, previous };
+}

--- a/projects/demo/src/app/datagrid/datagrid.demo.module.ts
+++ b/projects/demo/src/app/datagrid/datagrid.demo.module.ts
@@ -7,7 +7,7 @@
 import { CommonModule } from '@angular/common';
 import { NgModule } from '@angular/core';
 import { FormsModule } from '@angular/forms';
-import { ClarityModule } from '@clr/angular';
+import { ClarityModule, ClrKeyNavigationListModule } from '@clr/angular';
 
 import { UtilsDemoModule } from '../_utils/utils.module';
 import { DatagridBasicStructureDemo } from './basic-structure/basic-structure';
@@ -44,7 +44,7 @@ import { DatagridTestCasesDemo } from './test-cases/test-cases';
 import { ColorFilter } from './utils/color-filter';
 
 @NgModule({
-  imports: [CommonModule, FormsModule, ClarityModule, ROUTING, UtilsDemoModule],
+  imports: [CommonModule, FormsModule, ClarityModule, ROUTING, UtilsDemoModule, ClrKeyNavigationListModule],
   declarations: [
     DatagridDemo,
     DatagridBasicStructureDemo,

--- a/projects/demo/src/app/datagrid/full/full.html
+++ b/projects/demo/src/app/datagrid/full/full.html
@@ -86,14 +86,16 @@
     <clr-dg-placeholder>No users found</clr-dg-placeholder>
     <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
       <clr-dg-action-overflow (clrDgActionOverflowOpenChange)="clrDgActionOverflowOpenChangeFn($event)">
-        <button class="action-item">
-          <cds-icon shape="note"></cds-icon>
-          Edit
-        </button>
-        <button class="action-item">
-          <cds-icon shape="trash"></cds-icon>
-          Delete
-        </button>
+        <div role="menu" clrKeyNavigationList>
+          <button role="menuitem" class="action-item">
+            <cds-icon shape="note"></cds-icon>
+            Edit
+          </button>
+          <button role="menuitem" class="action-item">
+            <cds-icon shape="trash"></cds-icon>
+            Delete
+          </button>
+        </div>
       </clr-dg-action-overflow>
 
       <clr-dg-cell>{{user.id}}</clr-dg-cell>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

By [w3c specification](https://w3c.github.io/aria-practices/examples/menu-button/menu-button-links.html) role menu has to have keyboard navigation with arrow keys. At the moment the overflow menu in datagrid doesn't support this by default.

Issue Number: VPAT-600

## What is the new behavior?

By using the `clrKeyNavigationList` directive on the container all clickable/focusable elements inside the container will be able to focus with arrow key.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
