### PR TITLE
fix(modal): disconnect the resize observer once the modal body is removed (v12 backport)

### DIFF
--- a/projects/angular/src/modal/modal-body.ts
+++ b/projects/angular/src/modal/modal-body.ts
@@ -16,10 +16,12 @@ import { Directive, ElementRef, NgZone, OnDestroy, Renderer2 } from '@angular/co
 export class ClrModalBody implements OnDestroy {
   private tabindex = '0';
   private unlisteners: VoidFunction[] = [];
+  private observer: ResizeObserver;
 
   constructor(private readonly renderer: Renderer2, private readonly host: ElementRef<HTMLElement>, ngZone: NgZone) {
     ngZone.runOutsideAngular(() => {
-      new ResizeObserver(() => this.addOrRemoveTabIndex()).observe(this.host.nativeElement);
+      this.observer = new ResizeObserver(() => this.addOrRemoveTabIndex());
+      this.observer.observe(this.host.nativeElement);
 
       this.unlisteners.push(
         this.renderer.listen(this.host.nativeElement, 'mouseup', () => {
@@ -39,6 +41,9 @@ export class ClrModalBody implements OnDestroy {
     while (this.unlisteners.length) {
       this.unlisteners.pop()();
     }
+
+    this.observer.disconnect();
+    this.observer = null;
   }
 
   private addTabIndex() {


### PR DESCRIPTION
This is a backport of #5.

Requested here: https://github.com/vmware-clarity/ng-clarity/commit/b95729e6447b8f3180969fef939e10910dd62771#commitcomment-74553929

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
