### PR TITLE
fix: set wizard stepnav item `aria-controls` attribute to wizard page id (v12 backport)

### DIFF
--- a/projects/angular/src/wizard/wizard-stepnav-item.spec.ts
+++ b/projects/angular/src/wizard/wizard-stepnav-item.spec.ts
@@ -272,11 +272,11 @@ export default function (): void {
         });
 
         it('should have aria-controls attribute', () => {
-          const stepNavItemId = testItemComponent.id;
+          const pageId = testItemComponent.page.id;
 
           expect(myStepnavItem.hasAttribute('aria-controls')).toBeTruthy('stepnav item should have aria-controls attr');
           const myAriaControls = myStepnavItem.getAttribute('aria-controls');
-          expect(myAriaControls).toBe(stepNavItemId, 'aria-controls should contain id');
+          expect(myAriaControls).toBe(pageId, 'aria-controls should contain page id');
         });
 
         it('should add disabled attribute when isDisabled return true', () => {

--- a/projects/angular/src/wizard/wizard-stepnav-item.ts
+++ b/projects/angular/src/wizard/wizard-stepnav-item.ts
@@ -36,7 +36,7 @@ import { ClrWizardPage } from './wizard-page';
   host: {
     '[id]': 'id',
     '[attr.aria-current]': 'stepAriaCurrent',
-    '[attr.aria-controls]': 'id',
+    '[attr.aria-controls]': 'page.id',
     '[class.clr-nav-link]': 'true',
     '[class.nav-item]': 'true',
     '[class.active]': 'isCurrent',


### PR DESCRIPTION
This is a backport of #317.

partially fixes VPAT-805 (other issues are in datagrid filters)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The `aria-controls` attribute on the wizard stepnav item was the stepnav item id instead of the wizard page id.

## What is the new behavior?

The `aria-controls` attribute on the wizard stepnav item is the wizard page id.

## Does this PR introduce a breaking change?

No