### PR TITLE
fix(wizard): remove unnecessary vertical scroll bar

### DIFF
--- a/projects/angular/src/wizard/_wizard.clarity.scss
+++ b/projects/angular/src/wizard/_wizard.clarity.scss
@@ -74,7 +74,6 @@
       flex: 1 1 auto;
       @include css-var(color, clr-wizard-main-textColor, $clr-wizard-main-textColor, $clr-use-custom-properties);
       width: 100%;
-      min-height: 70vh;
     }
 
     .modal-footer {
@@ -379,6 +378,8 @@
     .modal-body-wrapper {
       // overriding forced style on .modal
       max-height: 100%;
+      flex-grow: 1;
+      width: 100%;
     }
 
     &.wizard-md {


### PR DESCRIPTION
fixes #107

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

There's a weird vertical scroll bar in the wizard on a div that is way too tall

Issue Number: #107

## What is the new behavior?

use flex-grow to make the div take up the full height instead of the previous attempted fix min-height 70vh

demo here: https://251--storybook-clarity-design.netlify.app/demo/wizard/basic

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
