### PR TITLE
chore: remove name for visual regression job

### DIFF
--- a/.github/workflows/pr-visual-regression.yml
+++ b/.github/workflows/pr-visual-regression.yml
@@ -6,7 +6,6 @@ on:
       - completed
 jobs:
   pr-visual-regression:
-    name: PR Visual Regression
     if: ${{github.event.workflow_run.conclusion == 'success'}}
     timeout-minutes: 10
     runs-on: ubuntu-latest


### PR DESCRIPTION
This is to work around https://github.com/haya14busa/action-workflow_run-status/issues/158.