### PR TITLE
fix(form): correct color on error icon

### DIFF
--- a/projects/angular/src/forms/common/control-container.ts
+++ b/projects/angular/src/forms/common/control-container.ts
@@ -23,7 +23,6 @@ import { NgControlService } from './providers/ng-control.service';
         <cds-icon
           *ngIf="showInvalid"
           class="clr-validate-icon"
-          status="danger"
           shape="exclamation-circle"
           aria-hidden="true"
         ></cds-icon>


### PR DESCRIPTION
The ClrControlContainer had wrong color on error icon as it sets the icon status to danger. This overrides the forms invalid color set by the form css. Other form containers such as ClrInputContainer don't set it either for this reason.

Close: #305

Signed-off-by: Ron Birk <rbirk@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: 305

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
