### PR TITLE
chore: cancel running builds if changes are pushed (backport)

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -1,6 +1,9 @@
 name: PR Build
 on:
   pull_request:
+concurrency:
+  group: pr-build-${{github.event.pull_request.number}}
+  cancel-in-progress: true
 jobs:
   pr-build:
     name: PR Build


### PR DESCRIPTION
This is a backport of #213.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

CI related changes

## What is the current behavior?

If a build is running when changes are pushed to a PR, a new build is started and the previous build continues.

## What is the new behavior?

If a build is running when changes are pushed to a PR, a new build is started and the previous build should be canceled.