### PR TITLE
chore: preserve path when hard landing on demo app url

### DIFF
--- a/projects/demo/src/app/cds-theme-select.component.ts
+++ b/projects/demo/src/app/cds-theme-select.component.ts
@@ -43,7 +43,7 @@ export class CdsThemeSelectComponent implements OnInit, OnDestroy {
   }
 
   private setThemeInQueryString(theme: string) {
-    this.router.navigate([], {
+    this.router.navigate([window.location.pathname], {
       queryParams: { ...getQueryParams(), [cdsThemeAttribute]: theme || null },
       replaceUrl: true,
     });


### PR DESCRIPTION
This fixes a regression I introduced in e87ee8b26801c275bcd1eb3d482c0a7a3c12678c.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: demo app fix

## What is the current behavior?

If you hard-land on demo.example.com/path, the demo landing page is loaded instead of the page you specified.

## What is the new behavior?

If you hard-land on demo.example.com/path, the page you specified is loaded.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
