### PR TITLE
    fix(combobox): force usage of css min function

### DIFF
--- a/projects/angular/src/forms/combobox/_combobox.clarity.scss
+++ b/projects/angular/src/forms/combobox/_combobox.clarity.scss
@@ -55,7 +55,7 @@
     @include css-var(font-size, clr-combobox-font-size, $clr-combobox-font-size, $clr-use-custom-properties);
 
     &.multi {
-      min-width: min($clr-ng-multiselect-min-width, 100%);
+      min-width: calc(min($clr-ng-multiselect-min-width, 100%));
       padding-bottom: $clr_baselineRem_0_125;
     }
 


### PR DESCRIPTION
    - wrap min in calc in _combobox.clarity.scss in order to force compiler to use the css min function, instead of sass min

    Close: #257

    Signed-off-by: Alex Pavlov <alex.pavlov@code-pine.com>

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: #257 

## What is the new behavior?

Css min function is forced to be used instead of the sass min function and therefore the app compiles properly.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No
