### PR TITLE
chore: remove unnecessary/deprecated `entryComponents` properties

### DIFF
--- a/projects/angular/src/data/data.module.ts
+++ b/projects/angular/src/data/data.module.ts
@@ -10,5 +10,7 @@ import { ClrDatagridModule } from './datagrid/datagrid.module';
 import { ClrStackViewModule } from './stack-view/stack-view.module';
 import { ClrTreeViewModule } from './tree-view/tree-view.module';
 
-@NgModule({ exports: [ClrDatagridModule, ClrStackViewModule, ClrTreeViewModule] })
+@NgModule({
+  exports: [ClrDatagridModule, ClrStackViewModule, ClrTreeViewModule],
+})
 export class ClrDataModule {}

--- a/projects/angular/src/data/datagrid/datagrid.module.ts
+++ b/projects/angular/src/data/datagrid/datagrid.module.ts
@@ -132,7 +132,6 @@ export const CLR_DATAGRID_DIRECTIVES: Type<any>[] = [
   ],
   declarations: [CLR_DATAGRID_DIRECTIVES],
   exports: [CLR_DATAGRID_DIRECTIVES],
-  entryComponents: [WrappedCell, WrappedColumn, WrappedRow],
 })
 export class ClrDatagridModule {
   constructor() {

--- a/projects/angular/src/emphasis/emphasis.module.ts
+++ b/projects/angular/src/emphasis/emphasis.module.ts
@@ -8,5 +8,7 @@ import { NgModule } from '@angular/core';
 
 import { ClrAlertModule } from './alert/alert.module';
 
-@NgModule({ exports: [ClrAlertModule] })
+@NgModule({
+  exports: [ClrAlertModule],
+})
 export class ClrEmphasisModule {}

--- a/projects/angular/src/forms/checkbox/checkbox.module.ts
+++ b/projects/angular/src/forms/checkbox/checkbox.module.ts
@@ -19,7 +19,6 @@ import { ClrCheckboxWrapper } from './checkbox-wrapper';
   imports: [CommonModule, ClrIconModule, ClrCommonFormsModule, ClrHostWrappingModule],
   declarations: [ClrCheckbox, ClrCheckboxContainer, ClrCheckboxWrapper],
   exports: [ClrCommonFormsModule, ClrCheckbox, ClrCheckboxContainer, ClrCheckboxWrapper],
-  entryComponents: [ClrCheckboxWrapper],
 })
 export class ClrCheckboxModule {
   constructor() {

--- a/projects/angular/src/forms/common/common.module.ts
+++ b/projects/angular/src/forms/common/common.module.ts
@@ -46,7 +46,6 @@ import { ClrControlSuccess } from './success';
     ClrControlContainer,
     ClrControl,
   ],
-  entryComponents: [ClrControlContainer],
 })
 export class ClrCommonFormsModule {
   constructor() {

--- a/projects/angular/src/forms/common/common.spec.ts
+++ b/projects/angular/src/forms/common/common.spec.ts
@@ -43,7 +43,6 @@ class GenericControl extends WrappedFormControl<GenericWrapper> {
   imports: [ClrCommonFormsModule, ClrHostWrappingModule],
   declarations: [GenericWrapper, GenericControl],
   exports: [ClrCommonFormsModule, GenericWrapper, GenericControl],
-  entryComponents: [GenericWrapper],
 })
 class CommonFormsTestModule {}
 

--- a/projects/angular/src/forms/common/wrapped-control.spec.ts
+++ b/projects/angular/src/forms/common/wrapped-control.spec.ts
@@ -95,7 +95,6 @@ class FormWrapper {}
   imports: [ClrHostWrappingModule, FormsModule],
   declarations: [TestWrapper, TestControl, TestWrapper2, TestControl2, TestControl3, TestWrapper3, FormWrapper],
   exports: [TestWrapper, TestControl, TestWrapper2, TestControl2, TestControl3, TestWrapper3, FormWrapper],
-  entryComponents: [TestWrapper, TestWrapper2, TestWrapper3, FormWrapper],
 })
 class WrappedFormControlTestModule {}
 

--- a/projects/angular/src/forms/datepicker/datepicker.module.ts
+++ b/projects/angular/src/forms/datepicker/datepicker.module.ts
@@ -53,7 +53,6 @@ export const CLR_DATEPICKER_DIRECTIVES: Type<any>[] = [
   ],
   declarations: [CLR_DATEPICKER_DIRECTIVES],
   exports: [CLR_DATEPICKER_DIRECTIVES],
-  entryComponents: [ClrDateContainer],
 })
 export class ClrDatepickerModule {
   constructor() {

--- a/projects/angular/src/forms/input/input.module.ts
+++ b/projects/angular/src/forms/input/input.module.ts
@@ -18,7 +18,6 @@ import { ClrInputContainer } from './input-container';
   imports: [CommonModule, FormsModule, ClrIconModule, ClrCommonFormsModule],
   declarations: [ClrInput, ClrInputContainer],
   exports: [ClrCommonFormsModule, ClrInput, ClrInputContainer],
-  entryComponents: [ClrInputContainer],
 })
 export class ClrInputModule {
   constructor() {

--- a/projects/angular/src/forms/password/password.module.ts
+++ b/projects/angular/src/forms/password/password.module.ts
@@ -18,7 +18,6 @@ import { ClrPasswordContainer } from './password-container';
   imports: [CommonModule, FormsModule, ClrIconModule, ClrCommonFormsModule],
   declarations: [ClrPassword, ClrPasswordContainer],
   exports: [ClrCommonFormsModule, ClrPassword, ClrPasswordContainer],
-  entryComponents: [ClrPasswordContainer],
 })
 export class ClrPasswordModule {
   constructor() {

--- a/projects/angular/src/forms/radio/radio.module.ts
+++ b/projects/angular/src/forms/radio/radio.module.ts
@@ -19,7 +19,6 @@ import { ClrRadioWrapper } from './radio-wrapper';
   imports: [CommonModule, ClrCommonFormsModule, ClrHostWrappingModule, ClrIconModule],
   declarations: [ClrRadio, ClrRadioContainer, ClrRadioWrapper],
   exports: [ClrCommonFormsModule, ClrRadio, ClrRadioContainer, ClrRadioWrapper],
-  entryComponents: [ClrRadioWrapper],
 })
 export class ClrRadioModule {
   constructor() {

--- a/projects/angular/src/forms/range/range.module.ts
+++ b/projects/angular/src/forms/range/range.module.ts
@@ -18,7 +18,6 @@ import { ClrRangeContainer } from './range-container';
   imports: [CommonModule, ClrCommonFormsModule, ClrHostWrappingModule, ClrIconModule],
   declarations: [ClrRange, ClrRangeContainer],
   exports: [ClrCommonFormsModule, ClrRange, ClrRangeContainer],
-  entryComponents: [ClrRangeContainer],
 })
 export class ClrRangeModule {
   constructor() {

--- a/projects/angular/src/forms/select/select.module.ts
+++ b/projects/angular/src/forms/select/select.module.ts
@@ -18,7 +18,6 @@ import { ClrSelectContainer } from './select-container';
   imports: [CommonModule, FormsModule, ClrIconModule, ClrCommonFormsModule],
   declarations: [ClrSelect, ClrSelectContainer],
   exports: [ClrCommonFormsModule, ClrSelect, ClrSelectContainer],
-  entryComponents: [ClrSelectContainer],
 })
 export class ClrSelectModule {
   constructor() {

--- a/projects/angular/src/forms/textarea/textarea.module.ts
+++ b/projects/angular/src/forms/textarea/textarea.module.ts
@@ -18,7 +18,6 @@ import { ClrTextareaContainer } from './textarea-container';
   imports: [CommonModule, FormsModule, ClrIconModule, ClrCommonFormsModule],
   declarations: [ClrTextarea, ClrTextareaContainer],
   exports: [ClrCommonFormsModule, ClrTextarea, ClrTextareaContainer],
-  entryComponents: [ClrTextareaContainer],
 })
 export class ClrTextareaModule {
   constructor() {

--- a/projects/angular/src/icon/icon.module.ts
+++ b/projects/angular/src/icon/icon.module.ts
@@ -11,5 +11,9 @@ import { CdsIconCustomTag, ClrIconCustomTag } from './icon';
 
 export const CLR_ICON_DIRECTIVES: Type<any>[] = [ClrIconCustomTag, CdsIconCustomTag];
 
-@NgModule({ imports: [CommonModule], declarations: [CLR_ICON_DIRECTIVES], exports: [CLR_ICON_DIRECTIVES] })
+@NgModule({
+  imports: [CommonModule],
+  declarations: [CLR_ICON_DIRECTIVES],
+  exports: [CLR_ICON_DIRECTIVES],
+})
 export class ClrIconModule {}

--- a/projects/angular/src/layout/layout.module.ts
+++ b/projects/angular/src/layout/layout.module.ts
@@ -11,5 +11,7 @@ import { ClrNavigationModule } from './nav/navigation.module';
 import { ClrTabsModule } from './tabs/tabs.module';
 import { ClrVerticalNavModule } from './vertical-nav/vertical-nav.module';
 
-@NgModule({ exports: [ClrMainContainerModule, ClrNavigationModule, ClrTabsModule, ClrVerticalNavModule] })
+@NgModule({
+  exports: [ClrMainContainerModule, ClrNavigationModule, ClrTabsModule, ClrVerticalNavModule],
+})
 export class ClrLayoutModule {}

--- a/projects/angular/src/popover/popover.module.ts
+++ b/projects/angular/src/popover/popover.module.ts
@@ -10,5 +10,7 @@ import { ClrDropdownModule } from './dropdown/dropdown.module';
 import { ClrSignpostModule } from './signpost/signpost.module';
 import { ClrTooltipModule } from './tooltip/tooltip.module';
 
-@NgModule({ exports: [ClrDropdownModule, ClrSignpostModule, ClrTooltipModule] })
+@NgModule({
+  exports: [ClrDropdownModule, ClrSignpostModule, ClrTooltipModule],
+})
 export class ClrPopoverModule {}

--- a/projects/angular/src/utils/conditional/conditional.module.ts
+++ b/projects/angular/src/utils/conditional/conditional.module.ts
@@ -13,5 +13,9 @@ import { ClrIfOpen } from './if-open.directive';
 
 export const CONDITIONAL_DIRECTIVES: Type<any>[] = [ClrIfActive, ClrIfOpen, ClrIfExpanded];
 
-@NgModule({ imports: [CommonModule], declarations: [CONDITIONAL_DIRECTIVES], exports: [CONDITIONAL_DIRECTIVES] })
+@NgModule({
+  imports: [CommonModule],
+  declarations: [CONDITIONAL_DIRECTIVES],
+  exports: [CONDITIONAL_DIRECTIVES],
+})
 export class ClrConditionalModule {}

--- a/projects/angular/src/utils/drag-and-drop/drag-and-drop.module.ts
+++ b/projects/angular/src/utils/drag-and-drop/drag-and-drop.module.ts
@@ -24,7 +24,6 @@ export const CLR_DRAG_AND_DROP_DIRECTIVES: Type<any>[] = [
 @NgModule({
   imports: [CommonModule],
   declarations: [CLR_DRAG_AND_DROP_DIRECTIVES],
-  entryComponents: [ClrDraggableGhost],
   exports: [CLR_DRAG_AND_DROP_DIRECTIVES],
 })
 export class ClrDragAndDropModule {}

--- a/projects/angular/src/utils/host-wrapping/host-wrapping.module.ts
+++ b/projects/angular/src/utils/host-wrapping/host-wrapping.module.ts
@@ -14,6 +14,5 @@ import { EmptyAnchor } from './empty-anchor';
 @NgModule({
   declarations: [EmptyAnchor],
   exports: [EmptyAnchor],
-  entryComponents: [EmptyAnchor],
 })
 export class ClrHostWrappingModule {}

--- a/projects/angular/src/utils/host-wrapping/host-wrapping.module.ts
+++ b/projects/angular/src/utils/host-wrapping/host-wrapping.module.ts
@@ -11,5 +11,9 @@ import { EmptyAnchor } from './empty-anchor';
 /**
  * Internal module, please do not export!
  */
-@NgModule({ declarations: [EmptyAnchor], exports: [EmptyAnchor], entryComponents: [EmptyAnchor] })
+@NgModule({
+  declarations: [EmptyAnchor],
+  exports: [EmptyAnchor],
+  entryComponents: [EmptyAnchor],
+})
 export class ClrHostWrappingModule {}

--- a/projects/angular/src/utils/host-wrapping/host-wrapping.spec.ts
+++ b/projects/angular/src/utils/host-wrapping/host-wrapping.spec.ts
@@ -40,7 +40,6 @@ class WrappedDirective implements OnInit {
 @NgModule({
   declarations: [WrapperComponent, WrappedDirective],
   exports: [WrapperComponent, WrappedDirective],
-  entryComponents: [WrapperComponent],
 })
 class HostWrappingTestModule {}
 

--- a/projects/angular/src/utils/loading/loading.module.ts
+++ b/projects/angular/src/utils/loading/loading.module.ts
@@ -11,5 +11,9 @@ import { ClrLoading } from './loading';
 
 export const CLR_LOADING_DIRECTIVES: Type<any>[] = [ClrLoading];
 
-@NgModule({ imports: [CommonModule], declarations: [CLR_LOADING_DIRECTIVES], exports: [CLR_LOADING_DIRECTIVES] })
+@NgModule({
+  imports: [CommonModule],
+  declarations: [CLR_LOADING_DIRECTIVES],
+  exports: [CLR_LOADING_DIRECTIVES],
+})
 export class ClrLoadingModule {}

--- a/projects/angular/src/utils/outside-click/outside-click.module.ts
+++ b/projects/angular/src/utils/outside-click/outside-click.module.ts
@@ -9,5 +9,9 @@ import { NgModule } from '@angular/core';
 
 import { OUSTIDE_CLICK_DIRECTIVES } from './index';
 
-@NgModule({ imports: [CommonModule], declarations: [OUSTIDE_CLICK_DIRECTIVES], exports: [OUSTIDE_CLICK_DIRECTIVES] })
+@NgModule({
+  imports: [CommonModule],
+  declarations: [OUSTIDE_CLICK_DIRECTIVES],
+  exports: [OUSTIDE_CLICK_DIRECTIVES],
+})
 export class ClrOutsideClickModule {}

--- a/projects/angular/src/utils/template-ref/template-ref.module.ts
+++ b/projects/angular/src/utils/template-ref/template-ref.module.ts
@@ -12,7 +12,6 @@ import { TEMPLATE_REF_DIRECTIVES } from './index';
 @NgModule({
   imports: [CommonModule],
   declarations: [TEMPLATE_REF_DIRECTIVES],
-  entryComponents: [TEMPLATE_REF_DIRECTIVES],
   exports: [TEMPLATE_REF_DIRECTIVES],
 })
 export class ClrTemplateRefModule {}

--- a/projects/angular/src/utils/virtual-scroll/virtual-scroll.module.ts
+++ b/projects/angular/src/utils/virtual-scroll/virtual-scroll.module.ts
@@ -9,5 +9,9 @@ import { NgModule } from '@angular/core';
 
 import { VIRTUAL_SCROLL_DIRECTIVES } from './index';
 
-@NgModule({ imports: [CommonModule], declarations: [VIRTUAL_SCROLL_DIRECTIVES], exports: [VIRTUAL_SCROLL_DIRECTIVES] })
+@NgModule({
+  imports: [CommonModule],
+  declarations: [VIRTUAL_SCROLL_DIRECTIVES],
+  exports: [VIRTUAL_SCROLL_DIRECTIVES],
+})
 export class ClrVirtualScrollModule {}

--- a/projects/demo/src/app/_utils/utils.module.ts
+++ b/projects/demo/src/app/_utils/utils.module.ts
@@ -10,5 +10,9 @@ import { ClarityModule } from '@clr/angular';
 
 import { FakeLoader } from './fake-loader';
 
-@NgModule({ imports: [CommonModule, ClarityModule], declarations: [FakeLoader], exports: [FakeLoader] })
+@NgModule({
+  imports: [CommonModule, ClarityModule],
+  declarations: [FakeLoader],
+  exports: [FakeLoader],
+})
 export class UtilsDemoModule {}

--- a/projects/demo/src/app/images/images.demo.module.ts
+++ b/projects/demo/src/app/images/images.demo.module.ts
@@ -11,5 +11,9 @@ import { ClarityModule } from '@clr/angular';
 import { ImagesDemo } from './images.demo';
 import { ROUTING } from './images.demo.routing';
 
-@NgModule({ imports: [CommonModule, ClarityModule, ROUTING], declarations: [ImagesDemo], exports: [ImagesDemo] })
+@NgModule({
+  imports: [CommonModule, ClarityModule, ROUTING],
+  declarations: [ImagesDemo],
+  exports: [ImagesDemo],
+})
 export class ImagesDemoModule {}


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Refactoring (no functional changes, no api changes)

## Other information

Entry components do not to be specified for libraries built with Ivy.