### PR TITLE
chore: update `potiuk/get-workflow-origin` action to v1_3

### DIFF
--- a/.github/workflows/pr-comment-bot.yml
+++ b/.github/workflows/pr-comment-bot.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Get PR Event
         id: get_pr_event
-        uses: potiuk/get-workflow-origin@v1_1
+        uses: potiuk/get-workflow-origin@v1_3
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           sourceRunId: ${{github.event.workflow_run.id}}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -26,7 +26,7 @@ jobs:
           run_id: ${{github.event.workflow_run.id}}
       - name: Get PR Event
         id: get_pr_event
-        uses: potiuk/get-workflow-origin@v1_1
+        uses: potiuk/get-workflow-origin@v1_3
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           sourceRunId: ${{github.event.workflow_run.id}}

--- a/.github/workflows/pr-visual-regression.yml
+++ b/.github/workflows/pr-visual-regression.yml
@@ -13,7 +13,7 @@ jobs:
       - uses: haya14busa/action-workflow_run-status@v1
       - name: Get PR Event
         id: get_pr_event
-        uses: potiuk/get-workflow-origin@v1_1
+        uses: potiuk/get-workflow-origin@v1_3
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           sourceRunId: ${{github.event.workflow_run.id}}


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

CI related changes

## What is the current behavior?

The Chromatic checks are skipped for PRs that target `main`.

## What is the new behavior?

The Chromatic checks are not skipped for PRs that target `main`.

## Does this PR introduce a breaking change?

No

## Other information

This fixes the "PR Visual Regression" workflow for PRs that target the `main` branch. I broke it in #220 because I used output that didn't exist in the older version of this action.
