### PR TITLE
feat(datagrid): add possibility to clear filters

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -892,6 +892,7 @@ export class ClrCommonFormsModule {
 export interface ClrCommonStrings {
     alertCloseButtonAriaLabel: string;
     allColumnsSelected: string;
+    clear?: string;
     close: string;
     collapse: string;
     columnSeparatorAriaLabel?: string;
@@ -1474,6 +1475,10 @@ export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDa
     // (undocumented)
     ariaExpanded: boolean;
     // (undocumented)
+    clearAvailable(): boolean;
+    // (undocumented)
+    clearFilter(event: MouseEvent): void;
+    // (undocumented)
     commonStrings: ClrCommonStringsService;
     // Warning: (ae-forgotten-export) The symbol "RegisteredFilter" needs to be exported by the entry point index.d.ts
     //
@@ -1502,6 +1507,8 @@ export interface ClrDatagridFilterInterface<T, S = any> {
     accepts(item: T): boolean;
     // (undocumented)
     changes: Observable<any>;
+    // (undocumented)
+    clear?(): void;
     // (undocumented)
     equals?(other: ClrDatagridFilterInterface<T, any>): boolean;
     // (undocumented)

--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -751,14 +751,6 @@
         @include css-var(border-radius, clr-global-borderradius, $clr-global-borderradius, $clr-use-custom-properties);
         font-weight: normal;
 
-        .datagrid-filter-close-wrapper {
-          text-align: right;
-
-          .close {
-            float: none;
-          }
-        }
-
         // FIXME: remove
         .datagrid-filter-apply {
           margin-bottom: 0;
@@ -788,14 +780,6 @@
         @include css-var(border-radius, clr-global-borderradius, $clr-global-borderradius, $clr-use-custom-properties);
         font-weight: normal;
 
-        .datagrid-filter-close-wrapper {
-          text-align: right;
-
-          .close {
-            float: none;
-          }
-        }
-
         // FIXME: remove
         .datagrid-filter-apply {
           margin-bottom: 0;
@@ -824,14 +808,6 @@
         @include clr-datagrid-popover-shadows;
         @include css-var(border-radius, clr-global-borderradius, $clr-global-borderradius, $clr-use-custom-properties);
         font-weight: normal;
-
-        .datagrid-filter-close-wrapper {
-          text-align: right;
-
-          .close {
-            float: none;
-          }
-        }
 
         // FIXME: remove
         .datagrid-filter-apply {
@@ -1935,14 +1911,6 @@
     @include clr-datagrid-popover-shadows;
     @include css-var(border-radius, clr-global-borderradius, $clr-global-borderradius, $clr-use-custom-properties);
     font-weight: normal;
-
-    .datagrid-filter-close-wrapper {
-      text-align: right;
-
-      .close {
-        float: none;
-      }
-    }
 
     // FIXME: remove
     .datagrid-filter-apply {

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter-impl.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter-impl.ts
@@ -84,6 +84,10 @@ export class DatagridNumericFilterImpl<T = any> implements ClrDatagridFilterInte
     return this.filterFn.accepts(item, this._low, this._high);
   }
 
+  public clear(): void {
+    this.value = [null, null];
+  }
+
   public get state() {
     if (this.filterFn instanceof DatagridPropertyNumericFilter) {
       return {

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-string-filter-impl.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-string-filter-impl.ts
@@ -66,6 +66,10 @@ export class DatagridStringFilterImpl<T = any> implements ClrDatagridFilterInter
     return this.filterFn.accepts(item, this.lowerCaseValue);
   }
 
+  public clear(): void {
+    this.value = '';
+  }
+
   public get state() {
     if (this.filterFn instanceof DatagridPropertyStringFilter) {
       return {

--- a/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
@@ -118,6 +118,19 @@ export default function (): void {
       it('registers itself as a CustomFilter provider', function () {
         expect(context.testComponent.customFilter).toBe(context.clarityDirective);
       });
+
+      it('should call clear when clear button is clicked', function () {
+        context.testComponent.filter = filter;
+        spyOn(filter, 'clear');
+        context.testComponent.open = true;
+        context.detectChanges();
+
+        const clearButton = document.querySelector('.datagrid-filter-close-wrapper button.clear') as HTMLButtonElement;
+        clearButton.click();
+        context.detectChanges();
+
+        expect(filter.clear).toHaveBeenCalled();
+      });
     });
 
     describe('View', function () {
@@ -222,6 +235,10 @@ class TestFilter implements ClrDatagridFilterInterface<number> {
   // eslint-disable-next-line
   accepts(_n: number): boolean {
     return true;
+  }
+
+  clear(): void {
+    this.active = false;
   }
 
   changes = new Subject<boolean>();

--- a/projects/angular/src/data/datagrid/datagrid-filter.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.ts
@@ -71,6 +71,9 @@ import { DatagridFilterRegistrar } from './utils/datagrid-filter-registrar';
         <button type="button" class="close" clrPopoverCloseButton>
           <cds-icon shape="window-close" [attr.title]="commonStrings.keys.close"></cds-icon>
         </button>
+        <button type="button" class="close clear" *ngIf="clearAvailable()" (click)="clearFilter($event)">
+          <cds-icon shape="trash" [attr.title]="commonStrings.keys.clear"></cds-icon>
+        </button>
       </div>
 
       <ng-content></ng-content>
@@ -142,6 +145,17 @@ export class ClrDatagridFilter<T = any>
    */
   public get active() {
     return !!this.filter && this.filter.isActive();
+  }
+
+  public clearAvailable() {
+    return this.active && typeof this.filter.clear === 'function';
+  }
+
+  public clearFilter(event: MouseEvent) {
+    if (this.clearAvailable()) {
+      this.filter.clear();
+      this.smartToggleService.toggleWithEvent(event);
+    }
   }
 
   override ngOnDestroy(): void {

--- a/projects/angular/src/data/datagrid/interfaces/filter.interface.ts
+++ b/projects/angular/src/data/datagrid/interfaces/filter.interface.ts
@@ -11,6 +11,8 @@ export interface ClrDatagridFilterInterface<T, S = any> {
 
   accepts(item: T): boolean;
 
+  clear?(): void;
+
   changes: Observable<any>;
 
   readonly state?: S;

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -11,6 +11,7 @@ export const commonStringsDefault: ClrCommonStrings = {
   close: 'Close',
   show: 'Show',
   hide: 'Hide',
+  clear: 'Clear',
   expand: 'Expand',
   collapse: 'Collapse',
   more: 'More',

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -26,6 +26,10 @@ export interface ClrCommonStrings {
    */
   delete?: string;
   /**
+   * Clear button
+   */
+  clear?: string;
+  /**
    * Expandable components: expand caret
    */
   expand: string;

--- a/projects/demo/src/app/datagrid/utils/color-filter.ts
+++ b/projects/demo/src/app/datagrid/utils/color-filter.ts
@@ -57,4 +57,10 @@ export class ColorFilter implements ClrDatagridFilterInterface<User> {
   isActive(): boolean {
     return this.nbColors > 0;
   }
+
+  clear(): void {
+    this.nbColors = 0;
+    this.selectedColors = {};
+    this.changes.emit(true);
+  }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)  
  Added it to the demo page.  
  I could not find the sources for https://clarity.design/documentation/datagrid/structure
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Now, you cannot easily clear a filter. For string filters you have to delete all chars in the field, for number filters you have to click both fields and clear them

Issue Number: #225

## What is the new behavior?

There is a new clear button added to the filter in the Datagrid which clears the current filter

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
