### PR TITLE
chore: include disabled state in checkbox in story variants and split checkbox container to separate story

### DIFF
--- a/.storybook/helpers/setup-storybook.helpers.ts
+++ b/.storybook/helpers/setup-storybook.helpers.ts
@@ -6,7 +6,7 @@
 
 import { CommonModule } from '@angular/common';
 import { Type } from '@angular/core';
-import { ReactiveFormsModule } from '@angular/forms';
+import { FormsModule, ReactiveFormsModule } from '@angular/forms';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { Parameters } from '@storybook/addons';
 import { moduleMetadata, storiesOf, Story } from '@storybook/angular';
@@ -25,6 +25,7 @@ export function setupStorybook(
         imports: [
           CommonModule,
           BrowserAnimationsModule,
+          FormsModule,
           ReactiveFormsModule,
           NgLetModule,
           ...(Array.isArray(ngModules) ? ngModules : [ngModules]),

--- a/.storybook/stories/checkbox-toggle/checkbox-toggle-container.stories.ts
+++ b/.storybook/stories/checkbox-toggle/checkbox-toggle-container.stories.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { ClrCheckbox, ClrCheckboxModule } from '@clr/angular';
+import { ClrCheckboxContainer, ClrCheckboxModule } from '@clr/angular';
 import { Parameters } from '@storybook/addons';
 import { Story } from '@storybook/angular';
 
@@ -22,10 +22,11 @@ const defaultStory: Story = args => {
 
   return {
     template: `
-      <${containerSelector}> <!-- The container is required in this story so that the disabled state works correctly. -->
-        <${wrapperSelector}>
-          <input type="checkbox" ${directive} [ngModel]="checked" [disabled]="disabled" />
-          <label>{{label}}</label>
+      <${containerSelector} [clrInline]="clrInline">
+        <label>{{label}}</label>
+        <${wrapperSelector} *ngFor="let _ of createArray(optionCount); let i = index">
+          <input type="checkbox" ${directive} />
+          <label>Option {{i + 1}}</label>
         </${wrapperSelector}>
       </${containerSelector}>
     `,
@@ -34,25 +35,27 @@ const defaultStory: Story = args => {
 };
 
 const defaultParameters: Parameters = {
-  title: 'Checkbox or Toggle/Checkbox or Toggle',
-  component: ClrCheckbox,
+  title: 'Checkbox or Toggle/Checkbox or Toggle Container',
+  component: ClrCheckboxContainer,
   argTypes: {
     // inputs
-    id: { defaultValue: '' },
+    clrInline: { defaultValue: false, control: { type: 'boolean' } },
     // methods
-    getProviderFromContainer: { control: { disable: true }, table: { disable: true } },
-    triggerValidation: { control: { disable: true }, table: { disable: true } },
+    addGrid: { control: { disable: true }, table: { disable: true } },
+    controlClass: { control: { disable: true }, table: { disable: true } },
     // story helpers
     type: {
       defaultValue: CheckboxType.Checkbox,
       control: { type: 'inline-radio', options: CheckboxType },
     },
+    createArray: { control: { disable: true }, table: { disable: true } },
+    optionCount: { control: { type: 'number', min: 1, max: 100 } },
   },
   args: {
     // story helpers
-    label: 'Option',
-    checked: false,
-    disabled: false,
+    label: 'Options',
+    createArray: n => new Array(n),
+    optionCount: 4,
   },
 };
 
@@ -62,14 +65,11 @@ function generateVariants() {
   const variants: Parameters[] = [];
 
   for (const type of [CheckboxType.Checkbox, CheckboxType.Toggle]) {
-    for (const disabled of [false, true]) {
-      for (const checked of [false, true]) {
-        variants.push({
-          type,
-          disabled,
-          checked,
-        });
-      }
+    for (const clrInline of [false, true]) {
+      variants.push({
+        clrInline,
+        type,
+      });
     }
   }
 

--- a/.storybook/stories/checkbox-toggle/checkbox-toggle.stories.ts
+++ b/.storybook/stories/checkbox-toggle/checkbox-toggle.stories.ts
@@ -23,9 +23,9 @@ const defaultStory: Story = args => {
   return {
     template: `
       <${containerSelector} [clrInline]="clrInline">
-        <${wrapperSelector} *ngFor="let _ of createArray(checkboxCount); let i = index">
+        <${wrapperSelector} *ngFor="let _ of createArray(optionCount); let i = index">
           <input type="checkbox" ${directive} [ngModel]="checked" [disabled]="disabled" />
-          <label>{{content}} {{i + 1}}</label>
+          <label>{{label}} {{i + 1}}</label>
         </${wrapperSelector}>
       </${containerSelector}>
     `,
@@ -48,13 +48,13 @@ const defaultParameters: Parameters = {
       control: { type: 'inline-radio', options: CheckboxType },
     },
     createArray: { control: { disable: true }, table: { disable: true } },
-    checkboxCount: { control: { type: 'number', min: 1, max: 100 } },
+    optionCount: { control: { type: 'number', min: 1, max: 100 } },
   },
   args: {
     // story helpers
     createArray: n => new Array(n),
-    checkboxCount: 4,
-    content: 'Option',
+    optionCount: 4,
+    label: 'Option',
     checked: false,
     disabled: false,
   },

--- a/.storybook/stories/checkbox-toggle/checkbox-toggle.stories.ts
+++ b/.storybook/stories/checkbox-toggle/checkbox-toggle.stories.ts
@@ -24,7 +24,7 @@ const defaultStory: Story = args => {
     template: `
       <${containerSelector} [clrInline]="clrInline">
         <${wrapperSelector} *ngFor="let _ of createArray(checkboxCount); let i = index">
-          <input type="checkbox" ${directive} [checked]="checked" [disabled]="disabled" />
+          <input type="checkbox" ${directive} [ngModel]="checked" [disabled]="disabled" />
           <label>{{content}} {{i + 1}}</label>
         </${wrapperSelector}>
       </${containerSelector}>

--- a/.storybook/stories/checkbox-toggle/checkbox-toggle.stories.ts
+++ b/.storybook/stories/checkbox-toggle/checkbox-toggle.stories.ts
@@ -67,12 +67,15 @@ function generateVariants() {
 
   for (const type of [CheckboxType.Checkbox, CheckboxType.Toggle]) {
     for (const clrInline of [false, true]) {
-      for (const checked of [false, true]) {
-        variants.push({
-          clrInline,
-          type,
-          checked,
-        });
+      for (const disabled of [false, true]) {
+        for (const checked of [false, true]) {
+          variants.push({
+            clrInline,
+            type,
+            disabled,
+            checked,
+          });
+        }
       }
     }
   }


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Documentation content changes (Storybook)

## What is the current behavior?

- The disabled state doesn't work and is not included in the variants
- The checkbox and checkbox container are in one story.

## What is the new behavior?

- The disabled state works and is included in the variants.
- The checkbox and checkbox container are in separate stories.

## Does this PR introduce a breaking change?

No