### PR TITLE
fix: ensure validation icons are the correct color (backport)

### DIFF
--- a/projects/angular/src/forms/checkbox/checkbox-container.ts
+++ b/projects/angular/src/forms/checkbox/checkbox-container.ts
@@ -26,15 +26,15 @@ import { ClrCheckbox } from './checkbox';
         <cds-icon
           *ngIf="showInvalid"
           class="clr-validate-icon"
-          status="danger"
           shape="exclamation-circle"
+          status="danger"
           aria-hidden="true"
         ></cds-icon>
         <cds-icon
           *ngIf="showValid"
           class="clr-validate-icon"
-          status="success"
           shape="check-circle"
+          status="success"
           aria-hidden="true"
         ></cds-icon>
         <ng-content select="clr-control-error" *ngIf="showInvalid"></ng-content>

--- a/projects/angular/src/forms/combobox/combobox-container.ts
+++ b/projects/angular/src/forms/combobox/combobox-container.ts
@@ -33,15 +33,15 @@ import { ComboboxContainerService } from './providers/combobox-container.service
       <cds-icon
         *ngIf="showInvalid"
         class="clr-validate-icon"
-        status="danger"
         shape="exclamation-circle"
+        status="danger"
         aria-hidden="true"
       ></cds-icon>
       <cds-icon
         *ngIf="showValid"
         class="clr-validate-icon"
-        status="success"
         shape="check-circle"
+        status="success"
         aria-hidden="true"
       ></cds-icon>
       <ng-content select="clr-control-helper" *ngIf="showHelper"></ng-content>

--- a/projects/angular/src/forms/common/control-container.ts
+++ b/projects/angular/src/forms/common/control-container.ts
@@ -23,8 +23,8 @@ import { NgControlService } from './providers/ng-control.service';
         <cds-icon
           *ngIf="showInvalid"
           class="clr-validate-icon"
-          status="danger"
           shape="exclamation-circle"
+          status="danger"
           aria-hidden="true"
         ></cds-icon>
         <cds-icon

--- a/projects/angular/src/forms/datalist/datalist-container.ts
+++ b/projects/angular/src/forms/datalist/datalist-container.ts
@@ -29,8 +29,8 @@ import { DatalistIdService } from './providers/datalist-id.service';
         <cds-icon
           *ngIf="showInvalid"
           class="clr-validate-icon"
-          status="danger"
           shape="exclamation-circle"
+          status="danger"
           aria-hidden="true"
         ></cds-icon>
         <cds-icon

--- a/projects/angular/src/forms/datepicker/date-container.ts
+++ b/projects/angular/src/forms/datepicker/date-container.ts
@@ -55,8 +55,8 @@ import { ViewManagerService } from './providers/view-manager.service';
         <cds-icon
           *ngIf="showInvalid"
           class="clr-validate-icon"
-          status="danger"
           shape="exclamation-circle"
+          status="danger"
           aria-hidden="true"
         ></cds-icon>
         <cds-icon

--- a/projects/angular/src/forms/input/input-container.ts
+++ b/projects/angular/src/forms/input/input-container.ts
@@ -24,6 +24,7 @@ import { NgControlService } from '../common/providers/ng-control.service';
           *ngIf="showInvalid"
           class="clr-validate-icon"
           shape="exclamation-circle"
+          status="danger"
           aria-hidden="true"
         ></cds-icon>
         <cds-icon

--- a/projects/angular/src/forms/password/password-container.ts
+++ b/projects/angular/src/forms/password/password-container.ts
@@ -47,8 +47,8 @@ export const TOGGLE_SERVICE_PROVIDER = { provide: TOGGLE_SERVICE, useFactory: To
         <cds-icon
           *ngIf="showInvalid"
           class="clr-validate-icon"
-          status="danger"
           shape="exclamation-circle"
+          status="danger"
           aria-hidden="true"
         ></cds-icon>
         <cds-icon

--- a/projects/angular/src/forms/radio/radio-container.ts
+++ b/projects/angular/src/forms/radio/radio-container.ts
@@ -26,8 +26,8 @@ import { ClrRadio } from './radio';
         <cds-icon
           *ngIf="showInvalid"
           class="clr-validate-icon"
-          status="danger"
           shape="exclamation-circle"
+          status="danger"
           aria-hidden="true"
         ></cds-icon>
         <cds-icon

--- a/projects/angular/src/forms/range/range-container.ts
+++ b/projects/angular/src/forms/range/range-container.ts
@@ -25,8 +25,8 @@ import { NgControlService } from '../common/providers/ng-control.service';
         <cds-icon
           *ngIf="showInvalid"
           class="clr-validate-icon"
-          status="danger"
           shape="exclamation-circle"
+          status="danger"
           aria-hidden="true"
         ></cds-icon>
         <cds-icon

--- a/projects/angular/src/forms/select/select-container.ts
+++ b/projects/angular/src/forms/select/select-container.ts
@@ -25,8 +25,8 @@ import { NgControlService } from '../common/providers/ng-control.service';
         <cds-icon
           *ngIf="showInvalid"
           class="clr-validate-icon"
-          status="danger"
           shape="exclamation-circle"
+          status="danger"
           aria-hidden="true"
         ></cds-icon>
         <cds-icon

--- a/projects/angular/src/forms/styles/_containers.clarity.scss
+++ b/projects/angular/src/forms/styles/_containers.clarity.scss
@@ -119,6 +119,7 @@
   .clr-validate-icon {
     @include min-equilateral($clr-forms-icon-size);
     @include css-var(color, clr-forms-invalid-color, $clr-forms-invalid-color, $clr-use-custom-properties);
+    @include css-var(fill, clr-forms-invalid-color, $clr-forms-invalid-color, $clr-use-custom-properties);
     display: none;
     margin-left: -1 * $clr_baselineRem_1;
   }
@@ -130,6 +131,7 @@
     .clr-validate-icon {
       display: inline-block;
       @include css-var(color, clr-forms-valid-color, $clr-forms-valid-color, $clr-use-custom-properties);
+      @include css-var(fill, clr-forms-valid-color, $clr-forms-valid-color, $clr-use-custom-properties);
       margin-left: -0.2rem;
     }
     .clr-subtext {

--- a/projects/angular/src/forms/styles/containers.spec.ts
+++ b/projects/angular/src/forms/styles/containers.spec.ts
@@ -26,7 +26,7 @@ import { ClrIconModule } from '../../icon/icon.module';
         >
           <div class="clr-input-wrapper">
             <input type="text" id="{{ layout }}-basic" placeholder="Enter value here" class="clr-input" />
-            <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+            <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
           </div>
           <span class="clr-subtext">Helper Text</span>
         </div>
@@ -74,7 +74,7 @@ import { ClrIconModule } from '../../icon/icon.module';
             <label for="{{ layout }}-checkbox3" class="clr-control-label">option 3</label>
           </div>
           <div class="clr-subtext-wrapper">
-            <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+            <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
             <span class="clr-subtext">Helper Text</span>
           </div>
         </div>
@@ -122,7 +122,7 @@ import { ClrIconModule } from '../../icon/icon.module';
             <label for="{{ layout }}-checkbox9" class="clr-control-label">option 3</label>
           </div>
           <div class="clr-subtext-wrapper">
-            <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+            <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
             <span class="clr-subtext">Helper Text</span>
           </div>
         </div>
@@ -170,7 +170,7 @@ import { ClrIconModule } from '../../icon/icon.module';
             <label for="{{ layout }}-toggle3" class="clr-control-label">option 3</label>
           </div>
           <div class="clr-subtext-wrapper">
-            <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+            <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
             <span class="clr-subtext">Helper Text</span>
           </div>
         </div>
@@ -218,7 +218,7 @@ import { ClrIconModule } from '../../icon/icon.module';
             <label for="{{ layout }}-toggle9" class="clr-control-label">option 3</label>
           </div>
           <div class="clr-subtext-wrapper">
-            <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+            <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
             <span class="clr-subtext">Helper Text</span>
           </div>
         </div>
@@ -266,7 +266,7 @@ import { ClrIconModule } from '../../icon/icon.module';
             <label for="{{ layout }}-radio3" class="clr-control-label">option 3</label>
           </div>
           <div class="clr-subtext-wrapper">
-            <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+            <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
             <span class="clr-subtext">Helper Text</span>
           </div>
         </div>
@@ -314,7 +314,7 @@ import { ClrIconModule } from '../../icon/icon.module';
             <label for="{{ layout }}-radio6" class="clr-control-label">option 3</label>
           </div>
           <div class="clr-subtext-wrapper">
-            <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+            <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
             <span class="clr-subtext">Helper Text</span>
           </div>
         </div>
@@ -337,7 +337,7 @@ import { ClrIconModule } from '../../icon/icon.module';
             <input #fileInput type="file" id="{{ layout }}-file" placeholder="Enter value here" class="clr-file" />
           </div>
           <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-          <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+          <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
           <span class="clr-subtext">Helper Text</span>
         </div>
       </div>
@@ -358,7 +358,7 @@ import { ClrIconModule } from '../../icon/icon.module';
             <input type="file" id="{{ layout }}-file" placeholder="Enter value here" />
           </div>
           <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-          <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+          <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
           <span class="clr-subtext">Helper Text</span>
         </div>
       </div>
@@ -382,7 +382,7 @@ import { ClrIconModule } from '../../icon/icon.module';
               placeholder="Enter value here"
               class="clr-textarea"
             ></textarea>
-            <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+            <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
           </div>
           <span class="clr-subtext">Helper Text</span>
         </div>
@@ -405,7 +405,7 @@ import { ClrIconModule } from '../../icon/icon.module';
               <option>Option 2</option>
               <option>Option 3</option>
             </select>
-            <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+            <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
           </div>
           <span class="clr-subtext">Helper Text</span>
         </div>
@@ -428,7 +428,7 @@ import { ClrIconModule } from '../../icon/icon.module';
               <option>Option 2</option>
               <option>Option 3</option>
             </select>
-            <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+            <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
           </div>
           <span class="clr-subtext">Helper Text</span>
         </div>

--- a/projects/angular/src/forms/textarea/textarea-container.ts
+++ b/projects/angular/src/forms/textarea/textarea-container.ts
@@ -23,8 +23,8 @@ import { NgControlService } from '../common/providers/ng-control.service';
         <cds-icon
           *ngIf="showInvalid"
           class="clr-validate-icon"
-          status="danger"
           shape="exclamation-circle"
+          status="danger"
           aria-hidden="true"
         ></cds-icon>
         <cds-icon

--- a/projects/demo/src/app/checkboxes/checkboxes.demo.html
+++ b/projects/demo/src/app/checkboxes/checkboxes.demo.html
@@ -289,7 +289,7 @@
         <label for="vertical-checkbox3" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>

--- a/projects/demo/src/app/forms/controls/checkbox.html
+++ b/projects/demo/src/app/forms/controls/checkbox.html
@@ -15,7 +15,7 @@
         <label for="basic" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -49,7 +49,7 @@
         <label for="multi-6" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -67,7 +67,7 @@
         <label for="multi-inline-2" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -85,7 +85,7 @@
         <label for="multi-wrappers-2" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -99,7 +99,7 @@
         <label for="multi-containers-1" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -109,7 +109,7 @@
         <label for="multi-containers-2" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -123,7 +123,7 @@
         <label for="error" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -137,7 +137,7 @@
         <label for="error-indeterminate" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -151,7 +151,7 @@
         <label for="disabled" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -165,7 +165,7 @@
         <label for="disabled-checked" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -185,7 +185,7 @@
         <label for="disabled-indeterminate-checked" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>

--- a/projects/demo/src/app/forms/controls/file.html
+++ b/projects/demo/src/app/forms/controls/file.html
@@ -15,7 +15,7 @@
         <input type="file" id="basic" placeholder="Enter value here" class="clr-file" />
       </div>
       <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-      <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
   </div>
@@ -27,7 +27,7 @@
         <input type="file" id="basic-default" placeholder="Enter value here" />
       </div>
       <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-      <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
   </div>
@@ -40,7 +40,7 @@
         <input type="file" id="error" placeholder="Enter value here" class="clr-file" />
       </div>
       <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-      <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
   </div>
@@ -52,7 +52,7 @@
         <input type="file" id="error-default" placeholder="Enter value here" />
       </div>
       <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-      <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
   </div>
@@ -65,7 +65,7 @@
         <input type="file" id="disaled" disabled placeholder="Enter value here" class="clr-file" />
       </div>
       <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-      <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
   </div>
@@ -77,7 +77,7 @@
         <input type="file" id="disabled-default" disabled placeholder="Enter value here" />
       </div>
       <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-      <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
   </div>

--- a/projects/demo/src/app/forms/controls/radio.html
+++ b/projects/demo/src/app/forms/controls/radio.html
@@ -15,7 +15,7 @@
         <label for="basic">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -49,7 +49,7 @@
         <label for="multi-6" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -67,7 +67,7 @@
         <label for="multi-inline-2" class="clr-control-label">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -85,7 +85,7 @@
         <label for="multi-wrapper-2">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -98,7 +98,7 @@
         <input type="radio" id="multi-container-1" class="clr-radio" name="multi-container" />
         <label for="multi-container-1">Label</label>
       </div>
-      <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
     <div class="clr-control-container clr-error">
@@ -107,7 +107,7 @@
         <label for="multi-container-2">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -121,7 +121,7 @@
         <label for="error">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -135,7 +135,7 @@
         <label for="disabled">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -149,7 +149,7 @@
         <label for="disabled-checked">Label</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>

--- a/projects/demo/src/app/forms/controls/select.html
+++ b/projects/demo/src/app/forms/controls/select.html
@@ -16,7 +16,7 @@
           <option>Option 2</option>
           <option>Option 3</option>
         </select>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Helper Helper Helper Helper Text</span>
     </div>
@@ -31,7 +31,7 @@
           <option>Option 2</option>
           <option>Option 3</option>
         </select>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -46,7 +46,7 @@
           <option>Option 2</option>
           <option>Option 3</option>
         </select>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -61,7 +61,7 @@
           <option>Option 2</option>
           <option>Option 3</option>
         </select>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -76,7 +76,7 @@
           <option selected>Option 2</option>
           <option>Option 3</option>
         </select>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -91,7 +91,7 @@
           <option selected>Option 2</option>
           <option>Option 3</option>
         </select>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>

--- a/projects/demo/src/app/forms/controls/text.html
+++ b/projects/demo/src/app/forms/controls/text.html
@@ -12,7 +12,7 @@
     <div class="clr-control-container">
       <div class="clr-input-wrapper">
         <input type="text" id="basic" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -22,7 +22,7 @@
     <div class="clr-control-container clr-error">
       <div class="clr-input-wrapper">
         <input type="text" id="error" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -32,7 +32,7 @@
     <div class="clr-control-container">
       <div class="clr-input-wrapper">
         <input type="text" id="disabled" disabled placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -42,7 +42,7 @@
     <div class="clr-control-container">
       <div class="clr-input-wrapper">
         <input type="text" id="readonly" readonly placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>

--- a/projects/demo/src/app/forms/controls/textarea.html
+++ b/projects/demo/src/app/forms/controls/textarea.html
@@ -12,7 +12,7 @@
     <div class="clr-control-container">
       <div class="clr-textarea-wrapper">
         <textarea id="basic" rows="5" placeholder="Enter value here" class="clr-textarea"></textarea>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -23,7 +23,7 @@
     <div class="clr-control-container clr-error">
       <div class="clr-textarea-wrapper">
         <textarea id="error" rows="5" placeholder="Enter value here" class="clr-textarea"></textarea>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -34,7 +34,7 @@
     <div class="clr-control-container">
       <div class="clr-textarea-wrapper">
         <textarea id="disabled" disabled rows="5" placeholder="Enter value here" class="clr-textarea"></textarea>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>

--- a/projects/demo/src/app/forms/input-group/input-group.html
+++ b/projects/demo/src/app/forms/input-group/input-group.html
@@ -10,7 +10,7 @@
     <div class="clr-control-container">
       <div class="clr-input-wrapper">
         <input type="text" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -20,7 +20,7 @@
     <div class="clr-control-container clr-error">
       <div class="clr-input-wrapper">
         <input type="text" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -40,7 +40,7 @@
           />
           <span class="clr-input-group-addon"><cds-icon shape="calendar"></cds-icon></span>
         </div>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -61,7 +61,7 @@
           />
           <span class="clr-input-group-addon"><cds-icon shape="calendar"></cds-icon></span>
         </div>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -82,7 +82,7 @@
           />
           <span class="clr-input-group-addon">.00</span>
         </div>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -106,7 +106,7 @@
             (blur)="focusSelectGroup = false"
           />
         </div>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -132,7 +132,7 @@
             </select>
           </div>
         </div>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -159,7 +159,7 @@
             ></cds-icon>
           </button>
         </div>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -186,7 +186,7 @@
             ></cds-icon>
           </button>
         </div>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>

--- a/projects/demo/src/app/forms/layout/layout.html
+++ b/projects/demo/src/app/forms/layout/layout.html
@@ -18,7 +18,7 @@
     <div class="clr-control-container" [ngClass]="{'clr-col-12': grid, 'clr-col-md-10': grid && layout !== 'vertical'}">
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-basic" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -42,7 +42,7 @@
           value="test value"
           disabled
         />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -62,7 +62,7 @@
     >
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-basic-error" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -88,7 +88,7 @@
     >
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-long" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">
         This is the song that doesn't end. It goes on and on my friend. Some people started singing it not knowing what
@@ -136,7 +136,7 @@
         <label for="{{layout}}-checkbox3" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -162,7 +162,7 @@
         <label for="{{layout}}-checkbox7" class="clr-control-label">option 1</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -178,7 +178,7 @@
         <label for="{{layout}}-checkbox8" class="clr-control-label">option 2</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -194,7 +194,7 @@
         <label for="{{layout}}-checkbox9" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -239,7 +239,7 @@
         <label for="{{layout}}-checkbox12" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -284,7 +284,7 @@
         <label for="{{layout}}-checkbox15" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -308,7 +308,7 @@
         <label for="{{layout}}-radio3" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -335,7 +335,7 @@
         <label for="{{layout}}-radio6" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -362,7 +362,7 @@
         <label for="{{layout}}-radio9" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -379,7 +379,7 @@
           <option>Option 2</option>
           <option>Option 3</option>
         </select>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -399,7 +399,7 @@
           <option>Option 2</option>
           <option>Option 3</option>
         </select>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -416,7 +416,7 @@
           <option>Option 2</option>
           <option>Option 3</option>
         </select>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -436,7 +436,7 @@
           <option>Option 2</option>
           <option>Option 3</option>
         </select>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -456,7 +456,7 @@
         <input #fileInput type="file" id="{{layout}}-file" placeholder="Enter value here" class="clr-file" />
       </div>
       <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-      <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       <span *ngIf="!fileInput.value" class="clr-subtext">Helper Text</span>
       <span *ngIf="fileInput.value" class="clr-subtext">{{fileInput.value}}</span>
     </div>
@@ -479,7 +479,7 @@
         <input type="file" id="{{layout}}-file2" placeholder="Enter value here" class="clr-file" />
       </div>
       <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-      <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
   </div>
@@ -497,7 +497,7 @@
         <input type="file" id="{{layout}}-file" placeholder="Enter value here" />
       </div>
       <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-      <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
   </div>
@@ -518,7 +518,7 @@
         <input type="file" id="{{layout}}-file2" placeholder="Enter value here" />
       </div>
       <!-- IMPORTANT DIFFERENCE IN STRUCTURE! ICON IS NOT PART OF THE INPUT WRAPPER -->
-      <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+      <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       <span class="clr-subtext">Helper Text</span>
     </div>
   </div>
@@ -534,7 +534,7 @@
     <div class="clr-control-container" [ngClass]="{'clr-col-12': grid, 'clr-col-md-10': grid && layout !== 'vertical'}">
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-basic" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">
         Helper Text
@@ -561,7 +561,7 @@
     <div class="clr-control-container" [ngClass]="{'clr-col-12': grid, 'clr-col-md-10': grid && layout !== 'vertical'}">
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-nolabel" placeholder="No label" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -578,7 +578,7 @@
     <div class="clr-control-container" [ngClass]="{'clr-col-12': grid, 'clr-col-md-10': grid && layout !== 'vertical'}">
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-nosubtext" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
     </div>
   </div>
@@ -611,21 +611,21 @@
     <div class="clr-control-container" [ngClass]="{'clr-col-12': grid, 'clr-col-md-3': grid}">
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-multiple" placeholder="Enter value here" class="clr-input" size="100" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
     <div class="clr-control-container" [ngClass]="{'clr-col-12': grid, 'clr-col-md-3': grid}">
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-multiple" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
     <div class="clr-control-container" [ngClass]="{'clr-col-12': grid, 'clr-col-md-3': grid}">
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-multiple" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -646,21 +646,21 @@
     <div class="clr-control-container clr-error" [ngClass]="{'clr-col-12': grid, 'clr-col-md-3': grid}">
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-multiple-error" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
     <div class="clr-control-container" [ngClass]="{'clr-col-12': grid, 'clr-col-md-3': grid}">
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-multiple-error" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
     <div class="clr-control-container clr-error" [ngClass]="{'clr-col-12': grid, 'clr-col-md-3': grid}">
       <div class="clr-input-wrapper">
         <input type="text" id="{{layout}}-multiple-error" placeholder="Enter value here" class="clr-input" />
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -682,7 +682,7 @@
           placeholder="Enter value here"
           class="clr-textarea"
         ></textarea>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -707,7 +707,7 @@
           placeholder="Enter value here"
           class="clr-textarea"
         ></textarea>
-        <cds-icon class="clr-validate-icon" status="danger" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>

--- a/projects/demo/src/app/radios/radios.demo.html
+++ b/projects/demo/src/app/radios/radios.demo.html
@@ -257,7 +257,7 @@
         <label for="vertical-radio3" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -279,7 +279,7 @@
         <label for="vertical-radio6" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -301,7 +301,7 @@
         <label for="vertical-radio9" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -327,7 +327,7 @@
         <label for="horizontal-radio3" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -349,7 +349,7 @@
         <label for="horizontal-radio6" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -371,7 +371,7 @@
         <label for="horizontal-radio9" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -397,7 +397,7 @@
         <label for="compact-radio3" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -419,7 +419,7 @@
         <label for="compact-radio6" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -441,7 +441,7 @@
         <label for="compact-radio9" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>

--- a/projects/demo/src/app/selects/selects.demo.html
+++ b/projects/demo/src/app/selects/selects.demo.html
@@ -209,7 +209,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -224,7 +224,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -239,7 +239,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -254,7 +254,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -269,7 +269,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -288,7 +288,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -303,7 +303,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -318,7 +318,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -333,7 +333,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -352,7 +352,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -367,7 +367,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -382,7 +382,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -397,7 +397,7 @@
           <option value="2">Two</option>
           <option value="3">Three</option>
         </select>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>

--- a/projects/demo/src/app/textarea/textarea.demo.html
+++ b/projects/demo/src/app/textarea/textarea.demo.html
@@ -97,7 +97,7 @@
     <div class="clr-control-container">
       <div class="clr-textarea-wrapper">
         <textarea id="vertical-textarea-basic" placeholder="Enter value here" class="clr-textarea"></textarea>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -108,7 +108,7 @@
     <div class="clr-control-container clr-error">
       <div class="clr-textarea-wrapper">
         <textarea id="vertical-textarea-basic-error" placeholder="Enter value here" class="clr-textarea"></textarea>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -123,7 +123,7 @@
     <div class="clr-control-container">
       <div class="clr-textarea-wrapper">
         <textarea id="horizontal-textarea-basic" placeholder="Enter value here" class="clr-textarea"></textarea>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -134,7 +134,7 @@
     <div class="clr-control-container clr-error">
       <div class="clr-textarea-wrapper">
         <textarea id="horizontal-textarea-basic-error" placeholder="Enter value here" class="clr-textarea"></textarea>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -149,7 +149,7 @@
     <div class="clr-control-container">
       <div class="clr-textarea-wrapper">
         <textarea id="compact-textarea-basic" placeholder="Enter value here" class="clr-textarea"></textarea>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>
@@ -160,7 +160,7 @@
     <div class="clr-control-container clr-error">
       <div class="clr-textarea-wrapper">
         <textarea id="compact-textarea-basic-error" placeholder="Enter value here" class="clr-textarea"></textarea>
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
       </div>
       <span class="clr-subtext">Helper Text</span>
     </div>

--- a/projects/demo/src/app/toggles/toggles.demo.html
+++ b/projects/demo/src/app/toggles/toggles.demo.html
@@ -397,7 +397,7 @@
         <label for="vertical-checkbox3" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -438,7 +438,7 @@
         <label for="vertical-checkbox6" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -479,7 +479,7 @@
         <label for="vertical-checkbox9" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -505,7 +505,7 @@
         <label for="horizontal-checkbox3" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -545,7 +545,7 @@
         <label for="horizontal-checkbox6" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -585,7 +585,7 @@
         <label for="horizontal-checkbox9" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -611,7 +611,7 @@
         <label for="compact-checkbox3" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -651,7 +651,7 @@
         <label for="compact-checkbox6" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>
@@ -691,7 +691,7 @@
         <label for="compact-checkbox9" class="clr-control-label">option 3</label>
       </div>
       <div class="clr-subtext-wrapper">
-        <cds-icon class="clr-validate-icon" shape="exclamation-circle"></cds-icon>
+        <cds-icon class="clr-validate-icon" shape="exclamation-circle" status="danger"></cds-icon>
         <span class="clr-subtext">Helper Text</span>
       </div>
     </div>


### PR DESCRIPTION
closes #305
supersedes #308

This is a backport of #311.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

Issue Number: #305

## What is the new behavior?

The validation icon and text are the same color.

## Does this PR introduce a breaking change?

No.