### PR TITLE
feat(datagrid): add ctrl/command click row selection mode 

### DIFF
--- a/.storybook/stories/datagrid/datagrid.stories.ts
+++ b/.storybook/stories/datagrid/datagrid.stories.ts
@@ -21,13 +21,13 @@ const defaultStory: Story = args => ({
       ${args.height ? '[style.height.px]="height"' : ''}
       ${args.multiSelectable ? '[clrDgSelected]="[]"' : ''}
       ${args.singleSelectable ? '[clrDgSingleSelected]="true"' : ''}
-      ${args.clrDgCtrlClickRowSelection ? 'clrDgCtrlClickRowSelection' : ''}
       [ngClass]="{ 'datagrid-compact': compact }"
       [clrDetailExpandableAriaLabel]="clrDetailExpandableAriaLabel"
       [clrDgDisablePageFocus]="clrDgDisablePageFocus"
       [clrDgLoading]="clrDgLoading"
       [clrDgPreserveSelection]="clrDgPreserveSelection"
       [clrDgRowSelection]="clrDgRowSelection"
+      [clrDgCtrlClickRowSelection]="clrDgCtrlClickRowSelection"
       [clrDgSingleActionableAriaLabel]="clrDgSingleActionableAriaLabel"
       [clrDgSingleSelectionAriaLabel]="clrDgSingleSelectionAriaLabel"
       (clrDgRefresh)="clrDgRefresh($event)"
@@ -83,6 +83,7 @@ const defaultParameters: Parameters = {
     clrDgLoading: { defaultValue: false },
     clrDgPreserveSelection: { defaultValue: false },
     clrDgRowSelection: { defaultValue: false },
+    clrDgCtrlClickRowSelection: { defaultValue: false, control: { type: 'boolean' } }, // input to a directive
     clrDgSelected: { control: { disable: true } },
     clrDgSingleActionableAriaLabel: { defaultValue: commonStringsService.keys.singleActionableAriaLabel },
     clrDgSingleSelected: { control: { disable: true } },
@@ -96,7 +97,6 @@ const defaultParameters: Parameters = {
     resize: { control: { disable: true } },
     // story helpers
     elements: { control: { disable: true }, table: { disable: true } },
-    clrDgCtrlClickRowSelection: { defaultValue: false, control: { type: 'boolean' } }, // adds a directive
   },
   args: {
     // outputs

--- a/.storybook/stories/datagrid/datagrid.stories.ts
+++ b/.storybook/stories/datagrid/datagrid.stories.ts
@@ -21,6 +21,7 @@ const defaultStory: Story = args => ({
       ${args.height ? '[style.height.px]="height"' : ''}
       ${args.multiSelectable ? '[clrDgSelected]="[]"' : ''}
       ${args.singleSelectable ? '[clrDgSingleSelected]="true"' : ''}
+      ${args.clrDgCtrlClickRowSelection ? 'clrDgCtrlClickRowSelection' : ''}
       [ngClass]="{ 'datagrid-compact': compact }"
       [clrDetailExpandableAriaLabel]="clrDetailExpandableAriaLabel"
       [clrDgDisablePageFocus]="clrDgDisablePageFocus"
@@ -95,6 +96,7 @@ const defaultParameters: Parameters = {
     resize: { control: { disable: true } },
     // story helpers
     elements: { control: { disable: true }, table: { disable: true } },
+    clrDgCtrlClickRowSelection: { defaultValue: false, control: { type: 'boolean' } }, // adds a directive
   },
   args: {
     // outputs

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -22,7 +22,7 @@ import { FormGroup } from '@angular/forms';
 import { FormGroupDirective } from '@angular/forms';
 import { FormGroupName } from '@angular/forms';
 import * as i0 from '@angular/core';
-import * as i40 from '@angular/forms';
+import * as i41 from '@angular/forms';
 import * as i6 from '@angular/common';
 import { InjectionToken } from '@angular/core';
 import { Injector } from '@angular/core';
@@ -860,10 +860,10 @@ export class ClrComboboxModule {
     // Warning: (ae-forgotten-export) The symbol "i4" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "i5" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "i6" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "i48" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "i49" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrComboboxModule, [typeof i1_12.ClrCombobox, typeof i2_9.ClrComboboxContainer, typeof i3_9.ClrOptions, typeof i4_6.ClrOption, typeof i5_4.ClrOptionSelected, typeof i6_5.ClrOptionItems], [typeof i6.CommonModule, typeof i40.FormsModule, typeof i3_2.ClrIconModule, typeof i48.ClrKeyFocusModule, typeof i2_6.ClrCommonFormsModule, typeof i6_2.ClrConditionalModule, typeof i19_2.ClrPopoverModuleNext, typeof i17_2.ClrSpinnerModule], [typeof i2_6.ClrCommonFormsModule, typeof i1_12.ClrCombobox, typeof i2_9.ClrComboboxContainer, typeof i3_9.ClrOptions, typeof i4_6.ClrOption, typeof i5_4.ClrOptionSelected, typeof i6_2.ClrConditionalModule, typeof i6_5.ClrOptionItems]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrComboboxModule, [typeof i1_12.ClrCombobox, typeof i2_9.ClrComboboxContainer, typeof i3_9.ClrOptions, typeof i4_6.ClrOption, typeof i5_4.ClrOptionSelected, typeof i6_5.ClrOptionItems], [typeof i6.CommonModule, typeof i41.FormsModule, typeof i3_2.ClrIconModule, typeof i49.ClrKeyFocusModule, typeof i2_6.ClrCommonFormsModule, typeof i6_2.ClrConditionalModule, typeof i19_2.ClrPopoverModuleNext, typeof i17_2.ClrSpinnerModule], [typeof i2_6.ClrCommonFormsModule, typeof i1_12.ClrCombobox, typeof i2_9.ClrComboboxContainer, typeof i3_9.ClrOptions, typeof i4_6.ClrOption, typeof i5_4.ClrOptionSelected, typeof i6_2.ClrConditionalModule, typeof i6_5.ClrOptionItems]>;
 }
 
 // @public (undocumented)
@@ -1625,11 +1625,12 @@ export class ClrDatagridModule {
     // Warning: (ae-forgotten-export) The symbol "i34" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "i35" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "i36" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "i43" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "i37" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "i44" needs to be exported by the entry point index.d.ts
+    // Warning: (ae-forgotten-export) The symbol "i45" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrDatagridModule, [typeof i1_8.ClrDatagrid, typeof i2_5.ClrDatagridActionBar, typeof i3_5.ClrDatagridActionOverflow, typeof i4_3.ClrDatagridColumn, typeof i5_2.ClrDatagridColumnSeparator, typeof i6_3.ClrDatagridColumnToggle, typeof i7.ClrDatagridHideableColumn, typeof i8_2.ClrDatagridFilter, typeof i9.ClrDatagridItems, typeof i10.ClrDatagridItemsTrackBy, typeof i11.ClrDatagridRow, typeof i12.ClrDatagridRowDetail, typeof i13.DatagridDetailRegisterer, typeof i14.ClrDatagridCell, typeof i15.ClrDatagridFooter, typeof i16.ClrDatagridPagination, typeof i17.ClrDatagridPageSize, typeof i18.ClrDatagridPlaceholder, typeof i19.ClrDatagridColumnToggleButton, typeof i20.ClrDatagridColumnToggleTitle, typeof i21.ClrDatagridDetail, typeof i22.ClrIfDetail, typeof i23.ClrDatagridDetailHeader, typeof i24.ClrDatagridDetailBody, typeof i25.WrappedCell, typeof i26.WrappedColumn, typeof i27.WrappedRow, typeof i28.DatagridMainRenderer, typeof i29.DatagridHeaderRenderer, typeof i30.DatagridRowRenderer, typeof i31.DatagridCellRenderer, typeof i32.DatagridWillyWonka, typeof i33.ActionableOompaLoompa, typeof i34.ExpandableOompaLoompa, typeof i35.DatagridStringFilter, typeof i36.DatagridNumericFilter], [typeof i6.CommonModule, typeof i3_2.ClrIconModule, typeof i11_2.ClrFormsModule, typeof i40.FormsModule, typeof i5_7.ClrLoadingModule, typeof i6_2.ClrConditionalModule, typeof i43.ClrOutsideClickModule, typeof i44.ClrExpandableAnimationModule, typeof i15_2.ClrDragAndDropModule, typeof i17_2.ClrSpinnerModule, typeof i19_2.ClrPopoverModuleNext, typeof i48.ClrKeyFocusModule, typeof i7_5.ClrFocusTrapModule, typeof i8_6.ClrFocusOnViewInitModule], [typeof i1_8.ClrDatagrid, typeof i2_5.ClrDatagridActionBar, typeof i3_5.ClrDatagridActionOverflow, typeof i4_3.ClrDatagridColumn, typeof i5_2.ClrDatagridColumnSeparator, typeof i6_3.ClrDatagridColumnToggle, typeof i7.ClrDatagridHideableColumn, typeof i8_2.ClrDatagridFilter, typeof i9.ClrDatagridItems, typeof i10.ClrDatagridItemsTrackBy, typeof i11.ClrDatagridRow, typeof i12.ClrDatagridRowDetail, typeof i13.DatagridDetailRegisterer, typeof i14.ClrDatagridCell, typeof i15.ClrDatagridFooter, typeof i16.ClrDatagridPagination, typeof i17.ClrDatagridPageSize, typeof i18.ClrDatagridPlaceholder, typeof i19.ClrDatagridColumnToggleButton, typeof i20.ClrDatagridColumnToggleTitle, typeof i21.ClrDatagridDetail, typeof i22.ClrIfDetail, typeof i23.ClrDatagridDetailHeader, typeof i24.ClrDatagridDetailBody, typeof i25.WrappedCell, typeof i26.WrappedColumn, typeof i27.WrappedRow, typeof i28.DatagridMainRenderer, typeof i29.DatagridHeaderRenderer, typeof i30.DatagridRowRenderer, typeof i31.DatagridCellRenderer, typeof i32.DatagridWillyWonka, typeof i33.ActionableOompaLoompa, typeof i34.ExpandableOompaLoompa, typeof i35.DatagridStringFilter, typeof i36.DatagridNumericFilter]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrDatagridModule, [typeof i1_8.ClrDatagrid, typeof i2_5.ClrDatagridActionBar, typeof i3_5.ClrDatagridActionOverflow, typeof i4_3.ClrDatagridColumn, typeof i5_2.ClrDatagridColumnSeparator, typeof i6_3.ClrDatagridColumnToggle, typeof i7.ClrDatagridHideableColumn, typeof i8_2.ClrDatagridFilter, typeof i9.ClrDatagridItems, typeof i10.ClrDatagridItemsTrackBy, typeof i11.ClrDatagridRow, typeof i12.ClrDatagridRowDetail, typeof i13.DatagridDetailRegisterer, typeof i14.ClrDatagridCell, typeof i15.ClrDatagridFooter, typeof i16.ClrDatagridPagination, typeof i17.ClrDatagridPageSize, typeof i18.ClrDatagridPlaceholder, typeof i19.ClrDatagridColumnToggleButton, typeof i20.ClrDatagridColumnToggleTitle, typeof i21.ClrDatagridDetail, typeof i22.ClrIfDetail, typeof i23.ClrDatagridDetailHeader, typeof i24.ClrDatagridDetailBody, typeof i25.WrappedCell, typeof i26.WrappedColumn, typeof i27.WrappedRow, typeof i28.DatagridCtrlClickRowSelectionDirective, typeof i29.DatagridMainRenderer, typeof i30.DatagridHeaderRenderer, typeof i31.DatagridRowRenderer, typeof i32.DatagridCellRenderer, typeof i33.DatagridWillyWonka, typeof i34.ActionableOompaLoompa, typeof i35.ExpandableOompaLoompa, typeof i36.DatagridStringFilter, typeof i37.DatagridNumericFilter], [typeof i6.CommonModule, typeof i3_2.ClrIconModule, typeof i11_2.ClrFormsModule, typeof i41.FormsModule, typeof i5_7.ClrLoadingModule, typeof i6_2.ClrConditionalModule, typeof i44.ClrOutsideClickModule, typeof i45.ClrExpandableAnimationModule, typeof i15_2.ClrDragAndDropModule, typeof i17_2.ClrSpinnerModule, typeof i19_2.ClrPopoverModuleNext, typeof i49.ClrKeyFocusModule, typeof i7_5.ClrFocusTrapModule, typeof i8_6.ClrFocusOnViewInitModule], [typeof i1_8.ClrDatagrid, typeof i2_5.ClrDatagridActionBar, typeof i3_5.ClrDatagridActionOverflow, typeof i4_3.ClrDatagridColumn, typeof i5_2.ClrDatagridColumnSeparator, typeof i6_3.ClrDatagridColumnToggle, typeof i7.ClrDatagridHideableColumn, typeof i8_2.ClrDatagridFilter, typeof i9.ClrDatagridItems, typeof i10.ClrDatagridItemsTrackBy, typeof i11.ClrDatagridRow, typeof i12.ClrDatagridRowDetail, typeof i13.DatagridDetailRegisterer, typeof i14.ClrDatagridCell, typeof i15.ClrDatagridFooter, typeof i16.ClrDatagridPagination, typeof i17.ClrDatagridPageSize, typeof i18.ClrDatagridPlaceholder, typeof i19.ClrDatagridColumnToggleButton, typeof i20.ClrDatagridColumnToggleTitle, typeof i21.ClrDatagridDetail, typeof i22.ClrIfDetail, typeof i23.ClrDatagridDetailHeader, typeof i24.ClrDatagridDetailBody, typeof i25.WrappedCell, typeof i26.WrappedColumn, typeof i27.WrappedRow, typeof i28.DatagridCtrlClickRowSelectionDirective, typeof i29.DatagridMainRenderer, typeof i30.DatagridHeaderRenderer, typeof i31.DatagridRowRenderer, typeof i32.DatagridCellRenderer, typeof i33.DatagridWillyWonka, typeof i34.ActionableOompaLoompa, typeof i35.ExpandableOompaLoompa, typeof i36.DatagridStringFilter, typeof i37.DatagridNumericFilter]>;
 }
 
 // @public (undocumented)
@@ -2707,7 +2708,7 @@ export class ClrInputModule {
     // Warning: (ae-forgotten-export) The symbol "i2" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrInputModule, [typeof i1_18.ClrInput, typeof i2_13.ClrInputContainer], [typeof i6.CommonModule, typeof i40.FormsModule, typeof i3_2.ClrIconModule, typeof i2_6.ClrCommonFormsModule], [typeof i2_6.ClrCommonFormsModule, typeof i1_18.ClrInput, typeof i2_13.ClrInputContainer]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrInputModule, [typeof i1_18.ClrInput, typeof i2_13.ClrInputContainer], [typeof i6.CommonModule, typeof i41.FormsModule, typeof i3_2.ClrIconModule, typeof i2_6.ClrCommonFormsModule], [typeof i2_6.ClrCommonFormsModule, typeof i1_18.ClrInput, typeof i2_13.ClrInputContainer]>;
 }
 
 // @public (undocumented)
@@ -3259,7 +3260,7 @@ export class ClrPasswordModule {
     // Warning: (ae-forgotten-export) The symbol "i2" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrPasswordModule, [typeof i1_19.ClrPassword, typeof i2_14.ClrPasswordContainer], [typeof i6.CommonModule, typeof i40.FormsModule, typeof i3_2.ClrIconModule, typeof i2_6.ClrCommonFormsModule], [typeof i2_6.ClrCommonFormsModule, typeof i1_19.ClrPassword, typeof i2_14.ClrPasswordContainer]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrPasswordModule, [typeof i1_19.ClrPassword, typeof i2_14.ClrPasswordContainer], [typeof i6.CommonModule, typeof i41.FormsModule, typeof i3_2.ClrIconModule, typeof i2_6.ClrCommonFormsModule], [typeof i2_6.ClrCommonFormsModule, typeof i1_19.ClrPassword, typeof i2_14.ClrPasswordContainer]>;
 }
 
 // @public (undocumented)
@@ -3680,7 +3681,7 @@ export class ClrSelectModule {
     // Warning: (ae-forgotten-export) The symbol "i2" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrSelectModule, [typeof i1_21.ClrSelect, typeof i2_16.ClrSelectContainer], [typeof i6.CommonModule, typeof i40.FormsModule, typeof i3_2.ClrIconModule, typeof i2_6.ClrCommonFormsModule], [typeof i2_6.ClrCommonFormsModule, typeof i1_21.ClrSelect, typeof i2_16.ClrSelectContainer]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrSelectModule, [typeof i1_21.ClrSelect, typeof i2_16.ClrSelectContainer], [typeof i6.CommonModule, typeof i41.FormsModule, typeof i3_2.ClrIconModule, typeof i2_6.ClrCommonFormsModule], [typeof i2_6.ClrCommonFormsModule, typeof i1_21.ClrSelect, typeof i2_16.ClrSelectContainer]>;
 }
 
 // @public (undocumented)
@@ -3955,7 +3956,7 @@ export class ClrStackViewModule {
     // Warning: (ae-forgotten-export) The symbol "i7" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrStackViewModule, [typeof i1_30.ClrStackView, typeof i2_22.ClrStackHeader, typeof i3_16.ClrStackBlock, typeof i4_10.ClrStackContentInput, typeof i5_9.ClrStackViewLabel, typeof i5_9.ClrStackViewCustomTags, typeof i6_8.ClrStackInput, typeof i7_7.ClrStackSelect], [typeof i6.CommonModule, typeof i40.FormsModule, typeof i3_2.ClrIconModule, typeof i44.ClrExpandableAnimationModule], [typeof i1_30.ClrStackView, typeof i2_22.ClrStackHeader, typeof i3_16.ClrStackBlock, typeof i4_10.ClrStackContentInput, typeof i5_9.ClrStackViewLabel, typeof i5_9.ClrStackViewCustomTags, typeof i6_8.ClrStackInput, typeof i7_7.ClrStackSelect]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrStackViewModule, [typeof i1_30.ClrStackView, typeof i2_22.ClrStackHeader, typeof i3_16.ClrStackBlock, typeof i4_10.ClrStackContentInput, typeof i5_9.ClrStackViewLabel, typeof i5_9.ClrStackViewCustomTags, typeof i6_8.ClrStackInput, typeof i7_7.ClrStackSelect], [typeof i6.CommonModule, typeof i41.FormsModule, typeof i3_2.ClrIconModule, typeof i45.ClrExpandableAnimationModule], [typeof i1_30.ClrStackView, typeof i2_22.ClrStackHeader, typeof i3_16.ClrStackBlock, typeof i4_10.ClrStackContentInput, typeof i5_9.ClrStackViewLabel, typeof i5_9.ClrStackViewCustomTags, typeof i6_8.ClrStackInput, typeof i7_7.ClrStackSelect]>;
 }
 
 // @public (undocumented)
@@ -4213,7 +4214,7 @@ export class ClrTabsModule {
     // Warning: (ae-forgotten-export) The symbol "i11" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrTabsModule, [typeof i1_40.ClrTabContent, typeof i2_29.ClrTab, typeof i3_21.ClrTabs, typeof i4_14.ClrTabOverflowContent, typeof i5_12.ClrTabLink, typeof i6_9.TabsWillyWonka, typeof i7_8.ActiveOompaLoompa], [typeof i6.CommonModule, typeof i6_2.ClrConditionalModule, typeof i3_2.ClrIconModule, typeof i11_4.ClrTemplateRefModule, typeof i48.ClrKeyFocusModule], [typeof i1_40.ClrTabContent, typeof i2_29.ClrTab, typeof i3_21.ClrTabs, typeof i4_14.ClrTabOverflowContent, typeof i5_12.ClrTabLink, typeof i6_9.TabsWillyWonka, typeof i7_8.ActiveOompaLoompa, typeof i6_2.ClrConditionalModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrTabsModule, [typeof i1_40.ClrTabContent, typeof i2_29.ClrTab, typeof i3_21.ClrTabs, typeof i4_14.ClrTabOverflowContent, typeof i5_12.ClrTabLink, typeof i6_9.TabsWillyWonka, typeof i7_8.ActiveOompaLoompa], [typeof i6.CommonModule, typeof i6_2.ClrConditionalModule, typeof i3_2.ClrIconModule, typeof i11_4.ClrTemplateRefModule, typeof i49.ClrKeyFocusModule], [typeof i1_40.ClrTabContent, typeof i2_29.ClrTab, typeof i3_21.ClrTabs, typeof i4_14.ClrTabOverflowContent, typeof i5_12.ClrTabLink, typeof i6_9.TabsWillyWonka, typeof i7_8.ActiveOompaLoompa, typeof i6_2.ClrConditionalModule]>;
 }
 
 // @public (undocumented)
@@ -4258,7 +4259,7 @@ export class ClrTextareaModule {
     // Warning: (ae-forgotten-export) The symbol "i2" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrTextareaModule, [typeof i1_22.ClrTextarea, typeof i2_17.ClrTextareaContainer], [typeof i6.CommonModule, typeof i40.FormsModule, typeof i3_2.ClrIconModule, typeof i2_6.ClrCommonFormsModule], [typeof i2_6.ClrCommonFormsModule, typeof i1_22.ClrTextarea, typeof i2_17.ClrTextareaContainer]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrTextareaModule, [typeof i1_22.ClrTextarea, typeof i2_17.ClrTextareaContainer], [typeof i6.CommonModule, typeof i41.FormsModule, typeof i3_2.ClrIconModule, typeof i2_6.ClrCommonFormsModule], [typeof i2_6.ClrCommonFormsModule, typeof i1_22.ClrTextarea, typeof i2_17.ClrTextareaContainer]>;
 }
 
 // @public (undocumented)
@@ -5006,6 +5007,19 @@ export const CONDITIONAL_DIRECTIVES: Type<any>[];
 
 // @public (undocumented)
 export const CUSTOM_BUTTON_TYPES: any;
+
+// @public (undocumented)
+export class DatagridCtrlClickRowSelectionDirective implements OnInit {
+    constructor(elementRef: ElementRef, datagrid: ClrDatagrid);
+    // (undocumented)
+    ngOnInit(): void;
+    // (undocumented)
+    overrideSelection(event: MouseEvent): void;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<DatagridCtrlClickRowSelectionDirective, "clr-datagrid[clrDgCtrlClickRowSelection]", never, {}, {}, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<DatagridCtrlClickRowSelectionDirective, never>;
+}
 
 // Warning: (ae-forgotten-export) The symbol "DatagridNumericFilterImpl" needs to be exported by the entry point index.d.ts
 //

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1182,7 +1182,6 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     // (undocumented)
     rowActionService: RowActionService;
     rows: QueryList<ClrDatagridRow<T>>;
-    // @deprecated (undocumented)
     set rowSelectionMode(value: boolean);
     // (undocumented)
     scrollableColumns: ViewContainerRef;

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -36,6 +36,7 @@ import { Observable } from 'rxjs';
 import { OnChanges } from '@angular/core';
 import { OnDestroy } from '@angular/core';
 import { OnInit } from '@angular/core';
+import { Provider } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { Renderer2 } from '@angular/core';
 import { RendererFactory2 } from '@angular/core';
@@ -5009,16 +5010,21 @@ export const CONDITIONAL_DIRECTIVES: Type<any>[];
 export const CUSTOM_BUTTON_TYPES: any;
 
 // @public (undocumented)
+export const DATAGRID_CTRL_CLICK_ROW_SELECTION: InjectionToken<boolean>;
+
+// @public (undocumented)
 export class DatagridCtrlClickRowSelectionDirective implements OnInit {
-    constructor(elementRef: ElementRef, datagrid: ClrDatagrid);
+    constructor(elementRef: ElementRef, datagrid: ClrDatagrid, enabledGlobally: any);
+    // (undocumented)
+    enabledLocally: boolean;
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)
     overrideSelection(event: MouseEvent): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<DatagridCtrlClickRowSelectionDirective, "clr-datagrid[clrDgCtrlClickRowSelection]", never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<DatagridCtrlClickRowSelectionDirective, "clr-datagrid", never, { "enabledLocally": "clrDgCtrlClickRowSelection"; }, {}, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<DatagridCtrlClickRowSelectionDirective, never>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<DatagridCtrlClickRowSelectionDirective, [null, null, { optional: true; }]>;
 }
 
 // Warning: (ae-forgotten-export) The symbol "DatagridNumericFilterImpl" needs to be exported by the entry point index.d.ts
@@ -5133,6 +5139,9 @@ class EmptyAnchor {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<EmptyAnchor, never>;
 }
+
+// @public (undocumented)
+export const enableDatagridCtrlClickRowSelectionProvider: Provider;
 
 // @public (undocumented)
 export const EXPANDABLE_ANIMATION_DIRECTIVES: Type<any>[];

--- a/projects/angular/src/data/datagrid/all.spec.ts
+++ b/projects/angular/src/data/datagrid/all.spec.ts
@@ -27,6 +27,7 @@ import DatagridColumnSeparatorSpecs from './datagrid-column-separator.spec';
 import DatagridColumnToggleButtonSpecs from './datagrid-column-toggle-button.spec';
 import DatagridColumnToggleSpecs from './datagrid-column-toggle.spec';
 import DatagridColumnSpecs from './datagrid-column.spec';
+import DatagridCtrlClickRowSelectionDirectiveSpecs from './datagrid-ctrl-click-row-selection.directive.spec';
 import DatagridFilterSpecs from './datagrid-filter.spec';
 import DatagridFooterSpecs from './datagrid-footer.spec';
 import DatagridHideableColumnDirectiveSpec from './datagrid-hideable-column.spec';
@@ -97,6 +98,10 @@ describe('Datagrid', function () {
     WrappedCellSpec();
     WrappedColumnSpec();
     WrappedRowSpec();
+  });
+
+  describe('Directives', function () {
+    DatagridCtrlClickRowSelectionDirectiveSpecs();
   });
 
   describe('Render', function () {

--- a/projects/angular/src/data/datagrid/datagrid-ctrl-click-row-selection.directive.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-ctrl-click-row-selection.directive.spec.ts
@@ -1,0 +1,78 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+
+import { ClrDatagrid } from './datagrid';
+import { DATAGRID_SPEC_PROVIDERS, TestContext } from './helpers.spec';
+
+export default function (): void {
+  let context: TestContext<ClrDatagrid, any>;
+  let datagrid: ClrDatagrid;
+  let element: HTMLElement;
+
+  describe('clrDgCtrlClickRowSelection', () => {
+    beforeEach(function () {
+      context = this.create(ClrDatagrid, TestComponent, DATAGRID_SPEC_PROVIDERS);
+
+      datagrid = context.clarityDirective;
+      element = context.fixture.nativeElement;
+    });
+
+    afterEach(() => {
+      context.fixture.destroy();
+    });
+
+    it('deselects other rows when a modifier key is not pressed', () => {
+      datagrid.selected = [1, 2, 3];
+      context.detectChanges();
+
+      element.querySelector<HTMLElement>('.row-4 clr-dg-cell')?.click();
+
+      expect(datagrid.selection.current).toEqual([4]);
+    });
+
+    it('does not deselect other rows when the selection cell is clicked', () => {
+      datagrid.selected = [1, 2, 3];
+      context.detectChanges();
+
+      element.querySelector<HTMLElement>('.row-4 .datagrid-select')?.click();
+
+      expect(datagrid.selection.current).toEqual([1, 2, 3, 4]);
+    });
+
+    ['shift', 'ctrl', 'meta'].forEach(key => {
+      it(`does not deselect other rows when ${key} key is pressed`, () => {
+        datagrid.selected = [1, 2, 3];
+        context.detectChanges();
+
+        const clickEvent = new MouseEvent('click', { bubbles: true, [`${key}Key`]: true });
+        element.querySelector<HTMLElement>('.row-4 clr-dg-cell')?.dispatchEvent(clickEvent);
+
+        expect(datagrid.selection.current).toEqual([1, 2, 3, 4]);
+      });
+    });
+  });
+}
+
+@Component({
+  template: `
+    <clr-datagrid>
+      <clr-dg-column>First</clr-dg-column>
+      <clr-dg-column>Second</clr-dg-column>
+
+      <clr-dg-row *ngFor="let item of items" class="row-{{ item }}" [clrDgItem]="item">
+        <clr-dg-cell>{{ item }}</clr-dg-cell>
+        <clr-dg-cell>{{ item * item }}</clr-dg-cell>
+      </clr-dg-row>
+
+      <clr-dg-footer>{{ items.length }} items</clr-dg-footer>
+    </clr-datagrid>
+  `,
+})
+class TestComponent {
+  readonly items = [1, 2, 3, 4, 5];
+}

--- a/projects/angular/src/data/datagrid/datagrid-ctrl-click-row-selection.directive.ts
+++ b/projects/angular/src/data/datagrid/datagrid-ctrl-click-row-selection.directive.ts
@@ -1,0 +1,46 @@
+/*
+ * Copyright (c) 2016-2022 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Directive, ElementRef, HostListener, OnInit } from '@angular/core';
+
+import { ClrDatagrid } from './datagrid';
+
+@Directive({
+  selector: 'clr-datagrid[clrDgCtrlClickRowSelection]',
+})
+export class DatagridCtrlClickRowSelectionDirective implements OnInit {
+  constructor(private readonly elementRef: ElementRef, private readonly datagrid: ClrDatagrid) {}
+
+  ngOnInit() {
+    this.datagrid.selected = [];
+    this.datagrid.rowSelectionMode = true;
+  }
+
+  @HostListener('click', ['$event'])
+  overrideSelection(event: MouseEvent) {
+    const target = event.target as HTMLElement;
+
+    if (
+      !mouseEventIsSpecialKeyClick(event) &&
+      !elementHasSelectionCellParent(target, this.elementRef.nativeElement) &&
+      elementHasDatagridRowParent(target, this.elementRef.nativeElement)
+    ) {
+      this.datagrid.selected = [];
+    }
+  }
+}
+
+function mouseEventIsSpecialKeyClick(event: MouseEvent) {
+  return event.shiftKey || event.ctrlKey || event.metaKey;
+}
+
+function elementHasSelectionCellParent(element: HTMLElement | null, maxParent: HTMLElement) {
+  return maxParent.contains(element?.closest('.datagrid-select') || null);
+}
+
+function elementHasDatagridRowParent(element: HTMLElement | null, maxParent: HTMLElement) {
+  return maxParent.contains(element?.closest('clr-dg-row') || null);
+}

--- a/projects/angular/src/data/datagrid/datagrid-row.html
+++ b/projects/angular/src/data/datagrid/datagrid-row.html
@@ -3,20 +3,17 @@
   Clicking of that wrapper label will equate to clicking on the whole row, which triggers the checkbox to toggle.
 -->
 <label class="datagrid-row-clickable" *ngIf="selection.rowSelectionMode" (mousedown)="clearRanges($event)">
+  <ng-template [ngTemplateOutlet]="expandableRowContent"></ng-template>
+</label>
+
+<ng-template *ngIf="!selection.rowSelectionMode" [ngTemplateOutlet]="expandableRowContent"></ng-template>
+
+<ng-template #expandableRowContent>
   <clr-expandable-animation [clrExpandTrigger]="expandAnimationTrigger" *ngIf="expand.expandable">
     <ng-template [ngTemplateOutlet]="rowContent"></ng-template>
   </clr-expandable-animation>
   <ng-template [ngTemplateOutlet]="rowContent" *ngIf="!expand.expandable"></ng-template>
-</label>
-
-<clr-expandable-animation
-  *ngIf="!selection.rowSelectionMode && expand.expandable"
-  [clrExpandTrigger]="expandAnimationTrigger"
->
-  <ng-template [ngTemplateOutlet]="rowContent"></ng-template>
-</clr-expandable-animation>
-
-<ng-template *ngIf="!selection.rowSelectionMode && !expand.expandable" [ngTemplateOutlet]="rowContent"></ng-template>
+</ng-template>
 
 <!--
     We need the "project into template" hacks because we need this in 2 different places

--- a/projects/angular/src/data/datagrid/datagrid.module.ts
+++ b/projects/angular/src/data/datagrid/datagrid.module.ts
@@ -46,6 +46,7 @@ import { ClrDatagridColumnSeparator } from './datagrid-column-separator';
 import { ClrDatagridColumnToggle } from './datagrid-column-toggle';
 import { ClrDatagridColumnToggleButton } from './datagrid-column-toggle-button';
 import { ClrDatagridColumnToggleTitle } from './datagrid-column-toggle-title';
+import { DatagridCtrlClickRowSelectionDirective } from './datagrid-ctrl-click-row-selection.directive';
 import { ClrDatagridDetail } from './datagrid-detail';
 import { ClrDatagridDetailBody } from './datagrid-detail-body';
 import { ClrDatagridDetailHeader } from './datagrid-detail-header';
@@ -98,6 +99,9 @@ export const CLR_DATAGRID_DIRECTIVES: Type<any>[] = [
   WrappedCell,
   WrappedColumn,
   WrappedRow,
+
+  // Options
+  DatagridCtrlClickRowSelectionDirective,
 
   // Renderers
   DatagridMainRenderer,

--- a/projects/angular/src/data/datagrid/datagrid.ts
+++ b/projects/angular/src/data/datagrid/datagrid.ts
@@ -176,6 +176,7 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
   set clrDgPreserveSelection(state: boolean) {
     this.selection.preserveSelection = state;
   }
+
   /**
    * @deprecated since 2.0, remove in 3.0
    *

--- a/projects/angular/src/data/datagrid/datagrid.ts
+++ b/projects/angular/src/data/datagrid/datagrid.ts
@@ -178,8 +178,6 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
   }
 
   /**
-   * @deprecated since 2.0, remove in 3.0
-   *
    * Selection/Deselection on row click mode
    */
   @Input('clrDgRowSelection')

--- a/projects/angular/src/data/datagrid/index.ts
+++ b/projects/angular/src/data/datagrid/index.ts
@@ -28,6 +28,8 @@ export * from './datagrid-page-size';
 export * from './datagrid-pagination';
 export * from './datagrid-placeholder';
 
+export * from './datagrid-ctrl-click-row-selection.directive';
+
 export * from './interfaces/state.interface';
 export * from './enums/sort-order.enum';
 export * from './interfaces/filter.interface';

--- a/projects/angular/src/data/datagrid/providers/selection.ts
+++ b/projects/angular/src/data/datagrid/providers/selection.ts
@@ -189,7 +189,6 @@ export class Selection<T = any> {
     }
   }
 
-  /** @deprecated since 2.0, remove in 3.0 */
   public rowSelectionMode = false;
 
   private get _selectable(): boolean {

--- a/projects/angular/src/deprecations.spec.ts
+++ b/projects/angular/src/deprecations.spec.ts
@@ -4,7 +4,6 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { ClrDatagrid } from './data/datagrid/datagrid';
 import { ClrDatagridColumnToggle } from './data/datagrid/datagrid-column-toggle';
 import { ClrDatagridColumnToggleButton } from './data/datagrid/datagrid-column-toggle-button';
 import { ClrDatagridColumnToggleTitle } from './data/datagrid/datagrid-column-toggle-title';
@@ -19,11 +18,6 @@ describe('Deprecations', () => {
       expect(ClrDatagridColumnToggle).toBeTruthy();
       expect(ClrDatagridColumnToggleTitle).toBeTruthy();
       expect(ClrDatagridColumnToggleButton).toBeTruthy();
-    });
-
-    it('should deprecate but still support clrDgRowSelection', () => {
-      const propTest = Object.getOwnPropertyDescriptor(ClrDatagrid.prototype, 'rowSelectionMode');
-      expect(propTest.set).toBeDefined();
     });
   });
 


### PR DESCRIPTION
This draft PR "undeprecates" datagrid row selection. This decision has not been approved and there is a high chance it won't be included in the final version of this PR (if this PR even gets merged since it extends a deprecated feature).

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Feature

## What is the current behavior?

The ctrl/command key has no effect on row selection.

## What is the new behavior?

There is a ctrl/command click row selection mode.

This mode enables a row selection mode that works similar to the Kendo datagrid and Windows File Explorer. If you click a row, all other rows are deselected unless you press ctrl or command when clicking the row.

## Does this PR introduce a breaking change?

No.