### PR TITLE
fix(list): make unstyled list markers transparent instead of list-sytle-type none (backport)

### DIFF
--- a/projects/angular/src/typography/_lists.scss
+++ b/projects/angular/src/typography/_lists.scss
@@ -8,7 +8,11 @@
   %kill-list-styles {
     padding-left: 0;
     margin-left: 0;
-    list-style: none;
+    list-style-position: outside;
+
+    li::marker {
+      color: transparent;
+    }
   }
 
   ul:not([cds-list]),


### PR DESCRIPTION
Backport of #327 