### PR TITLE
chore: apply style changes in storybook watch mode

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
     "_build:demo": "ng build clr-demo --configuration production",
     "_build:storybook": "npm run docs:json && build-storybook --output-dir ./dist/docs",
     "_build:ui:css": "sass ./projects/ui/src:./dist/clr-ui --precision=8",
-    "_build:ui:css:watch": "npm run --silent _build:ui:css -- --watch",
+    "_build:ui:css:watch": "npm run --silent _build:ui:css -- --watch --load-path=projects",
     "_build:ui:prefix": "postcss ./dist/clr-ui/clr-ui.css ./dist/clr-ui/clr-ui-dark.css --use autoprefixer --dir ./dist/clr-ui",
     "_build:ui:optimize": "csso ./dist/clr-ui/clr-ui.css --output ./dist/clr-ui/clr-ui.min.css --source-map file --no-restructure && csso ./dist/clr-ui/clr-ui-dark.css --output ./dist/clr-ui/clr-ui-dark.min.css --source-map file --no-restructure",
     "_build:ui:src": "cpy \"**/*.scss\" ./../../dist/clr-ui --cwd=./projects/angular --parents",


### PR DESCRIPTION
The `sass` CLI does not automatically watch imported paths, so explicitly instructing `sass` to watch the projects folder fixes the issue.