### PR TITLE
fix(combobox): keep focus while filtering and improve input on small devices

### DIFF
--- a/projects/angular/src/forms/combobox/_combobox.clarity.scss
+++ b/projects/angular/src/forms/combobox/_combobox.clarity.scss
@@ -55,7 +55,7 @@
     @include css-var(font-size, clr-combobox-font-size, $clr-combobox-font-size, $clr-use-custom-properties);
 
     &.multi {
-      min-width: $clr-ng-multiselect-min-width;
+      min-width: min($clr-ng-multiselect-min-width, 100%);
       padding-bottom: $clr_baselineRem_0_125;
     }
 

--- a/projects/angular/src/forms/combobox/options.ts
+++ b/projects/angular/src/forms/combobox/options.ts
@@ -134,6 +134,11 @@ export class ClrOptions<T> implements AfterViewInit, LoadingListener, OnDestroy 
         ) {
           this.toggleService.open = false;
         }
+      }),
+      this.items.changes.subscribe(() => {
+        setTimeout(() => {
+          this.focusHandler.focusFirstActive();
+        });
       })
     );
   }

--- a/projects/angular/src/forms/combobox/providers/combobox-focus-handler.service.ts
+++ b/projects/angular/src/forms/combobox/providers/combobox-focus-handler.service.ts
@@ -201,7 +201,13 @@ export class ComboboxFocusHandler<T> {
           firstActive = this.selectionService.selectionModel.model as T;
         }
         const activeProxy = this.optionData.find(option => option.value === firstActive);
-        this.pseudoFocus.select(activeProxy);
+        if (activeProxy) {
+          // active element is visible
+          this.pseudoFocus.select(activeProxy);
+        } else {
+          // we have active element, but it's filtered out
+          this.pseudoFocus.select(this.optionData[0]);
+        }
       }
     }
   }


### PR DESCRIPTION
closes #106
closes #139
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

1. When screen gets too small the min width of the combobox container leads to the dropdown arrow getting outside the screen and the combobox unable to be open.

2. When filtering the focus was getting lost

## What is the new behavior?

1. The combobox still has min-width value, but it gets overridden if the component container width is less than the min-value. Note, there is still a min-width on the input itself. It is smaller than the one on the combo container, so it gets in effect on much smaller screen widths and should not be a problem on real devices.

2. While filtering, the focus is moved to the first selected item on the list, or the 1st item without selection, if no selected item is visible. Focus is preserved.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
