### PR TITLE
chore: fetch commit in pr visual regression workflow

### DIFF
--- a/.github/workflows/pr-visual-regression.yml
+++ b/.github/workflows/pr-visual-regression.yml
@@ -35,6 +35,13 @@ jobs:
           path: dist/docs
           workflow: ${{github.event.workflow_run.workflow_id}}
           run_id: ${{github.event.workflow_run.id}}
+      - name: Fetch Commit
+        if: ${{steps.get_pr_event.outputs.targetBranch == 'main'}}
+        env:
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}
+          SOURCE_HEAD_REPO: ${{steps.get_pr_event.outputs.sourceHeadRepo}}
+          SOURCE_HEAD_SHA: ${{steps.get_pr_event.outputs.sourceHeadSha}}
+        run: git fetch https://x-access-token:${GITHUB_TOKEN}@github.com/${SOURCE_HEAD_REPO}.git ${SOURCE_HEAD_SHA}
       - name: Deploy Chromatic
         if: ${{steps.get_pr_event.outputs.targetBranch == 'main'}}
         timeout-minutes: 5


### PR DESCRIPTION
This is mainly needed to fetch commits that live in another repo (forks).

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

CI related changes

## What is the current behavior?

Chromatic cannot find the correct baseline for commits that live in another repo.

## What is the new behavior?

Chromatic should find the correct baseline for commits that live in another repo.

## Does this PR introduce a breaking change?

No