### PR TITLE
chore: register providers that use `Renderer2` at component in tests

### DIFF
--- a/projects/angular/src/data/datagrid/all.spec.ts
+++ b/projects/angular/src/data/datagrid/all.spec.ts
@@ -72,6 +72,7 @@ describe('Datagrid', function () {
     TableSizeServiceSpec();
     ColumnResizerServiceSpecs();
   });
+
   describe('Components', function () {
     DatagridActionBarSpecs();
     DatagridActionOverflowSpecs();
@@ -96,6 +97,7 @@ describe('Datagrid', function () {
     WrappedColumnSpec();
     WrappedRowSpec();
   });
+
   describe('Render', function () {
     DomAdapterSpecs();
     NoopDomAdapterSpecs();
@@ -105,6 +107,7 @@ describe('Datagrid', function () {
     DatagridHeaderRendererSpecs();
     DatagridMainRendererSpecs();
   });
+
   describe('Built-in', function () {
     NestedPropertySpecs();
     DatagridPropertyComparatorSpecs();

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter.spec.ts
@@ -39,6 +39,7 @@ const PROVIDERS = [
     useClass: MockRenderer,
   },
 ];
+
 export default function (): void {
   describe('DatagridNumericFilter accessibility', function () {
     let context: TestContext<DatagridNumericFilter<string>, AccessibilityTest>;

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Renderer2, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { DomAdapter } from '../../../../utils/dom-adapter/dom-adapter';
@@ -20,25 +20,7 @@ import { StateDebouncer } from '../../providers/state-debouncer.provider';
 import { DatagridNumericFilter } from './datagrid-numeric-filter';
 import { DatagridNumericFilterImpl } from './datagrid-numeric-filter-impl';
 
-class MockRenderer {
-  listen() {
-    // Do nothing
-  }
-}
-
-const PROVIDERS = [
-  FiltersProvider,
-  DomAdapter,
-  Page,
-  StateDebouncer,
-  ClrPopoverEventsService,
-  ClrPopoverPositionService,
-  ClrPopoverToggleService,
-  {
-    provide: Renderer2,
-    useClass: MockRenderer,
-  },
-];
+const PROVIDERS = [FiltersProvider, DomAdapter, Page, StateDebouncer, ClrPopoverToggleService];
 
 export default function (): void {
   describe('DatagridNumericFilter accessibility', function () {
@@ -174,6 +156,7 @@ class TestFilter implements ClrDatagridNumericFilterInterface<number> {
   template: `
     <clr-dg-numeric-filter [clrDgNumericFilter]="filter" [(clrFilterValue)]="filterValue"></clr-dg-numeric-filter>
   `,
+  providers: [ClrPopoverEventsService, ClrPopoverPositionService],
 })
 class FullTest {
   @ViewChild(CustomFilter) customFilter: CustomFilter;
@@ -191,6 +174,7 @@ class FullTest {
       [clrFilterMinPlaceholder]="clrFilterMinPlaceholder"
     ></clr-dg-numeric-filter>
   `,
+  providers: [ClrPopoverEventsService, ClrPopoverPositionService],
 })
 class AccessibilityTest {
   @ViewChild(CustomFilter) customFilter: CustomFilter;

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Renderer2, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { DomAdapter } from '../../../../utils/dom-adapter/dom-adapter';
@@ -20,25 +20,7 @@ import { StateDebouncer } from '../../providers/state-debouncer.provider';
 import { DatagridStringFilter } from './datagrid-string-filter';
 import { DatagridStringFilterImpl } from './datagrid-string-filter-impl';
 
-class MockRenderer {
-  listen() {
-    // Do nothing
-  }
-}
-
-const PROVIDERS = [
-  FiltersProvider,
-  DomAdapter,
-  Page,
-  StateDebouncer,
-  ClrPopoverEventsService,
-  ClrPopoverPositionService,
-  ClrPopoverToggleService,
-  {
-    provide: Renderer2,
-    useClass: MockRenderer,
-  },
-];
+const PROVIDERS = [FiltersProvider, DomAdapter, Page, StateDebouncer, ClrPopoverToggleService];
 
 export default function (): void {
   describe('DatagridStringFilter accessibility', function () {
@@ -166,6 +148,7 @@ class TestFilter implements ClrDatagridStringFilterInterface<string> {
   template: `
     <clr-dg-string-filter [clrDgStringFilter]="filter" [(clrFilterValue)]="filterValue"></clr-dg-string-filter>
   `,
+  providers: [ClrPopoverEventsService, ClrPopoverPositionService],
 })
 class FullTest {
   @ViewChild(CustomFilter) customFilter: CustomFilter;
@@ -182,6 +165,7 @@ class FullTest {
       [clrFilterPlaceholder]="clrFilterPlaceholder"
     ></clr-dg-string-filter>
   `,
+  providers: [ClrPopoverEventsService, ClrPopoverPositionService],
 })
 class AccessibilityTest {
   @ViewChild(CustomFilter) customFilter: CustomFilter;

--- a/projects/angular/src/data/datagrid/datagrid-action-overflow.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-action-overflow.spec.ts
@@ -6,8 +6,6 @@
 
 import { Component, ElementRef, ViewChild } from '@angular/core';
 
-import { ClrPopoverEventsService } from '../../utils/popover/providers/popover-events.service';
-import { ClrPopoverPositionService } from '../../utils/popover/providers/popover-position.service';
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
 import { ClrDatagridActionOverflow } from './datagrid-action-overflow';
 import { TestContext } from './helpers.spec';
@@ -19,12 +17,7 @@ export default function (): void {
     let toggle: HTMLElement;
 
     beforeEach(function () {
-      context = this.create(ClrDatagridActionOverflow, SimpleTest, [
-        RowActionService,
-        ClrPopoverEventsService,
-        ClrPopoverToggleService,
-        ClrPopoverPositionService,
-      ]);
+      context = this.create(ClrDatagridActionOverflow, SimpleTest, [RowActionService, ClrPopoverToggleService]);
       toggle = context.clarityElement.querySelector('.clr-smart-open-close');
     });
 

--- a/projects/angular/src/data/datagrid/datagrid-column-toggle-button.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column-toggle-button.spec.ts
@@ -29,6 +29,7 @@ export default function (): void {
       toggleButton = context.clarityDirective;
       columnsService.mockColumns(3);
     });
+
     describe('Typescript API', function () {
       it('checks hideable columns are all hidden', function () {
         columnsService.mockPartialHideable(0, 1);
@@ -48,6 +49,7 @@ export default function (): void {
         expect(toggleButton.allHideablesVisible).toBeTruthy();
       });
     });
+
     describe('View', function () {
       it('makes button disabled when all hideable columns are visible', function () {
         columnsService.mockPartialHideable(0, 1);

--- a/projects/angular/src/data/datagrid/datagrid-column-toggle.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column-toggle.spec.ts
@@ -120,6 +120,7 @@ export default function (): void {
         tick();
         expect(toggleBtn.getAttribute('aria-expanded')).toBe('false');
       }));
+
       it('toggles switch panel', fakeAsync(function () {
         context.detectChanges();
         expect(document.querySelectorAll('.column-switch').length).toBe(0);

--- a/projects/angular/src/data/datagrid/datagrid-column-toggle.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column-toggle.spec.ts
@@ -8,8 +8,6 @@ import { Component, TemplateRef, ViewChild } from '@angular/core';
 import { fakeAsync, tick } from '@angular/core/testing';
 
 import { commonStringsDefault } from '../../utils/i18n/common-strings.default';
-import { ClrPopoverEventsService } from '../../utils/popover/providers/popover-events.service';
-import { ClrPopoverPositionService } from '../../utils/popover/providers/popover-position.service';
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
 import { ClrDatagridColumnToggle } from './datagrid-column-toggle';
 import { TestContext } from './helpers.spec';
@@ -53,8 +51,6 @@ export default function (): void {
       context = this.create(ClrDatagridColumnToggle, ColumnToggleTest, [
         MOCK_COLUMN_SERVICE_PROVIDER,
         ClrPopoverToggleService,
-        ClrPopoverPositionService,
-        ClrPopoverEventsService,
       ]);
       columnsService = context.getClarityProvider(ColumnsService) as MockColumnsService;
       testComponent = context.testComponent;

--- a/projects/angular/src/data/datagrid/datagrid-column.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column.spec.ts
@@ -163,6 +163,7 @@ export default function (): void {
         this.directive = this.context.clarityDirective;
         expect(this.directive._view).toBeDefined();
       });
+
       it('receives an input for the comparator', function () {
         this.context = this.create(ClrDatagridColumn, SimpleTest, DATAGRID_SPEC_PROVIDERS);
         this.comparator = new TestComparator();
@@ -416,6 +417,7 @@ export default function (): void {
 
     describe('Build-in string and numeric filters', function () {
       let context;
+
       beforeEach(function () {
         context = this.create(ClrDatagridColumn, ColTypeTest, DATAGRID_SPEC_PROVIDERS);
       });

--- a/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Renderer2, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { Subject } from 'rxjs';
 
 import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
@@ -18,12 +18,6 @@ import { CustomFilter } from './providers/custom-filter';
 import { FiltersProvider } from './providers/filters';
 import { Page } from './providers/page';
 import { StateDebouncer } from './providers/state-debouncer.provider';
-
-class MockRenderer {
-  listen() {
-    // Do nothing
-  }
-}
 
 function cleanPopoverDOM(component: ClrDatagridFilter) {
   const popoverContent = document.querySelectorAll('.clr-popover-content');
@@ -91,10 +85,7 @@ export default function (): void {
           FiltersProvider,
           Page,
           StateDebouncer,
-          ClrPopoverEventsService,
-          ClrPopoverPositionService,
           ClrPopoverToggleService,
-          Renderer2,
         ]);
         toggleService = context.getClarityProvider(ClrPopoverToggleService);
       });
@@ -130,13 +121,7 @@ export default function (): void {
           FiltersProvider,
           Page,
           StateDebouncer,
-          ClrPopoverEventsService,
-          ClrPopoverPositionService,
           ClrPopoverToggleService,
-          {
-            provide: Renderer2,
-            useClass: MockRenderer,
-          },
         ]);
         context.testComponent.filter = filter;
       });
@@ -237,6 +222,7 @@ class TestFilter implements ClrDatagridFilterInterface<number> {
       Hello world
     </clr-dg-filter>
   `,
+  providers: [ClrPopoverEventsService, ClrPopoverPositionService],
 })
 class FullTest {
   @ViewChild(CustomFilter) customFilter: CustomFilter;

--- a/projects/angular/src/data/datagrid/datagrid-hideable-column.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-hideable-column.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, DebugElement, Renderer2 } from '@angular/core';
+import { Component, DebugElement } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
@@ -29,7 +29,6 @@ const PROVIDERS_NEEDED = [
   Page,
   StateDebouncer,
   TableSizeService,
-  Renderer2,
   ColumnsService,
   DetailService,
 ];

--- a/projects/angular/src/data/datagrid/datagrid.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid.spec.ts
@@ -1092,6 +1092,7 @@ export default function (): void {
           // final state
           expect(selection.current.every(x => [1, 2, 3, 4, 5, 6, 7].includes(x))).toBeTrue();
         });
+
         it('can update ranges in a sequence, releasing Shift', function () {
           // first range
           checkboxes[1].click();
@@ -1110,6 +1111,7 @@ export default function (): void {
           // final state
           expect(selection.current.every(x => [1, 2, 3, 5, 6, 7].includes(x))).toBeTrue();
         });
+
         it('can deselect items inside a range', fakeAsync(function () {
           // define range
           selection.current.push(1, 2, 3, 4, 5, 6, 7);

--- a/projects/angular/src/data/datagrid/helpers.spec.ts
+++ b/projects/angular/src/data/datagrid/helpers.spec.ts
@@ -174,6 +174,7 @@ export function addHelpers(): void {
       return (this._context = new TestContext<D, C>(clarityDirective, testComponent));
     };
   });
+
   afterEach(function () {
     if (this._context) {
       this._context.fixture.destroy();

--- a/projects/angular/src/data/datagrid/providers/column-resizer.service.spec.ts
+++ b/projects/angular/src/data/datagrid/providers/column-resizer.service.spec.ts
@@ -12,7 +12,7 @@ import { DatagridRenderOrganizer } from '../render/render-organizer';
 import { ColumnResizerService } from './column-resizer.service';
 
 @Component({
-  providers: [ColumnResizerService, DomAdapter, DatagridRenderOrganizer], // Should be declared here in a component level, not in the TestBed because Renderer2 wouldn't be present
+  providers: [ColumnResizerService, DomAdapter, DatagridRenderOrganizer],
   template: `<div></div>`,
   styles: [':host { position: position; width: 200px; height: 400px;}'],
 })

--- a/projects/angular/src/data/datagrid/providers/selection.spec.ts
+++ b/projects/angular/src/data/datagrid/providers/selection.spec.ts
@@ -532,6 +532,7 @@ export default function (): void {
 
       describe('single selection', function () {
         let ngZone: NgZone;
+
         beforeEach(function () {
           selectionInstance.selectionType = SelectionType.Single;
           ngZone = TestBed.get(NgZone);

--- a/projects/angular/src/data/datagrid/render/header-renderer.spec.ts
+++ b/projects/angular/src/data/datagrid/render/header-renderer.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, DebugElement, Renderer2 } from '@angular/core';
+import { Component, DebugElement } from '@angular/core';
 import { By } from '@angular/platform-browser';
 import { BehaviorSubject } from 'rxjs';
 
@@ -82,7 +82,6 @@ export default function (): void {
         StateDebouncer,
         TableSizeService,
         DetailService,
-        Renderer2,
         ColumnsService,
       ]);
       domAdapter = context.getClarityProvider(DomAdapter) as MockDomAdapter;

--- a/projects/angular/src/data/datagrid/render/main-renderer.spec.ts
+++ b/projects/angular/src/data/datagrid/render/main-renderer.spec.ts
@@ -145,6 +145,7 @@ export default function (): void {
     describe('smart datagrid width', () => {
       let context: ComponentFixture<RenderWidthTest>;
       let containerWidth: number;
+
       beforeEach(() => {
         TestBed.configureTestingModule({
           imports: [BrowserAnimationsModule, ClrDatagridModule],

--- a/projects/angular/src/data/datagrid/wrapped-cell.spec.ts
+++ b/projects/angular/src/data/datagrid/wrapped-cell.spec.ts
@@ -30,12 +30,15 @@ export default function (): void {
       this.wrapper = this.fixture.componentInstance.wrapper;
       this.fixture.detectChanges();
     });
+
     it('should have a cellView', function (this: TestContext) {
       expect(this.wrapper.cellView).toBeDefined();
     });
+
     it('should have a templateRef to the portal', function (this: TestContext) {
       expect(this.wrapper.templateRef).toBeDefined();
     });
+
     it('projects content into the template', function (this: TestContext) {
       expect(this.wrapper.cellView.rootNodes[0].textContent.trim()).toBe('Hello World!');
     });

--- a/projects/angular/src/data/datagrid/wrapped-column.spec.ts
+++ b/projects/angular/src/data/datagrid/wrapped-column.spec.ts
@@ -30,12 +30,15 @@ export default function (): void {
       this.wrapper = this.fixture.componentInstance.wrapper;
       this.fixture.detectChanges();
     });
+
     it('should have a columnView', function (this: TestContext) {
       expect(this.wrapper.columnView).toBeDefined();
     });
+
     it('should have a templateRef to the portal', function (this: TestContext) {
       expect(this.wrapper.templateRef).toBeDefined();
     });
+
     it('projects content into the template', function (this: TestContext) {
       expect(this.wrapper.columnView.rootNodes[0].textContent.trim()).toBe('Hello World!');
     });

--- a/projects/angular/src/data/datagrid/wrapped-row.spec.ts
+++ b/projects/angular/src/data/datagrid/wrapped-row.spec.ts
@@ -30,12 +30,15 @@ export default function (): void {
       this.wrapper = this.fixture.componentInstance.wrapper;
       this.fixture.detectChanges();
     });
+
     it('should have a rowView', function (this: TestContext) {
       expect(this.wrapper.rowView).toBeDefined();
     });
+
     it('should have a templateRef to the portal', function (this: TestContext) {
       expect(this.wrapper.templateRef).toBeDefined();
     });
+
     it('should project content into the template', function (this: TestContext) {
       expect(this.wrapper.rowView.rootNodes[0].textContent.trim()).toBe('Hello World!');
     });

--- a/projects/angular/src/data/tree-view/tree.spec.ts
+++ b/projects/angular/src/data/tree-view/tree.spec.ts
@@ -55,6 +55,7 @@ class TreeTypeAhead {}
 
 export default function (): void {
   type Context = TestContext<ClrTree<void>, TestComponent>;
+
   describe('ClrTree Component', function () {
     spec(ClrTree, TestComponent, ClrTreeViewModule, { imports: [NoopAnimationsModule] });
 

--- a/projects/angular/src/deprecations.spec.ts
+++ b/projects/angular/src/deprecations.spec.ts
@@ -20,11 +20,13 @@ describe('Deprecations', () => {
       expect(ClrDatagridColumnToggleTitle).toBeTruthy();
       expect(ClrDatagridColumnToggleButton).toBeTruthy();
     });
+
     it('should deprecate but still support clrDgRowSelection', () => {
       const propTest = Object.getOwnPropertyDescriptor(ClrDatagrid.prototype, 'rowSelectionMode');
       expect(propTest.set).toBeDefined();
     });
   });
+
   describe('3.0', () => {
     it('should deprecate inline wizard inputs', () => {
       const propTest = Object.getOwnPropertyDescriptor(ClrWizard.prototype, 'stopModalAnimations');

--- a/projects/angular/src/emphasis/alert/alerts.spec.ts
+++ b/projects/angular/src/emphasis/alert/alerts.spec.ts
@@ -181,6 +181,7 @@ export default function () {
 
           expect(alertsContainer.classList.contains('alert-danger')).toBe(true);
         });
+
         it('sets info classname as expected', function () {
           const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
           const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
@@ -189,6 +190,7 @@ export default function () {
 
           expect(alertsContainer.classList.contains('alert-info')).toBe(true);
         });
+
         it('sets success classname as expected', function () {
           const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
           const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;
@@ -197,6 +199,7 @@ export default function () {
 
           expect(alertsContainer.classList.contains('alert-success')).toBe(true);
         });
+
         it('sets warning classname as expected', function () {
           const alertsContainer: Element = fixture.nativeElement.querySelector('.alerts');
           const myAlert: ClrAlert = fixture.componentInstance.alertsInstance.currentAlert;

--- a/projects/angular/src/forms/checkbox/checkbox-container.spec.ts
+++ b/projects/angular/src/forms/checkbox/checkbox-container.spec.ts
@@ -105,6 +105,7 @@ export default function (): void {
 
     describe('inline buttons', () => {
       let fixture, containerDE, containerEl;
+
       beforeEach(() => {
         TestBed.configureTestingModule({
           imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],

--- a/projects/angular/src/forms/checkbox/toggle-container.spec.ts
+++ b/projects/angular/src/forms/checkbox/toggle-container.spec.ts
@@ -97,6 +97,7 @@ export default function (): void {
 
     describe('inline buttons', () => {
       let fixture, containerDE, containerEl;
+
       beforeEach(() => {
         TestBed.configureTestingModule({
           imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],

--- a/projects/angular/src/forms/checkbox/toggle-wrapper.spec.ts
+++ b/projects/angular/src/forms/checkbox/toggle-wrapper.spec.ts
@@ -63,6 +63,7 @@ export default function (): void {
 
     describe('toggle class', () => {
       let fixture, containerDE, containerEl;
+
       beforeEach(() => {
         TestBed.configureTestingModule({
           imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],

--- a/projects/angular/src/forms/combobox/combobox-container.spec.ts
+++ b/projects/angular/src/forms/combobox/combobox-container.spec.ts
@@ -82,6 +82,7 @@ export default function (): void {
     describe('label offset', () => {
       let fixture, containerDE;
       let containerService: ComboboxContainerService;
+
       beforeEach(() => {
         TestBed.configureTestingModule({
           imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],

--- a/projects/angular/src/forms/combobox/filter-highlight.directive.spec.ts
+++ b/projects/angular/src/forms/combobox/filter-highlight.directive.spec.ts
@@ -25,6 +25,7 @@ export default function () {
   describe('Highlight directive', () => {
     let context: TestContext<ClrFilterHighlight<string>, TestComponent>;
     let optionService: OptionSelectionService<string>;
+
     beforeEach(function () {
       context = this.createOnly(ClrFilterHighlight, TestComponent, [OptionSelectionService]);
       optionService = context.getClarityProvider(OptionSelectionService) as OptionSelectionService<string>;

--- a/projects/angular/src/forms/combobox/option-items.directive.spec.ts
+++ b/projects/angular/src/forms/combobox/option-items.directive.spec.ts
@@ -173,6 +173,7 @@ export default function (): void {
         expect(replacedItem.style.color).toBe('red');
       });
     });
+
     describe('handles object arrays correctly', () => {
       beforeEach(function () {
         TestBed.configureTestingModule({

--- a/projects/angular/src/forms/combobox/option-items.directive.spec.ts
+++ b/projects/angular/src/forms/combobox/option-items.directive.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Renderer2, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
 import { ClrPopoverEventsService } from '../../utils/popover/providers/popover-events.service';
@@ -20,6 +20,7 @@ import { OptionSelectionService } from './providers/option-selection.service';
       <li *clrOptionItems="let n of numbers; trackBy: trackBy">{{ n }}</li>
     </ul>
   `,
+  providers: [ClrPopoverEventsService, ClrPopoverPositionService],
 })
 class FullTest {
   @ViewChild(ClrOptionItems) optionItems: ClrOptionItems<number>;
@@ -33,6 +34,7 @@ class FullTest {
       <li *clrOptionItems="let n of numbers; trackBy: trackBy">{{ n }}</li>
     </ul>
   `,
+  providers: [ClrPopoverEventsService, ClrPopoverPositionService],
 })
 class TrackByIndexTest {
   @ViewChild(ClrOptionItems) optionItems: ClrOptionItems<number>;
@@ -46,6 +48,7 @@ class TrackByIndexTest {
       <li *clrOptionItems="let n of numbers; field: 'a'">{{ n.a }}</li>
     </ul>
   `,
+  providers: [ClrPopoverEventsService, ClrPopoverPositionService],
 })
 class ObjectDataTest {
   @ViewChild(ClrOptionItems) optionItems: ClrOptionItems<number>;
@@ -53,13 +56,7 @@ class ObjectDataTest {
   trackBy = (index: number) => index;
 }
 
-const OPTION_ITEM_PROVIDERS = [
-  OptionSelectionService,
-  ClrPopoverToggleService,
-  ClrPopoverPositionService,
-  ClrPopoverEventsService,
-  Renderer2,
-];
+const OPTION_ITEM_PROVIDERS = [OptionSelectionService, ClrPopoverToggleService];
 
 export default function (): void {
   describe('ClrOptionItems directive', function () {

--- a/projects/angular/src/forms/combobox/providers/combobox-focus-handler.service.spec.ts
+++ b/projects/angular/src/forms/combobox/providers/combobox-focus-handler.service.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ElementRef, Renderer2, RendererFactory2, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { KeyCodes } from '../../../utils/enums/key-codes.enum';
@@ -44,15 +44,7 @@ export default function (): void {
     beforeEach(function (this: TestContext) {
       TestBed.configureTestingModule({
         declarations: [SimpleHost],
-        providers: [
-          {
-            provide: Renderer2,
-            useFactory: RendererFactory2,
-          },
-          ClrPopoverToggleService,
-          OptionSelectionService,
-          COMBOBOX_FOCUS_HANDLER_PROVIDER,
-        ],
+        providers: [ClrPopoverToggleService, OptionSelectionService, COMBOBOX_FOCUS_HANDLER_PROVIDER],
       });
       this.fixture = TestBed.createComponent(SimpleHost);
       this.testComponent = this.fixture.componentInstance;

--- a/projects/angular/src/forms/common/common.spec.ts
+++ b/projects/angular/src/forms/common/common.spec.ts
@@ -107,8 +107,11 @@ export default function (): void {
     }
 
     it('works without an explicit wrapper and without an id', assertMatching(NoWrapperNoId, false));
+
     it('works without an explicit wrapper and with an id', assertMatching(NoWrapperWithId, false, 'hello'));
+
     it('works with an explicit wrapper and without an id', assertMatching(WithWrapperNoId, true));
+
     it('works with an explicit wrapper and with an id', assertMatching(WithWrapperWithId, true, 'hello'));
   });
 }

--- a/projects/angular/src/forms/common/providers/control-class.service.spec.ts
+++ b/projects/angular/src/forms/common/providers/control-class.service.spec.ts
@@ -12,6 +12,7 @@ export default function (): void {
   describe('ControlClassService', function () {
     let controlClassService: ControlClassService;
     let layoutService: LayoutService;
+
     beforeEach(() => {
       layoutService = new LayoutService();
       controlClassService = new ControlClassService(layoutService);

--- a/projects/angular/src/forms/common/providers/layout.service.spec.ts
+++ b/projects/angular/src/forms/common/providers/layout.service.spec.ts
@@ -9,6 +9,7 @@ import { ClrFormLayout, LayoutService } from './layout.service';
 export default function (): void {
   describe('LayoutService', function () {
     let service;
+
     beforeEach(() => {
       service = new LayoutService();
     });

--- a/projects/angular/src/forms/datalist/datalist-input.spec.ts
+++ b/projects/angular/src/forms/datalist/datalist-input.spec.ts
@@ -76,6 +76,7 @@ export default function (): void {
 
     describe('set datalist type', () => {
       let fixture, containerDE, containerEl;
+
       beforeEach(() => {
         TestBed.configureTestingModule({
           imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],

--- a/projects/angular/src/forms/datalist/datalist.spec.ts
+++ b/projects/angular/src/forms/datalist/datalist.spec.ts
@@ -40,6 +40,7 @@ export default function (): void {
     spec(ClrDatalist, TestDatalistId, undefined, {
       providers: [DatalistIdService],
     });
+
     beforeEach(function () {
       datalistIdService = this.getClarityProvider(DatalistIdService);
     });

--- a/projects/angular/src/forms/datepicker/date-container.spec.ts
+++ b/projects/angular/src/forms/datepicker/date-container.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Renderer2 } from '@angular/core';
+import { Component } from '@angular/core';
 import { async, TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
@@ -32,21 +32,17 @@ import { LocaleHelperService } from './providers/locale-helper.service';
 import { ViewManagerService } from './providers/view-manager.service';
 
 const DATEPICKER_PROVIDERS: any[] = [
-  ClrPopoverEventsService,
-  ClrPopoverPositionService,
   ClrPopoverToggleService,
   DateNavigationService,
   ViewManagerService,
   LocaleHelperService,
   ControlClassService,
   IfControlStateService,
-  FocusService,
   LayoutService,
   NgControlService,
   DateIOService,
   ControlIdService,
   DateFormControlService,
-  Renderer2,
 ];
 
 export default function () {
@@ -233,6 +229,7 @@ export default function () {
       <clr-control-success>Valid</clr-control-success>
     </clr-date-container>
   `,
+  providers: [ClrPopoverEventsService, ClrPopoverPositionService, FocusService],
 })
 class TestComponent {
   model = '';

--- a/projects/angular/src/forms/datepicker/date-input.spec.ts
+++ b/projects/angular/src/forms/datepicker/date-input.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, DebugElement, Injectable, Renderer2, ViewChild } from '@angular/core';
+import { Component, DebugElement, Injectable, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormControl, FormGroup, FormsModule, NgControl, NgForm, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
@@ -58,13 +58,9 @@ export default function () {
       LayoutService,
       IfControlStateService,
       ClrPopoverToggleService,
-      ClrPopoverEventsService,
-      ClrPopoverPositionService,
-      FocusService,
       DatepickerFocusService,
       DateNavigationService,
       LocaleHelperService,
-      Renderer2,
       ViewManagerService,
       DateIOService,
       ControlIdService,
@@ -770,6 +766,7 @@ export default function () {
       (clrDateChange)="dateChanged($event)"
     />
   `,
+  providers: [ClrPopoverEventsService, ClrPopoverPositionService, FocusService],
 })
 class TestComponent {
   date: Date;
@@ -806,6 +803,7 @@ class TestComponentWithClrDate {
       <input id="dateControl" type="date" clrDate (clrDateChange)="dateChanged($event)" formControlName="date" />
     </form>
   `,
+  providers: [ClrPopoverEventsService, ClrPopoverPositionService, FocusService],
 })
 class TestComponentWithReactiveForms {
   dateInput = '01/01/2015';

--- a/projects/angular/src/forms/datepicker/providers/date-io.service.spec.ts
+++ b/projects/angular/src/forms/datepicker/providers/date-io.service.spec.ts
@@ -189,6 +189,7 @@ export default function () {
         expect(assertEqualDates(date, new Date(2016, 0, 3)));
       });
     });
+
     describe('TypeScript API', () => {
       beforeEach(() => {
         localeHelperService = new LocaleHelperService('en-US');

--- a/projects/angular/src/forms/password/password-container.spec.ts
+++ b/projects/angular/src/forms/password/password-container.spec.ts
@@ -73,6 +73,7 @@ export default function (): void {
 
     describe('password toggle', () => {
       let fixture, containerDE, containerEl;
+
       beforeEach(() => {
         TestBed.configureTestingModule({
           imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],
@@ -100,6 +101,7 @@ export default function (): void {
         fixture.detectChanges();
         expect(containerEl.querySelector('button')).toBeFalsy();
       });
+
       it('should provide screen-reader only text for toggle button', () => {
         const button: HTMLButtonElement = containerEl.querySelector('button');
         expect(button.textContent.trim()).toEqual('Show password');

--- a/projects/angular/src/forms/password/password.spec.ts
+++ b/projects/angular/src/forms/password/password.spec.ts
@@ -68,6 +68,7 @@ export default function (): void {
 
     describe('set password type', () => {
       let fixture, containerDE, containerEl;
+
       beforeEach(() => {
         TestBed.configureTestingModule({
           imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],

--- a/projects/angular/src/forms/radio/radio-container.spec.ts
+++ b/projects/angular/src/forms/radio/radio-container.spec.ts
@@ -92,6 +92,7 @@ export default function (): void {
 
     describe('inline buttons', () => {
       let fixture, containerDE, containerEl;
+
       beforeEach(() => {
         TestBed.configureTestingModule({
           imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],

--- a/projects/angular/src/forms/styles/containers.spec.ts
+++ b/projects/angular/src/forms/styles/containers.spec.ts
@@ -472,82 +472,126 @@ describe('Form layouts', () => {
 
     describe('checkbox', () => {
       it('control height', () => verifyHeight('#checkbox', base * 18));
+
       it('label height', () => verifyHeight('#checkbox .clr-control-label', base * 3));
+
       it('container height', () => verifyHeight('#checkbox .clr-control-container', base * 15));
+
       it('wrapper height', () => verifyHeight('#checkbox .clr-checkbox-wrapper', base * 4));
+
       it('checkbox height', () => verifyHeight('#checkbox .clr-checkbox', 16, false));
+
       it('checkbox label height', () => verifyHeight('#checkbox .clr-checkbox-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#checkbox .clr-subtext', base * 2));
     });
 
     describe('checkbox inline', () => {
       it('control height', () => verifyHeight('#checkbox-inline', base * 10));
+
       it('label height', () => verifyHeight('#checkbox-inline .clr-control-label', base * 3));
+
       it('container height', () => verifyHeight('#checkbox-inline .clr-control-container', base * 7));
+
       it('wrapper height', () => verifyHeight('#checkbox-inline .clr-checkbox-wrapper', base * 4));
+
       it('checkbox height', () => verifyHeight('#checkbox-inline .clr-checkbox', 16, false));
+
       it('checkbox label height', () =>
         verifyHeight('#checkbox-inline .clr-checkbox-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#checkbox-inline .clr-subtext', base * 2));
     });
 
     describe('radio', () => {
       it('control height', () => verifyHeight('#radio', base * 18));
+
       it('label height', () => verifyHeight('#radio .clr-control-label', base * 3));
+
       it('container height', () => verifyHeight('#radio .clr-control-container', base * 15));
+
       it('wrapper height', () => verifyHeight('#radio .clr-radio-wrapper', base * 4));
+
       it('radio height', () => verifyHeight('#radio .clr-radio', 16, false));
+
       it('radio label height', () => verifyHeight('#radio .clr-radio-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#radio .clr-subtext', base * 2));
     });
 
     describe('radio inline', () => {
       it('control height', () => verifyHeight('#radio-inline', base * 10));
+
       it('label height', () => verifyHeight('#radio-inline .clr-control-label', base * 3));
+
       it('container height', () => verifyHeight('#radio-inline .clr-control-container', base * 7));
+
       it('wrapper height', () => verifyHeight('#radio-inline .clr-radio-wrapper', base * 4));
+
       it('radio height', () => verifyHeight('#radio-inline .clr-radio', 16, false));
+
       it('radio label height', () => verifyHeight('#radio-inline .clr-radio-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#radio-inline .clr-subtext', base * 2));
     });
 
     describe('file', () => {
       it('control height', () => verifyHeight('#file', base * 12));
+
       it('label height', () => verifyHeight('#file .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#file .clr-file-wrapper', base * 4));
+
       it('file height', () => verifyHeight('#file .clr-file', 0));
+
       it('file label height', () => verifyHeight('#file .clr-file-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#file .clr-subtext', base * 2));
     });
 
     describe('file plain', () => {
       let fileInput;
+
       beforeEach(() => {
         fileInput = height('#file-plain input');
       });
+
       it('control height', () => verifyHeight('#file-plain', fileInput + base * 8, false));
+
       it('label height', () => verifyHeight('#file-plain .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#file-plain .clr-file-wrapper', fileInput, false));
+
       it('subtext height', () => verifyHeight('#file-plain .clr-subtext', base * 2));
     });
 
     describe('textarea', () => {
       let textarea;
+
       beforeEach(() => {
         textarea = height('#textarea textarea');
       });
+
       it('control height', () => verifyHeight('#textarea', textarea + base * 7, false));
+
       it('label height', () => verifyHeight('#textarea .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#textarea .clr-textarea-wrapper', textarea, false));
+
       it('textarea height', () => verifyHeight('#textarea .clr-textarea', textarea, false));
+
       it('subtext height', () => verifyHeight('#textarea .clr-subtext', base * 2));
     });
 
     describe('select', () => {
       it('control height', () => verifyHeight('#select', base * 10));
+
       it('label height', () => verifyHeight('#select .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#select .clr-select-wrapper', base * 4));
+
       it('select height', () => verifyHeight('#select select', base * 4));
+
       it('subtext height', () => verifyHeight('#select .clr-subtext', base * 2));
     });
 
@@ -556,13 +600,19 @@ describe('Form layouts', () => {
     // @TODO See if it is possible or worth fixing vertical rhythm
     describe('multiselect', () => {
       let multiselect;
+
       beforeEach(() => {
         multiselect = height('#multiselect select');
       });
+
       it('control height', () => verifyHeight('#multiselect', multiselect + base * 6, false));
+
       it('label height', () => verifyHeight('#multiselect .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#multiselect .clr-multiselect-wrapper', multiselect, false));
+
       it('select height', () => verifyHeight('#multiselect select', multiselect, false));
+
       it('subtext height', () => verifyHeight('#multiselect .clr-subtext', base * 2));
     });
   }
@@ -570,102 +620,156 @@ describe('Form layouts', () => {
   function horizontalTests() {
     describe('text', () => {
       it('control height', () => verifyHeight('#text', base * 7));
+
       it('label height', () => verifyHeight('#text .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#text .clr-input-wrapper', base * 4));
+
       it('input height', () => verifyHeight('#text .clr-input', base * 4));
+
       it('subtext height', () => verifyHeight('#text .clr-subtext', base * 2));
     });
 
     describe('checkbox', () => {
       it('control height', () => verifyHeight('#checkbox', base * 15));
+
       it('label height', () => verifyHeight('#checkbox .clr-control-label', base * 3));
+
       it('container height', () => verifyHeight('#checkbox .clr-control-container', base * 15));
+
       it('wrapper height', () => verifyHeight('#checkbox .clr-checkbox-wrapper', base * 4));
+
       it('checkbox height', () => verifyHeight('#checkbox .clr-checkbox', 16, false));
+
       it('checkbox label height', () => verifyHeight('#checkbox .clr-checkbox-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#checkbox .clr-subtext-wrapper', base * 3));
     });
 
     describe('checkbox inline', () => {
       it('control height', () => verifyHeight('#checkbox-inline', base * 7));
+
       it('label height', () => verifyHeight('#checkbox-inline .clr-control-label', base * 3));
+
       it('container height', () => verifyHeight('#checkbox-inline .clr-control-container', base * 7));
+
       it('wrapper height', () => verifyHeight('#checkbox-inline .clr-checkbox-wrapper', base * 4));
+
       it('checkbox height', () => verifyHeight('#checkbox-inline .clr-checkbox', 16, false));
+
       it('checkbox label height', () =>
         verifyHeight('#checkbox-inline .clr-checkbox-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#checkbox-inline .clr-subtext-wrapper', base * 3));
     });
 
     describe('radio', () => {
       it('control height', () => verifyHeight('#radio', base * 15));
+
       it('label height', () => verifyHeight('#radio .clr-control-label', base * 3));
+
       it('container height', () => verifyHeight('#radio .clr-control-container', base * 15));
+
       it('wrapper height', () => verifyHeight('#radio .clr-radio-wrapper', base * 4));
+
       it('radio height', () => verifyHeight('#radio .clr-radio', 16, false));
+
       it('radio label height', () => verifyHeight('#radio .clr-radio-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#radio .clr-subtext-wrapper', base * 3));
     });
 
     describe('radio inline', () => {
       it('control height', () => verifyHeight('#radio-inline', base * 7));
+
       it('label height', () => verifyHeight('#radio-inline .clr-control-label', base * 3));
+
       it('container height', () => verifyHeight('#radio-inline .clr-control-container', base * 7));
+
       it('wrapper height', () => verifyHeight('#radio-inline .clr-radio-wrapper', base * 4));
+
       it('radio height', () => verifyHeight('#radio-inline .clr-radio', 16, false));
+
       it('radio label height', () => verifyHeight('#radio-inline .clr-radio-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#radio-inline .clr-subtext-wrapper', base * 3));
     });
 
     describe('file', () => {
       it('control height', () => verifyHeight('#file', base * 9));
+
       it('label height', () => verifyHeight('#file .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#file .clr-file-wrapper', base * 4));
+
       it('file height', () => verifyHeight('#file .clr-file', 0));
+
       it('file label height', () => verifyHeight('#file .clr-file-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#file .clr-subtext', base * 2));
     });
 
     describe('file plain', () => {
       let fileInput;
+
       beforeEach(() => {
         fileInput = height('#file-plain input');
       });
+
       it('control height', () => verifyHeight('#file-plain', fileInput + base * 5, false));
+
       it('label height', () => verifyHeight('#file-plain .clr-control-label', base * 3, false));
+
       it('wrapper height', () => verifyHeight('#file-plain .clr-file-wrapper', fileInput, false));
+
       it('subtext height', () => verifyHeight('#file-plain .clr-subtext', base * 2));
     });
 
     describe('textarea', () => {
       let textarea;
+
       beforeEach(() => {
         textarea = height('#textarea textarea');
       });
+
       it('control height', () => verifyHeight('#textarea', textarea + base * 4, false));
+
       it('label height', () => verifyHeight('#textarea .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#textarea .clr-textarea-wrapper', textarea, false));
+
       it('textarea height', () => verifyHeight('#textarea .clr-textarea', textarea, false));
+
       it('subtext height', () => verifyHeight('#textarea .clr-subtext', base * 2));
     });
 
     describe('select', () => {
       it('control height', () => verifyHeight('#select', base * 7));
+
       it('label height', () => verifyHeight('#select .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#select .clr-select-wrapper', base * 4));
+
       it('select height', () => verifyHeight('#select select', base * 4));
+
       it('subtext height', () => verifyHeight('#select .clr-subtext', base * 2));
     });
 
     describe('multiselect', () => {
       let multiselect;
+
       beforeEach(() => {
         multiselect = height('#multiselect select');
       });
+
       it('control height', () => verifyHeight('#multiselect', multiselect + base * 3, false));
+
       it('label height', () => verifyHeight('#multiselect .clr-control-label', base * 3, false));
+
       it('wrapper height', () => verifyHeight('#multiselect .clr-multiselect-wrapper', multiselect, false));
+
       it('select height', () => verifyHeight('#multiselect select', multiselect, false));
+
       it('subtext height', () => verifyHeight('#multiselect .clr-subtext', base * 2));
     });
   }
@@ -675,118 +779,178 @@ describe('Form layouts', () => {
     // subtext wraps it would be taller.
     describe('text', () => {
       it('control height', () => verifyHeight('#text', base * 4));
+
       it('label height', () => verifyHeight('#text .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#text .clr-input-wrapper', base * 4));
+
       it('input height', () => verifyHeight('#text .clr-input', base * 4));
+
       it('subtext height', () => verifyHeight('#text .clr-subtext', base * 3));
     });
 
     describe('checkbox', () => {
       it('control height', () => verifyHeight('#checkbox', base * 4));
+
       it('label height', () => verifyHeight('#checkbox .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#checkbox .clr-checkbox-wrapper', base * 4));
+
       it('checkbox height', () => verifyHeight('#checkbox .clr-checkbox', 16, false));
+
       it('checkbox label height', () => verifyHeight('#checkbox .clr-checkbox-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#checkbox .clr-subtext-wrapper', base * 4));
     });
 
     describe('checkbox inline', () => {
       it('control height', () => verifyHeight('#checkbox-inline', base * 4));
+
       it('label height', () => verifyHeight('#checkbox-inline .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#checkbox-inline .clr-checkbox-wrapper', base * 4));
+
       it('checkbox height', () => verifyHeight('#checkbox-inline .clr-checkbox', 16, false));
+
       it('checkbox label height', () =>
         verifyHeight('#checkbox-inline .clr-checkbox-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#checkbox-inline .clr-subtext-wrapper', base * 4));
     });
 
     describe('toggle', () => {
       it('control height', () => verifyHeight('#toggle', base * 4));
+
       it('label height', () => verifyHeight('#toggle .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#toggle .clr-toggle-wrapper', base * 4));
+
       it('checkbox height', () => verifyHeight('#toggle .clr-checkbox', 16, false));
+
       it('checkbox label height', () => verifyHeight('#toggle .clr-toggle-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#toggle .clr-subtext-wrapper', base * 4));
     });
 
     describe('toggle inline', () => {
       it('control height', () => verifyHeight('#toggle-inline', base * 4));
+
       it('label height', () => verifyHeight('#toggle-inline .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#toggle-inline .clr-toggle-wrapper', base * 4));
+
       it('checkbox height', () => verifyHeight('#toggle-inline .clr-checkbox', 16, false));
+
       it('checkbox label height', () =>
         verifyHeight('#toggle-inline .clr-toggle-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#toggle-inline .clr-subtext-wrapper', base * 4));
     });
 
     describe('radio', () => {
       it('control height', () => verifyHeight('#radio', base * 4));
+
       it('label height', () => verifyHeight('#radio .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#radio .clr-radio-wrapper', base * 4));
+
       it('radio height', () => verifyHeight('#radio .clr-radio', 16, false));
+
       it('radio label height', () => verifyHeight('#radio .clr-radio-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#radio .clr-subtext-wrapper', base * 4));
     });
 
     describe('radio inline', () => {
       it('control height', () => verifyHeight('#radio-inline', base * 4));
+
       it('label height', () => verifyHeight('#radio-inline .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#radio-inline .clr-radio-wrapper', base * 4));
+
       it('radio height', () => verifyHeight('#radio-inline .clr-radio', 16, false));
+
       it('radio label height', () => verifyHeight('#radio-inline .clr-radio-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#radio-inline .clr-subtext-wrapper', base * 4));
     });
 
     describe('file', () => {
       it('control height', () => verifyHeight('#file', base * 4));
+
       it('label height', () => verifyHeight('#file .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#file .clr-file-wrapper', base * 4));
+
       it('file height', () => verifyHeight('#file .clr-file', 0));
+
       it('file label height', () => verifyHeight('#file .clr-file-wrapper .clr-control-label', base * 4));
+
       it('subtext height', () => verifyHeight('#file .clr-subtext', base * 4));
     });
 
     describe('file plain', () => {
       let fileInput;
+
       beforeEach(() => {
         // the default file input is out of our control, so need to get its size for calculations
         fileInput = height('#file-plain input');
       });
+
       it('control height', () => verifyHeight('#file-plain', fileInput, false));
+
       it('label height', () => verifyHeight('#file-plain .clr-control-label', base * 3, false));
+
       it('wrapper height', () => verifyHeight('#file-plain .clr-file-wrapper', fileInput, false));
+
       it('subtext height', () => verifyHeight('#file-plain .clr-subtext', fileInput, false));
     });
 
     describe('textarea', () => {
       let textarea;
+
       beforeEach(() => {
         textarea = height('#textarea textarea');
       });
+
       it('control height', () => verifyHeight('#textarea', textarea, false));
+
       it('label height', () => verifyHeight('#textarea .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#textarea .clr-textarea-wrapper', textarea, false));
+
       it('textarea height', () => verifyHeight('#textarea .clr-textarea', textarea, false));
+
       it('subtext height', () => verifyHeight('#textarea .clr-subtext', textarea - base, false));
     });
 
     describe('select', () => {
       it('control height', () => verifyHeight('#select', base * 4));
+
       it('label height', () => verifyHeight('#select .clr-control-label', base * 3));
+
       it('wrapper height', () => verifyHeight('#select .clr-select-wrapper', base * 4));
+
       it('select height', () => verifyHeight('#select select', base * 4));
+
       it('subtext height', () => verifyHeight('#select .clr-subtext', base * 3));
     });
 
     describe('multiselect', () => {
       let multiselect;
+
       beforeEach(() => {
         multiselect = height('#multiselect select');
       });
+
       it('control height', () => verifyHeight('#multiselect', multiselect, false));
+
       it('label height', () => verifyHeight('#multiselect .clr-control-label', base * 3, false));
+
       it('wrapper height', () => verifyHeight('#multiselect .clr-multiselect-wrapper', multiselect, false));
+
       it('select height', () => verifyHeight('#multiselect select', multiselect, false));
+
       it('subtext height', () => verifyHeight('#multiselect .clr-subtext', multiselect - base, false));
     });
   }

--- a/projects/angular/src/forms/tests/container.spec.ts
+++ b/projects/angular/src/forms/tests/container.spec.ts
@@ -20,6 +20,7 @@ import { DatalistIdService } from '../datalist/providers/datalist-id.service';
 export function ContainerNoLabelSpec(testContainer, testControl, testComponent): void {
   describe('no label', () => {
     let fixture, containerDE, containerEl, layoutService, container;
+
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],

--- a/projects/angular/src/forms/tests/wrapper.spec.ts
+++ b/projects/angular/src/forms/tests/wrapper.spec.ts
@@ -17,6 +17,7 @@ import { NgControlService } from '../common/providers/ng-control.service';
 export function WrapperNoLabelSpec(testContainer, testControl, testComponent): void {
   describe('no label', () => {
     let fixture, containerDE, containerEl;
+
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],
@@ -40,6 +41,7 @@ export function WrapperNoLabelSpec(testContainer, testControl, testComponent): v
 export function WrapperFullSpec(testContainer, testControl, testComponent, wrapperClass): void {
   describe('full example', () => {
     let fixture, containerDE, containerEl;
+
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],
@@ -78,6 +80,7 @@ export function WrapperFullSpec(testContainer, testControl, testComponent, wrapp
 export function WrapperContainerSpec(testContainer, testWrapper, testControl, testComponent, wrapperClass): void {
   describe('wrapper in container', () => {
     let fixture, wrapper, wrapperEl;
+
     beforeEach(() => {
       TestBed.configureTestingModule({
         imports: [ClrIconModule, ClrCommonFormsModule, FormsModule],

--- a/projects/angular/src/layout/nav/nav-level.spec.ts
+++ b/projects/angular/src/layout/nav/nav-level.spec.ts
@@ -162,16 +162,19 @@ describe('NavLevelDirective', function () {
       it('should be closed by default', function () {
         expect(this.clarityDirective.isOpen).toBe(false);
       });
+
       it('should call hideNavigation()', function () {
         const spy = spyOn(this.clarityDirective, 'hideNavigation');
         this.clarityDirective.close();
         expect(spy).toHaveBeenCalled();
       });
+
       it('should call removeFocusTrap()', function () {
         const spy = spyOn(this.clarityDirective, 'removeFocusTrap');
         this.clarityDirective.close();
         expect(spy).toHaveBeenCalled();
       });
+
       it('should call hideCloseButton()', function () {
         const spy = spyOn(this.clarityDirective, 'hideCloseButton');
         this.clarityDirective.close();

--- a/projects/angular/src/popover/tooltip/tooltip.spec.ts
+++ b/projects/angular/src/popover/tooltip/tooltip.spec.ts
@@ -30,6 +30,7 @@ interface TooltipContext extends TestContext<ClrTooltip, SimpleTest> {
 export default function (): void {
   describe('Tooltip component', function () {
     spec(ClrTooltip, SimpleTest, ClrTooltipModule, { providers: [TooltipIdService] });
+
     beforeEach(function (this: TooltipContext) {
       this.tooltipIdService = this.getClarityProvider(TooltipIdService);
     });

--- a/projects/angular/src/utils/drag-and-drop/all.spec.ts
+++ b/projects/angular/src/utils/drag-and-drop/all.spec.ts
@@ -27,17 +27,20 @@ describe('Drag And Drop', function () {
     ClrDraggableSnapshotSpecs();
     ClrGlobalDragModeSpecs();
   });
+
   describe('Components And Directives', function () {
     ClrIfDraggedSpecs();
     ClrDragHandleSpecs();
     ClrDraggableGhostSpecs();
     ClrDragAndDropIntegratedSpecs();
+
     describe('ClrDraggable', function () {
       ClrDraggableSpecs();
       ClrDraggableWithCustomGhostSpecs();
       ClrDraggableWithDragHandleSpecs();
       ClrDraggableWithGhostAndHandleSpecs();
     });
+
     describe('ClrDroppable', function () {
       ClrDroppableSpecs();
     });

--- a/projects/angular/src/utils/drag-and-drop/drag-handle.spec.ts
+++ b/projects/angular/src/utils/drag-and-drop/drag-handle.spec.ts
@@ -23,6 +23,7 @@ export default function (): void {
         }).toThrowError('The clrDragHandle directive can only be used inside of a clrDraggable directive.');
       });
     });
+
     describe('With ClrDragHandleRegistrar', function () {
       beforeEach(function () {
         TestBed.configureTestingModule({

--- a/projects/angular/src/utils/drag-and-drop/if-dragged.spec.ts
+++ b/projects/angular/src/utils/drag-and-drop/if-dragged.spec.ts
@@ -22,6 +22,7 @@ export default function (): void {
         }).toThrowError('The *clrIfDragged directive can only be used inside of a clrDraggable directive.');
       });
     });
+
     describe('With ClrDragEventListener', function () {
       beforeEach(function () {
         TestBed.configureTestingModule({

--- a/projects/angular/src/utils/drag-and-drop/providers/drag-event-listener.service.spec.ts
+++ b/projects/angular/src/utils/drag-and-drop/providers/drag-event-listener.service.spec.ts
@@ -288,7 +288,7 @@ export default function (): void {
 }
 
 @Component({
-  providers: [DragEventListenerService], // Should be declared here in a component level, not in the TestBed because Renderer2 wouldn't be present
+  providers: [DragEventListenerService],
   template: `<button #draggableButton></button>`,
 })
 class TestComponent implements OnInit, OnDestroy {

--- a/projects/angular/src/utils/drag-and-drop/providers/drag-handle-registrar.service.spec.ts
+++ b/projects/angular/src/utils/drag-and-drop/providers/drag-handle-registrar.service.spec.ts
@@ -112,7 +112,7 @@ export default function (): void {
 }
 
 @Component({
-  providers: [MOCK_DRAG_EVENT_LISTENER_PROVIDER, DragHandleRegistrarService], // Should be declared here in a component level, not in the TestBed because Renderer2 wouldn't be present
+  providers: [MOCK_DRAG_EVENT_LISTENER_PROVIDER, DragHandleRegistrarService],
   template: '<div>Test</div>',
 })
 class DragHandleTestComponent {}

--- a/projects/angular/src/utils/focus/focus.service.spec.ts
+++ b/projects/angular/src/utils/focus/focus.service.spec.ts
@@ -51,7 +51,6 @@ export default function (): void {
 
     describe('API', function () {
       beforeEach(function (this: TestContext) {
-        // Because the service uses Angular's Renderer2, we need to use TestBed for this spec.
         TestBed.configureTestingModule({ declarations: [SimpleHost] });
         const fixture = TestBed.createComponent(SimpleHost);
         this.focusService = fixture.debugElement.injector.get(FocusService, null);

--- a/projects/angular/src/utils/focus/key-focus/key-focus.spec.ts
+++ b/projects/angular/src/utils/focus/key-focus/key-focus.spec.ts
@@ -132,6 +132,7 @@ describe('KeyFocus directive', () => {
       keyPress(KeyCodes.ArrowUp);
       expect(clarityDirective.current).toBe(0);
     });
+
     it('current value updates, when elements are being removed', () => {
       openMenu();
       expect(clarityDirective.current).toBe(0);
@@ -140,6 +141,7 @@ describe('KeyFocus directive', () => {
       component.showLast = false;
       fixture.detectChanges();
     });
+
     it('checks if keyboard event comes focused current', () => {
       openMenu();
       expect(clarityDirective.current).toBe(0);
@@ -309,6 +311,7 @@ describe('KeyFocus directive', () => {
       fixture.detectChanges();
       expect(clarityDirective.focusableItems.length).toBe(3);
     });
+
     it('focus updates, when elements are being removed', () => {
       domComponent.buttons = Array.from(fixture.nativeElement.querySelectorAll('button'));
       fixture.detectChanges();

--- a/projects/angular/src/utils/focus/key-focus/roving-tabindex.spec.ts
+++ b/projects/angular/src/utils/focus/key-focus/roving-tabindex.spec.ts
@@ -145,6 +145,7 @@ describe('RovingTabindex directive', () => {
       keyPress(KeyCodes.ArrowUp);
       expect(clarityDirective.current).toBe(0);
     });
+
     it('current value updates, when elements are being removed', () => {
       openMenu();
       expect(clarityDirective.current).toBe(0);
@@ -153,6 +154,7 @@ describe('RovingTabindex directive', () => {
       component.showLast = false;
       fixture.detectChanges();
     });
+
     it('checks if keyboard event comes focused current', () => {
       openMenu();
       expect(clarityDirective.current).toBe(0);
@@ -356,6 +358,7 @@ describe('RovingTabindex directive', () => {
       fixture.detectChanges();
       expect(clarityDirective.focusableItems.length).toBe(3);
     });
+
     it('focus updates, when elements are being removed', () => {
       domComponent.buttons = Array.from(fixture.nativeElement.querySelectorAll('button'));
       fixture.detectChanges();

--- a/projects/angular/src/utils/popover/all.spec.ts
+++ b/projects/angular/src/utils/popover/all.spec.ts
@@ -19,11 +19,13 @@ describe('ClrPopover', () => {
     ClrAlignmentSpec();
     ClrViewportValidationSpec();
   });
+
   describe('Service', () => {
     EventServiceSpec();
     ToggleServiceSpec();
     PositionServiceSpec();
   });
+
   describe('Directive', () => {
     ClrPopoverAnchorSpec();
     ClrPopoverOpenCloseButtonSpec();

--- a/projects/angular/src/utils/popover/popover-anchor.spec.ts
+++ b/projects/angular/src/utils/popover/popover-anchor.spec.ts
@@ -26,6 +26,7 @@ export default function (): void {
     type Context = TestContext<ClrPopoverAnchor, TestHost> & {
       eventService: ClrPopoverEventsService;
     };
+
     describe('Template API', () => {
       spec(ClrPopoverAnchor, TestHost, undefined, { providers: [ClrPopoverEventsService] });
 
@@ -38,8 +39,10 @@ export default function (): void {
         expect(this.eventService.anchorButtonRef).toEqual(this.hostComponent.anchor);
       });
     });
+
     describe('View Basics', function (this: Context) {
       spec(ClrPopoverAnchor, TestHost, undefined, { providers: [ClrPopoverEventsService] });
+
       it('adds the clr-anchor classname', function (this: Context) {
         expect(this.clarityElement.classList).toContain('clr-anchor');
       });

--- a/projects/angular/src/utils/popover/popover-anchor.spec.ts
+++ b/projects/angular/src/utils/popover/popover-anchor.spec.ts
@@ -28,7 +28,7 @@ export default function (): void {
     };
 
     describe('Template API', () => {
-      spec(ClrPopoverAnchor, TestHost, undefined, { providers: [ClrPopoverEventsService] });
+      spec(ClrPopoverAnchor, TestHost, undefined);
 
       beforeEach(function (this: Context) {
         this.eventService = this.getClarityProvider(ClrPopoverEventsService);
@@ -41,7 +41,7 @@ export default function (): void {
     });
 
     describe('View Basics', function (this: Context) {
-      spec(ClrPopoverAnchor, TestHost, undefined, { providers: [ClrPopoverEventsService] });
+      spec(ClrPopoverAnchor, TestHost, undefined);
 
       it('adds the clr-anchor classname', function (this: Context) {
         expect(this.clarityElement.classList).toContain('clr-anchor');

--- a/projects/angular/src/utils/popover/popover-close-button.spec.ts
+++ b/projects/angular/src/utils/popover/popover-close-button.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ElementRef, Renderer2, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 
 import { spec, TestContext } from '../testing/helpers.spec';
 import { ClrPopoverCloseButton } from './popover-close-button';
@@ -19,7 +19,7 @@ import { ClrPopoverToggleService } from './providers/popover-toggle.service';
     <button #closeButton clrPopoverCloseButton (clrPopoverOnCloseChange)="handleClose()">Smart Close Button</button>
     <button #toggleButton clrPopoverAnchor>Toggle Button</button>
   `,
-  providers: [ClrPopoverToggleService],
+  providers: [ClrPopoverToggleService, ClrPopoverEventsService],
 })
 class TestHost {
   @ViewChild('closeButton', { read: ElementRef, static: true })
@@ -42,7 +42,7 @@ export default function (): void {
 
     describe('TypeScript API', function (this: Context) {
       spec(ClrPopoverCloseButton, TestHost, ClrPopoverModuleNext, {
-        providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],
+        providers: [ClrPopoverToggleService, ClrPopoverPositionService],
       });
 
       beforeEach(function (this: Context) {
@@ -66,7 +66,7 @@ export default function (): void {
 
     describe('Template API', () => {
       spec(ClrPopoverCloseButton, TestHost, ClrPopoverModuleNext, {
-        providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],
+        providers: [ClrPopoverToggleService, ClrPopoverPositionService],
       });
 
       beforeEach(function (this: Context) {
@@ -97,7 +97,7 @@ export default function (): void {
 
     describe('View Basics', function (this: Context) {
       spec(ClrPopoverCloseButton, TestHost, undefined, {
-        providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],
+        providers: [ClrPopoverToggleService, ClrPopoverPositionService],
       });
 
       it('adds the clr-smart-close-button classname to the host', function (this: Context) {

--- a/projects/angular/src/utils/popover/popover-close-button.spec.ts
+++ b/projects/angular/src/utils/popover/popover-close-button.spec.ts
@@ -10,7 +10,6 @@ import { spec, TestContext } from '../testing/helpers.spec';
 import { ClrPopoverCloseButton } from './popover-close-button';
 import { ClrPopoverModuleNext } from './popover.module';
 import { ClrPopoverEventsService } from './providers/popover-events.service';
-import { ClrPopoverPositionService } from './providers/popover-position.service';
 import { ClrPopoverToggleService } from './providers/popover-toggle.service';
 
 @Component({
@@ -42,7 +41,7 @@ export default function (): void {
 
     describe('TypeScript API', function (this: Context) {
       spec(ClrPopoverCloseButton, TestHost, ClrPopoverModuleNext, {
-        providers: [ClrPopoverToggleService, ClrPopoverPositionService],
+        providers: [ClrPopoverToggleService],
       });
 
       beforeEach(function (this: Context) {
@@ -66,7 +65,7 @@ export default function (): void {
 
     describe('Template API', () => {
       spec(ClrPopoverCloseButton, TestHost, ClrPopoverModuleNext, {
-        providers: [ClrPopoverToggleService, ClrPopoverPositionService],
+        providers: [ClrPopoverToggleService],
       });
 
       beforeEach(function (this: Context) {
@@ -97,7 +96,7 @@ export default function (): void {
 
     describe('View Basics', function (this: Context) {
       spec(ClrPopoverCloseButton, TestHost, undefined, {
-        providers: [ClrPopoverToggleService, ClrPopoverPositionService],
+        providers: [ClrPopoverToggleService],
       });
 
       it('adds the clr-smart-close-button classname to the host', function (this: Context) {

--- a/projects/angular/src/utils/popover/popover-close-button.spec.ts
+++ b/projects/angular/src/utils/popover/popover-close-button.spec.ts
@@ -39,21 +39,26 @@ export default function (): void {
       toggleService: ClrPopoverToggleService;
       eventService: ClrPopoverEventsService;
     };
+
     describe('TypeScript API', function (this: Context) {
       spec(ClrPopoverCloseButton, TestHost, ClrPopoverModuleNext, {
         providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],
       });
+
       beforeEach(function (this: Context) {
         this.toggleService = this.getClarityProvider(ClrPopoverToggleService);
         this.eventService = this.getClarityProvider(ClrPopoverEventsService);
         this.detectChanges();
       });
+
       it('declares a Popover ToggleService', function (this: Context) {
         expect(this.toggleService).toBeDefined();
       });
+
       it('declares a Popover EventService', function (this: Context) {
         expect(this.eventService).toBeDefined();
       });
+
       it('sets the close button ref in the events service', function (this: Context) {
         expect(this.hostComponent.closeButton).toEqual(this.eventService.closeButtonRef);
       });
@@ -63,11 +68,13 @@ export default function (): void {
       spec(ClrPopoverCloseButton, TestHost, ClrPopoverModuleNext, {
         providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],
       });
+
       beforeEach(function (this: Context) {
         this.toggleService = this.getClarityProvider(ClrPopoverToggleService);
         this.eventService = this.getClarityProvider(ClrPopoverEventsService);
         this.detectChanges();
       });
+
       it('emits a close change event when popover is closed', function (this: Context) {
         this.toggleService.open = true;
         this.detectChanges();
@@ -77,6 +84,7 @@ export default function (): void {
         this.detectChanges();
         expect(this.hostComponent.openState).toBe(this.toggleService.open);
       });
+
       it('focuses on the toggle/anchor element when clicked', function (this: Context) {
         const clickSpy = spyOn(this.toggleService, 'toggleWithEvent');
         const closeBtn: HTMLButtonElement = this.hostElement.querySelector('.clr-smart-close-button');
@@ -86,6 +94,7 @@ export default function (): void {
         expect(focusSpy.calls.count()).toEqual(1);
       });
     });
+
     describe('View Basics', function (this: Context) {
       spec(ClrPopoverCloseButton, TestHost, undefined, {
         providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],

--- a/projects/angular/src/utils/popover/popover-content.spec.ts
+++ b/projects/angular/src/utils/popover/popover-content.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Renderer2, ViewChild } from '@angular/core';
+import { Component, ViewChild } from '@angular/core';
 import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 
 import { TestContext } from '../testing/helpers.spec';
@@ -72,7 +72,6 @@ export default function (): void {
       TestBed.configureTestingModule({
         imports: [ClrPopoverModuleNext],
         declarations: [SimpleContent],
-        providers: [Renderer2],
       });
       this.fixture = TestBed.createComponent(SimpleContent);
       this.fixture.detectChanges();

--- a/projects/angular/src/utils/popover/popover-content.spec.ts
+++ b/projects/angular/src/utils/popover/popover-content.spec.ts
@@ -62,6 +62,7 @@ export default function (): void {
       positionService: ClrPopoverPositionService;
       toggleService: ClrPopoverToggleService;
     };
+
     beforeEach(function (this: Context) {
       /*
        * The ClrPopoverContent element is a template and not rendered in the DOM,
@@ -86,9 +87,11 @@ export default function (): void {
       it('declares a Popover EventService', function (this: Context) {
         expect(this.eventService).toBeDefined();
       });
+
       it('declares a Popover PositionService', function (this: Context) {
         expect(this.positionService).toBeDefined();
       });
+
       it('declares a Popover ToggleService', function (this: Context) {
         expect(this.toggleService).toBeDefined();
       });

--- a/projects/angular/src/utils/popover/popover-open-close-button.spec.ts
+++ b/projects/angular/src/utils/popover/popover-open-close-button.spec.ts
@@ -37,17 +37,21 @@ export default function (): void {
     type Context = TestContext<ClrPopoverOpenCloseButton, TestHost> & {
       toggleService: ClrPopoverToggleService;
     };
+
     describe('TypeScript API', function (this: Context) {
       spec(ClrPopoverOpenCloseButton, TestHost, undefined, {
         providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],
       });
+
       beforeEach(function (this: Context) {
         this.toggleService = this.getClarityProvider(ClrPopoverToggleService);
         this.detectChanges();
       });
+
       it('declares a ClrPopoverToggleService', function (this: Context) {
         expect(this.toggleService).toBeDefined();
       });
+
       it('responds to openChange events from the toggleService', function (this: Context) {
         let changeCount = 0;
         const sub: Subscription = this.toggleService.openChange.subscribe(() => {
@@ -66,10 +70,12 @@ export default function (): void {
       spec(ClrPopoverOpenCloseButton, TestHost, undefined, {
         providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],
       });
+
       beforeEach(function (this: Context) {
         this.toggleService = this.getClarityProvider(ClrPopoverToggleService);
         this.detectChanges();
       });
+
       it('emits events when the open state changes', function (this: Context) {
         expect(this.fixture.componentInstance.openState).toBeUndefined(); // inital state
         this.clarityElement.click();
@@ -79,12 +85,14 @@ export default function (): void {
         expect(this.hostComponent.openState).toEqual(this.toggleService.open);
         expect(this.hostComponent.openState).toBe(false); // closed state
       });
+
       it('handles click events', function (this: Context) {
         const clickSpy = spyOn(this.toggleService, 'toggleWithEvent');
         this.clarityElement.click();
         expect(clickSpy.calls.count()).toEqual(1);
       });
     });
+
     describe('View Basics', function (this: Context) {
       spec(ClrPopoverOpenCloseButton, TestHost, undefined, {
         providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],

--- a/projects/angular/src/utils/popover/popover-open-close-button.spec.ts
+++ b/projects/angular/src/utils/popover/popover-open-close-button.spec.ts
@@ -4,13 +4,11 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ElementRef, Renderer2, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { Subscription } from 'rxjs';
 
 import { spec, TestContext } from '../testing/helpers.spec';
 import { ClrPopoverOpenCloseButton } from './popover-open-close-button';
-import { ClrPopoverEventsService } from './providers/popover-events.service';
-import { ClrPopoverPositionService } from './providers/popover-position.service';
 import { ClrPopoverToggleService } from './providers/popover-toggle.service';
 
 @Component({
@@ -40,7 +38,7 @@ export default function (): void {
 
     describe('TypeScript API', function (this: Context) {
       spec(ClrPopoverOpenCloseButton, TestHost, undefined, {
-        providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],
+        providers: [ClrPopoverToggleService],
       });
 
       beforeEach(function (this: Context) {
@@ -68,7 +66,7 @@ export default function (): void {
 
     describe('Template API', () => {
       spec(ClrPopoverOpenCloseButton, TestHost, undefined, {
-        providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],
+        providers: [ClrPopoverToggleService],
       });
 
       beforeEach(function (this: Context) {
@@ -95,7 +93,7 @@ export default function (): void {
 
     describe('View Basics', function (this: Context) {
       spec(ClrPopoverOpenCloseButton, TestHost, undefined, {
-        providers: [ClrPopoverToggleService, ClrPopoverPositionService, ClrPopoverEventsService, Renderer2],
+        providers: [ClrPopoverToggleService],
       });
 
       it('adds the clr-smart-open-close classname', function (this: Context) {

--- a/projects/angular/src/utils/popover/position-operators.spec.ts
+++ b/projects/angular/src/utils/popover/position-operators.spec.ts
@@ -21,6 +21,7 @@ import {
 export function ClrPositionTransformSpec(): void {
   describe('Transorm Function', () => {
     let position: ClrPopoverPosition;
+
     beforeEach(function () {
       position = {
         anchor: ClrAlignment.START,
@@ -29,6 +30,7 @@ export function ClrPositionTransformSpec(): void {
         side: ClrSide.BEFORE,
       };
     });
+
     describe('flipSides', () => {
       it('transforms a ClrPopoverPosition.side into the opposite ClrSide', () => {
         position = flipSides(position);
@@ -37,6 +39,7 @@ export function ClrPositionTransformSpec(): void {
         expect(position.side).toBe(ClrSide.BEFORE);
       });
     });
+
     describe('flipAxis', () => {
       it('transforms ClrPopoverPosition.axis into the opposite ClrAxis', () => {
         position = flipAxis(position);
@@ -45,37 +48,44 @@ export function ClrPositionTransformSpec(): void {
         expect(position.axis).toBe(ClrAxis.HORIZONTAL);
       });
     });
+
     describe('nudgeContent', () => {
       it('transforms a ClrPopoverPosition.content alignment forward from start to middle', () => {
         position = nudgeContent(position, true);
         expect(position.content).toBe(ClrAlignment.CENTER);
       });
+
       it('transforms the content alignment forward from center to end', () => {
         position.content = ClrAlignment.CENTER;
         position = nudgeContent(position, true);
         expect(position.content).toBe(ClrAlignment.END);
       });
+
       it('does not transform the content alignment forward when ClrAlignment.END', () => {
         position.content = ClrAlignment.END;
         position = nudgeContent(position, true);
         expect(position.content).toBe(ClrAlignment.END);
       });
+
       it('does not transform the content alignment backwards when ClrAlignment.START', () => {
         expect(position.content).toBe(ClrAlignment.START);
         position = nudgeContent(position);
         expect(position.content).toBe(ClrAlignment.START);
       });
+
       it('transforms the content alignment backwards from center to start', () => {
         position.content = ClrAlignment.CENTER;
         position = nudgeContent(position);
         expect(position.content).toBe(ClrAlignment.START);
       });
+
       it('transforms the content alignment backwards from end to center', () => {
         position.content = ClrAlignment.END;
         position = nudgeContent(position);
         expect(position.content).toBe(ClrAlignment.CENTER);
       });
     });
+
     describe('flipSidesAndNudgeContent', () => {
       it('should compose a function that performs two transforms on a ClrPosition', () => {
         const flipSidesAndNudgeRight = flipSidesAndNudgeContent(flipSides, nudgeContent, true);
@@ -108,18 +118,21 @@ export function ClrViewportValidationSpec() {
       innerWidth: window.innerWidth,
       innerHeight: window.innerHeight,
     };
+
     beforeEach(() => {
       // resize the browser for this suite
       (window as any).innerHeight = 600;
       (window as any).innerWidth = 600;
       window.dispatchEvent(new Event('resize'));
     });
+
     afterEach(() => {
       // Put the browser size back to its original
       (window as any).innerHeight = originalWindowSize.innerHeight;
       (window as any).innerWidth = originalWindowSize.innerWidth;
       window.dispatchEvent(new Event('resize'));
     });
+
     describe('Single violations', () => {
       it('should identify top window violations', () => {
         // make content rect very tall for a TOP violation
@@ -143,6 +156,7 @@ export function ClrViewportValidationSpec() {
         expect(errors.length).toEqual(1);
         expect(errors[0]).toBe(ClrViewportViolation.TOP);
       });
+
       it('should identify left window violations', () => {
         const wideContentRect: ClientRect = {
           bottom: 400,
@@ -164,6 +178,7 @@ export function ClrViewportValidationSpec() {
         expect(errors.length).toEqual(1);
         expect(errors[0]).toBe(ClrViewportViolation.LEFT);
       });
+
       it('should identify bottom window violations', () => {
         // make content rect very tall for a BOTTOM violation
         const tallContentRect: ClientRect = {
@@ -186,6 +201,7 @@ export function ClrViewportValidationSpec() {
         expect(errors.length).toEqual(1);
         expect(errors[0]).toBe(ClrViewportViolation.BOTTOM);
       });
+
       it('should identify right window violations', () => {
         const wideContentRect: ClientRect = {
           bottom: 400,
@@ -208,6 +224,7 @@ export function ClrViewportValidationSpec() {
         expect(errors[0]).toBe(ClrViewportViolation.RIGHT);
       });
     });
+
     describe('Double violations', () => {
       it('should identify top+left violations', () => {
         const topLeftRect: ClientRect = {
@@ -231,6 +248,7 @@ export function ClrViewportValidationSpec() {
         expect(errors).toContain(ClrViewportViolation.LEFT);
         expect(errors).toContain(ClrViewportViolation.TOP);
       });
+
       it('should identify top+right violations', () => {
         const topRightRect: ClientRect = {
           bottom: 400,
@@ -253,6 +271,7 @@ export function ClrViewportValidationSpec() {
         expect(errors).toContain(ClrViewportViolation.RIGHT);
         expect(errors).toContain(ClrViewportViolation.TOP);
       });
+
       it('should identify bottom+left violations', () => {
         const bottomLeftRect: ClientRect = {
           bottom: 400,
@@ -275,6 +294,7 @@ export function ClrViewportValidationSpec() {
         expect(errors).toContain(ClrViewportViolation.LEFT);
         expect(errors).toContain(ClrViewportViolation.BOTTOM);
       });
+
       it('should identify bottom+right violations', () => {
         const bottomRightRect: ClientRect = {
           bottom: 400,
@@ -297,6 +317,7 @@ export function ClrViewportValidationSpec() {
         expect(errors).toContain(ClrViewportViolation.RIGHT);
         expect(errors).toContain(ClrViewportViolation.BOTTOM);
       });
+
       it('should identify top+bottom violations', () => {
         const bottomTopRect: ClientRect = {
           bottom: 400,
@@ -319,6 +340,7 @@ export function ClrViewportValidationSpec() {
         expect(errors).toContain(ClrViewportViolation.TOP);
         expect(errors).toContain(ClrViewportViolation.BOTTOM);
       });
+
       it('should identify left+right violations', () => {
         const leftRightRect: ClientRect = {
           bottom: 400,
@@ -342,6 +364,7 @@ export function ClrViewportValidationSpec() {
         expect(errors).toContain(ClrViewportViolation.RIGHT);
       });
     });
+
     describe('Triple violations', () => {
       it('should identify left+top+right violations', () => {
         const leftRightRect: ClientRect = {
@@ -366,6 +389,7 @@ export function ClrViewportValidationSpec() {
         expect(errors).toContain(ClrViewportViolation.RIGHT);
         expect(errors).toContain(ClrViewportViolation.TOP);
       });
+
       it('should identify top+right+bottom violations', () => {
         const topRightBottomRect: ClientRect = {
           bottom: 400,
@@ -389,6 +413,7 @@ export function ClrViewportValidationSpec() {
         expect(errors).toContain(ClrViewportViolation.RIGHT);
         expect(errors).toContain(ClrViewportViolation.TOP);
       });
+
       it('should identify right+bottom+left violations', () => {
         const rightBottomLeftRect: ClientRect = {
           bottom: 400,
@@ -412,6 +437,7 @@ export function ClrViewportValidationSpec() {
         expect(errors).toContain(ClrViewportViolation.RIGHT);
         expect(errors).toContain(ClrViewportViolation.LEFT);
       });
+
       it('should identify bottom+left+top violations', () => {
         const bottomLeftTopRect: ClientRect = {
           bottom: 400,

--- a/projects/angular/src/utils/popover/providers/popover-events.service.spec.ts
+++ b/projects/angular/src/utils/popover/providers/popover-events.service.spec.ts
@@ -29,7 +29,7 @@ export default function (): void {
       beforeEach(function (this: TestContext) {
         TestBed.configureTestingModule({
           declarations: [TestHost],
-          providers: [ClrPopoverEventsService, ClrPopoverPositionService, ClrPopoverToggleService],
+          providers: [ClrPopoverToggleService],
         });
         const fixture = TestBed.createComponent(TestHost);
         this.eventService = fixture.debugElement.injector.get(ClrPopoverEventsService, null);

--- a/projects/angular/src/utils/popover/providers/popover-events.service.spec.ts
+++ b/projects/angular/src/utils/popover/providers/popover-events.service.spec.ts
@@ -68,16 +68,19 @@ export default function (): void {
         const testElementRef = setupAnchor(this);
         expect(this.eventService.anchorButtonRef).toEqual(testElementRef);
       });
+
       it('sets the content element', function (this: TestContext) {
         expect(this.eventService.contentRef).not.toBeDefined();
         const testElementRef = setupContent(this);
         expect(this.eventService.contentRef).toEqual(testElementRef);
       });
+
       it('sets the close button reference', function (this: TestContext) {
         expect(this.eventService.closeButtonRef).not.toBeDefined();
         const testElementRef = setupCloseButton(this);
         expect(this.eventService.closeButtonRef).toEqual(testElementRef);
       });
+
       it('sets outside click to close property', function (this: TestContext) {
         expect(this.eventService.ignoredEvent).not.toBeDefined();
         const testClick = new MouseEvent('click', {
@@ -88,6 +91,7 @@ export default function (): void {
         this.toggleService.toggleWithEvent(testClick);
         expect(this.eventService.ignoredEvent).toEqual(testClick);
       });
+
       it('set focus on the anchor button', function (this: TestContext) {
         const testAnchor = setupAnchor(this);
         setupContent(this);
@@ -95,6 +99,7 @@ export default function (): void {
         this.eventService.setAnchorFocus();
         expect(testAnchor.nativeElement.focus).toHaveBeenCalled();
       });
+
       it('sets focus on the close button', function (this: TestContext) {
         setupContent(this);
         const closeBtn = setupCloseButton(this);

--- a/projects/angular/src/utils/popover/providers/popover-position.service.spec.ts
+++ b/projects/angular/src/utils/popover/providers/popover-position.service.spec.ts
@@ -37,7 +37,7 @@ export default function (): void {
     beforeEach(function (this: TestContext) {
       TestBed.configureTestingModule({
         declarations: [TestHost],
-        providers: [ClrPopoverEventsService, ClrPopoverPositionService, ClrPopoverToggleService],
+        providers: [ClrPopoverToggleService],
       });
       this.fixture = TestBed.createComponent(TestHost);
       this.eventService = this.fixture.debugElement.injector.get(ClrPopoverEventsService, null);

--- a/projects/angular/src/utils/popover/providers/popover-toggle.service.spec.ts
+++ b/projects/angular/src/utils/popover/providers/popover-toggle.service.spec.ts
@@ -42,11 +42,13 @@ export default function (): void {
         expect(changeObservable).toBeDefined();
         expect(changeObservable instanceof Observable).toBe(true);
       });
+
       it('exposes an observable for the change events', function (this: TestContext) {
         const eventObservable: Observable<Event> = this.toggleService.getEventChange();
         expect(eventObservable).toBeDefined();
         expect(eventObservable instanceof Observable).toBe(true);
       });
+
       it('exposes an observable for the alignment events', function (this: TestContext) {
         const alignedObservable: Observable<HTMLElement> = this.toggleService.popoverAligned;
         expect(alignedObservable).toBeDefined();
@@ -59,6 +61,7 @@ export default function (): void {
         expect(aligned).toBeTrue();
         subscription.unsubscribe();
       });
+
       it('updates and notifies when the openEvent changes', function (this: TestContext) {
         const clickEvent: Event = new MouseEvent('click');
         let testEvent: Event;
@@ -71,6 +74,7 @@ export default function (): void {
         expect(this.toggleService.openEvent).toBe(testEvent);
         eventSubscription.unsubscribe();
       });
+
       it('updates and notifies when the open value changes', function (this: TestContext) {
         let openValue: boolean;
         const openSubscription = this.toggleService.openChange.subscribe(change => {
@@ -83,6 +87,7 @@ export default function (): void {
         expect(this.toggleService.open).toEqual(openValue);
         openSubscription.unsubscribe();
       });
+
       it('toggles open state with events', function (this: TestContext) {
         const openClickEvent: Event = new MouseEvent('click');
         const closeClickEvent: Event = new MouseEvent('click');

--- a/projects/angular/src/utils/popover/providers/popover-toggle.service.spec.ts
+++ b/projects/angular/src/utils/popover/providers/popover-toggle.service.spec.ts
@@ -31,7 +31,7 @@ export default function (): void {
       beforeEach(function (this: TestContext) {
         TestBed.configureTestingModule({
           declarations: [TestHost],
-          providers: [ClrPopoverEventsService, ClrPopoverPositionService, ClrPopoverToggleService],
+          providers: [ClrPopoverToggleService],
         });
         const fixture = TestBed.createComponent(TestHost);
         this.toggleService = fixture.debugElement.injector.get(ClrPopoverToggleService, null);

--- a/projects/angular/src/utils/testing/helpers.spec.ts
+++ b/projects/angular/src/utils/testing/helpers.spec.ts
@@ -150,6 +150,7 @@ export function addHelpersDeprecated(
       return this._context;
     };
   });
+
   afterEach(function () {
     if (this._context) {
       this._context.fixture.destroy();

--- a/projects/angular/src/utils/virtual-scroll/dom-helpers.spec.ts
+++ b/projects/angular/src/utils/virtual-scroll/dom-helpers.spec.ts
@@ -31,6 +31,7 @@ export default function (): void {
         this.viewport = createDiv(document.body, { height: '100px', overflow: 'auto' });
         this.child = createDiv(this.viewport, { height: '300px' }, 'Hello');
       });
+
       afterEach(function (this: TestContext) {
         document.body.removeChild(this.viewport);
       });
@@ -73,6 +74,7 @@ export default function (): void {
         this.child = createDiv(this.viewport, { height: '300px' }, 'Hello');
         this.viewport.scrollTop = 200;
       });
+
       afterEach(function (this: TestContext) {
         document.body.removeChild(this.viewport);
       });
@@ -127,6 +129,7 @@ export default function (): void {
         this.viewport = createDiv(document.body, { height: '100px', overflow: 'auto' });
         this.child = createDiv(this.viewport, { height: '300px' }, 'Hello');
       });
+
       afterEach(function (this: TestContext) {
         document.body.removeChild(this.viewport);
       });
@@ -149,6 +152,7 @@ export default function (): void {
         this.viewport = createDiv(document.body, { height: '100px', overflow: 'auto' });
         this.child = createDiv(this.viewport, { height: '300px' }, 'Hello');
       });
+
       afterEach(function (this: TestContext) {
         document.body.removeChild(this.viewport);
       });

--- a/projects/angular/src/wizard/wizard-header-action.spec.ts
+++ b/projects/angular/src/wizard/wizard-header-action.spec.ts
@@ -212,6 +212,7 @@ export default function (): void {
           lookupEl = debugEl.nativeElement;
           projectedEl = lookupEl.querySelector('#clr-wizard-header-action-projection');
         });
+
         it('projects as expected', () => {
           expect(projectedEl.textContent.trim()).toBe(testComponent.projector);
         });


### PR DESCRIPTION
This prevents the `this.renderer.listen is not a function` error that was being thrown in `afterAll`.

I think the fix is a combination of using a real `Renderer2` and ensuring that `ClrPopoverEventsService` is destroyed properly.