### PR TITLE
fix(datagrid): add role=gridcell to row detail element (backport)

### DIFF
--- a/projects/angular/src/data/datagrid/datagrid-row-detail.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row-detail.spec.ts
@@ -75,6 +75,10 @@ export default function (): void {
     it('should add id to the root element', function () {
       expect(context.clarityElement.getAttribute('id')).not.toBeNull();
     });
+
+    it('should have role=gridcell', function () {
+      expect(context.clarityElement.getAttribute('role')).toBe('gridcell');
+    });
   });
 }
 

--- a/projects/angular/src/data/datagrid/datagrid-row-detail.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row-detail.ts
@@ -35,6 +35,7 @@ import { Selection } from './providers/selection';
     '[class.datagrid-row-detail]': 'true',
     '[class.datagrid-container]': 'cells.length === 0',
     '[attr.id]': 'expand.expandableId',
+    role: 'gridcell',
   },
 })
 export class ClrDatagridRowDetail implements AfterContentInit, OnDestroy {


### PR DESCRIPTION
fixes VPAT-601

Signed-off-by: Ashley Ryan <asryan@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

the detail pane exists inside of a role="gridrow" element, but is not denoted as a cell, which is incorrect semantically

Issue Number: VPAT-601

## What is the new behavior?

Now it's a gridcell to match the semantic requirements (all of the issues with expandable rows in a datagrid still exist)

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
