### PR TITLE
fix(datagrid): reject undefined and strings (when active) in the numeric property filter (v12 backport)

### DIFF
--- a/projects/angular/src/data/datagrid/all.spec.ts
+++ b/projects/angular/src/data/datagrid/all.spec.ts
@@ -15,6 +15,7 @@ import DomAdapterSpecs from '../../utils/dom-adapter/dom-adapter.spec';
 import DatagridPropertyComparatorSpecs from './built-in/comparators/datagrid-property-comparator.spec';
 import DatagridNumericFilterImplSpecs from './built-in/filters/datagrid-numeric-filter-impl.spec';
 import DatagridNumericFilterSpecs from './built-in/filters/datagrid-numeric-filter.spec';
+import DatagridPropertyNumericFilterSpecs from './built-in/filters/datagrid-property-numeric-filter.spec';
 import DatagridPropertyStringFilterSpecs from './built-in/filters/datagrid-property-string-filter.spec';
 import DatagridStringFilterImplSpecs from './built-in/filters/datagrid-string-filter-impl.spec';
 import DatagridStringFilterSpecs from './built-in/filters/datagrid-string-filter.spec';
@@ -112,6 +113,7 @@ describe('Datagrid', function () {
     NestedPropertySpecs();
     DatagridPropertyComparatorSpecs();
     DatagridPropertyStringFilterSpecs();
+    DatagridPropertyNumericFilterSpecs();
     DatagridStringFilterSpecs();
     DatagridStringFilterImplSpecs();
     DatagridNumericFilterSpecs();

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-property-numeric-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-property-numeric-filter.spec.ts
@@ -26,10 +26,10 @@ export default function (): void {
     //   expect(this.filter.accepts({ a: 'not a number' }, null, 1)).toBe(false);
     // });
 
-    // it('always rejects undefined', function () {
-    //   this.filter = new DatagridPropertyNumericFilter('a');
-    //   expect(this.filter.accepts({}, null, null)).toBe(false);
-    // });
+    it('always rejects undefined', function () {
+      this.filter = new DatagridPropertyNumericFilter('a');
+      expect(this.filter.accepts({}, null, null)).toBe(false);
+    });
 
     it('supports nested properties', function () {
       this.filter = new DatagridPropertyNumericFilter('a.b');

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-property-numeric-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-property-numeric-filter.spec.ts
@@ -10,30 +10,30 @@ export default function (): void {
   describe('DatagridPropertyNumericFilter', function () {
     it('checks if a number is within the range', function () {
       this.filter = new DatagridPropertyNumericFilter('a');
-      expect(this.filter.accepts({ a: 1 }, [null, 10])).toBe(true);
-      expect(this.filter.accepts({ a: 1 }, [null, -1])).toBe(false);
-      expect(this.filter.accepts({ a: 9 }, [1, null])).toBe(true);
-      expect(this.filter.accepts({ a: 9 }, [10, null])).toBe(false);
+      expect(this.filter.accepts({ a: 1 }, null, 10)).toBe(true);
+      expect(this.filter.accepts({ a: 1 }, null, -1)).toBe(false);
+      expect(this.filter.accepts({ a: 9 }, 1, null)).toBe(true);
+      expect(this.filter.accepts({ a: 9 }, 10, null)).toBe(false);
     });
 
     it('accepts strings when not active', function () {
       this.filter = new DatagridPropertyNumericFilter('a');
-      expect(this.filter.accepts({ a: 'not a number' }, [null, null])).toBe(true);
+      expect(this.filter.accepts({ a: 'not a number' }, null, null)).toBe(true);
     });
 
-    it('rejects strings when active', function () {
-      this.filter = new DatagridPropertyNumericFilter('a');
-      expect(this.filter.accepts({ a: 'not a number' }, [null, 1])).toBe(false);
-    });
+    // it('rejects strings when active', function () {
+    //   this.filter = new DatagridPropertyNumericFilter('a');
+    //   expect(this.filter.accepts({ a: 'not a number' }, null, 1)).toBe(false);
+    // });
 
-    it('always rejects undefined', function () {
-      this.filter = new DatagridPropertyNumericFilter('a');
-      expect(this.filter.accepts({}, 'a')).toBe(false);
-    });
+    // it('always rejects undefined', function () {
+    //   this.filter = new DatagridPropertyNumericFilter('a');
+    //   expect(this.filter.accepts({}, null, null)).toBe(false);
+    // });
 
     it('supports nested properties', function () {
       this.filter = new DatagridPropertyNumericFilter('a.b');
-      expect(this.filter.accepts({ a: { b: 1 } }, [0, 10])).toBe(true);
+      expect(this.filter.accepts({ a: { b: 1 } }, 0, 10)).toBe(true);
     });
   });
 }

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-property-numeric-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-property-numeric-filter.spec.ts
@@ -21,10 +21,10 @@ export default function (): void {
       expect(this.filter.accepts({ a: 'not a number' }, null, null)).toBe(true);
     });
 
-    // it('rejects strings when active', function () {
-    //   this.filter = new DatagridPropertyNumericFilter('a');
-    //   expect(this.filter.accepts({ a: 'not a number' }, null, 1)).toBe(false);
-    // });
+    it('rejects strings when active', function () {
+      this.filter = new DatagridPropertyNumericFilter('a');
+      expect(this.filter.accepts({ a: 'not a number' }, null, 1)).toBe(false);
+    });
 
     it('always rejects undefined', function () {
       this.filter = new DatagridPropertyNumericFilter('a');

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-property-numeric-filter.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-property-numeric-filter.ts
@@ -19,10 +19,10 @@ export class DatagridPropertyNumericFilter<T = any> implements ClrDatagridNumeri
     if (propValue === undefined) {
       return false;
     }
-    if (low !== null && propValue < low) {
+    if (low !== null && (typeof propValue !== 'number' || propValue < low)) {
       return false;
     }
-    if (high !== null && propValue > high) {
+    if (high !== null && (typeof propValue !== 'number' || propValue > high)) {
       return false;
     }
     return true;

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-property-numeric-filter.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-property-numeric-filter.ts
@@ -16,6 +16,9 @@ export class DatagridPropertyNumericFilter<T = any> implements ClrDatagridNumeri
 
   accepts(item: T, low: number, high: number): boolean {
     const propValue = this.nestedProp.getPropValue(item);
+    if (propValue === undefined) {
+      return false;
+    }
     if (low !== null && propValue < low) {
       return false;
     }


### PR DESCRIPTION
This is a backport of #283.

This fixes the behavior of `DatagridPropertyNumericFilter` and the corresponding tests.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently the tests in `datagrid-property-numeric-filter.spec.ts` are not executed. 

## What is the new behavior?

The tests are now executed and the handling of `undefined` and non-number values was adopted to make the tests pass.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
