### PR TITLE
feat(datagrid): add input for page size select element id

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1649,7 +1649,9 @@ export class ClrDatagridPageSize {
     // (undocumented)
     pageSizeOptions: number[];
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridPageSize, "clr-dg-page-size", never, { "pageSizeOptions": "clrPageSizeOptions"; }, {}, never, ["*"]>;
+    pageSizeOptionsId: string;
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridPageSize, "clr-dg-page-size", never, { "pageSizeOptions": "clrPageSizeOptions"; "pageSizeOptionsId": "clrPageSizeOptionsId"; }, {}, never, ["*"]>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrDatagridPageSize, never>;
 }

--- a/projects/angular/src/data/datagrid/datagrid-page-size.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-page-size.spec.ts
@@ -25,6 +25,12 @@ export default function (): void {
         context.detectChanges();
         expect(context.clarityDirective.pageSizeOptions).toEqual([10, 20, 50, 100]);
       });
+
+      it('receives an input for page size options id', function () {
+        context.testComponent.pageSizeOptionsId = 'some-id';
+        context.detectChanges();
+        expect(context.clarityDirective.pageSizeOptionsId).toEqual('some-id');
+      });
     });
 
     describe('View', function () {
@@ -54,6 +60,21 @@ export default function (): void {
 
         it('projects content before the select element', function () {
           expect(context.clarityElement.textContent.trim()).toMatch('Hello world');
+        });
+
+        it('displays a select with a default id if none given', function () {
+          const select = context.clarityElement.querySelector('select');
+          expect(select).not.toBeNull();
+          expect(select.id).toBeTruthy();
+        });
+
+        it('displays a select with pageSizeOptionsId as id', function () {
+          const pageSizeOptionsId = 'some-id';
+          context.testComponent.pageSizeOptionsId = pageSizeOptionsId;
+          context.detectChanges();
+          const select = context.clarityElement.querySelector('select');
+          expect(select).not.toBeNull();
+          expect(select.id).toBe(pageSizeOptionsId);
         });
 
         it('displays a select with pageSizeOptions as choices', function () {
@@ -92,8 +113,13 @@ export default function (): void {
 class SimpleTest {}
 
 @Component({
-  template: `<clr-dg-page-size [clrPageSizeOptions]="pageSizeOptions">Hello world</clr-dg-page-size>`,
+  template: `
+    <clr-dg-page-size [clrPageSizeOptions]="pageSizeOptions" [clrPageSizeOptionsId]="pageSizeOptionsId">
+      Hello world
+    </clr-dg-page-size>
+  `,
 })
 class FullTest {
   pageSizeOptions: number[];
+  pageSizeOptionsId: string;
 }

--- a/projects/angular/src/data/datagrid/datagrid-page-size.ts
+++ b/projects/angular/src/data/datagrid/datagrid-page-size.ts
@@ -6,6 +6,7 @@
 
 import { Component, Input } from '@angular/core';
 
+import { uniqueIdFactory } from '../../utils/id-generator/id-generator.service';
 import { Page } from './providers/page';
 
 @Component({
@@ -13,7 +14,7 @@ import { Page } from './providers/page';
   template: `
     <ng-content></ng-content>
     <div class="clr-select-wrapper">
-      <select [class.clr-page-size-select]="true" [(ngModel)]="page.size">
+      <select [id]="pageSizeOptionsId" [class.clr-page-size-select]="true" [(ngModel)]="page.size">
         <option *ngFor="let option of pageSizeOptions" [ngValue]="option">{{ option }}</option>
       </select>
     </div>
@@ -21,6 +22,7 @@ import { Page } from './providers/page';
 })
 export class ClrDatagridPageSize {
   @Input('clrPageSizeOptions') pageSizeOptions: number[];
+  @Input('clrPageSizeOptionsId') pageSizeOptionsId = uniqueIdFactory();
 
   constructor(public page: Page) {}
 


### PR DESCRIPTION
This originated in #255 as an external contribution by @pradoslavVM. I accidentally closed that PR by running a bad `git` command.

PR Type
Fix - Accessibility
What is the current behavior?
Currently you cant set an Id for the select
displaying the page size.
What is the new behavior?
Will be able to set an Id to the select
and associate it with a label using the
for attribute.
Does this PR introduce a breaking change?
No.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [x] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
