### PR TITLE
Revert "chore: use correct name in pull request bot comments"

### DIFF
--- a/.github/workflows/bot.yml
+++ b/.github/workflows/bot.yml
@@ -27,7 +27,7 @@ jobs:
           comment-id: ${{steps.find-comment.outputs.comment-id}}
           issue-number: ${{steps.get_pr_event.outputs.pullRequestNumber}}
           body: |
-            👋 @${{github.event.pull_request.user.login}},
+            👋 @${{github.event.sender.login}},
 
             * 🙏 The Clarity team thanks you for opening a pull request
             * ⏳ The build for this PR has started
@@ -44,7 +44,7 @@ jobs:
           comment-id: ${{steps.find-comment.outputs.comment-id}}
           issue-number: ${{steps.get_pr_event.outputs.pullRequestNumber}}
           body: |
-            👋 @${{github.event.pull_request.user.login}},
+            👋 @${{github.event.sender.login}},
 
             * 🙏 The Clarity team thanks you for opening a pull request
             * 🎉 The build for this PR has succeeded
@@ -63,7 +63,7 @@ jobs:
           comment-id: ${{steps.find-comment.outputs.comment-id}}
           issue-number: ${{steps.get_pr_event.outputs.pullRequestNumber}}
           body: |
-            👋 @${{github.event.pull_request.user.login}},
+            👋 @${{github.event.sender.login}},
 
             * 😭 The build for this PR has failed
             * 🗒 Please check out the [build log](${{github.event.workflow_run.html_url}})


### PR DESCRIPTION
This PR reverts vmware-clarity/ng-clarity#148 since it doesn't work.