### PR TITLE
chore: add checkout step back to `demo` workflow

### DIFF
--- a/.github/workflows/demo.yml
+++ b/.github/workflows/demo.yml
@@ -11,6 +11,8 @@ jobs:
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
+      - name: Checkout
+        uses: actions/checkout@v2
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
This fixes a mistake I made in 6741ea51f55365f3576e787e861baa270d84836d.

The code needs to be checked out so the .nvmrc file is present.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

CI related changes