### PR TITLE
fix(list): make unstyled list markers transparent instead of list-style-type none

### DIFF
--- a/projects/angular/src/typography/_lists.scss
+++ b/projects/angular/src/typography/_lists.scss
@@ -8,7 +8,11 @@
   %kill-list-styles {
     padding-left: 0;
     margin-left: 0;
-    list-style: none;
+    list-style-position: outside;
+
+    li::marker {
+      color: transparent;
+    }
   }
 
   ul:not([cds-list]),


### PR DESCRIPTION
screen readers can't read list-style-type: none, so change the markers to be transparent instead

Fixes VPAT-612

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?


- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Screen readers cannot read list-style-type: none

Issue Number: VPAT-612

## What is the new behavior?

The markers needed to be hidden in a different way, using color: transparent, with no margin/padding. list-style-position:outside allows the 0 margin/padding to work 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
