### PR TITLE
fix(vertical-nav): set min-height of nav icon (backport)

### DIFF
--- a/projects/angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
+++ b/projects/angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
@@ -293,6 +293,7 @@
 
       //Dims
       @include equilateral($clr-vertical-nav-icon-size);
+      @include min-equilateral($clr-vertical-nav-icon-size);
       margin-right: $clr-vertical-nav-icon-right-margin;
 
       //Others


### PR DESCRIPTION
dont fall back to Core's min-height value when not using css tokens

closes #138

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The base size in core changed in v6, when not using the core tokens. While the ng css has a height/width set, it did not have a min-height and min-width, which was resulting in larger than expected icons in the vertical nav

Issue Number: #138 

## What is the new behavior?

Sets a min-height and min-width on the nav-icon to properly size the icon. Core will be addressed separately

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
