### PR TITLE
fix(stepper): reset when form is reset but not when form is patched (backport)

### DIFF
--- a/projects/angular/src/accordion/stepper/stepper.spec.ts
+++ b/projects/angular/src/accordion/stepper/stepper.spec.ts
@@ -144,6 +144,13 @@ describe('ClrStepper', () => {
       expect(stepperService.resetPanels).toHaveBeenCalled();
     });
 
+    it('should not reset panels when form is patched', () => {
+      spyOn(stepperService, 'resetPanels');
+      testComponent.form.patchValue({});
+      fixture.detectChanges();
+      expect(stepperService.resetPanels).not.toHaveBeenCalled();
+    });
+
     it('should trigger ngSubmit event when all panels have completed', () => {
       spyOn(testComponent, 'submit');
       (testComponent.form.controls.group as FormGroup).controls.name.setValue('1');


### PR DESCRIPTION
closes #191

This is a backport of #232.

## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

Issue Number: #191

## What is the new behavior?

The stepper resets when the form is reset but not when the form is patched.

## Does this PR introduce a breaking change?

No. (Unless some user is relying on the broken behavior.)