### PR TITLE
fix(header): show nav overflow triggers until correct breakpoint

### DIFF
--- a/projects/angular/src/layout/nav/_responsive-nav.clarity.scss
+++ b/projects/angular/src/layout/nav/_responsive-nav.clarity.scss
@@ -197,7 +197,7 @@
     }
   }
 
-  @media screen and (max-width: map-get($clr-grid-breakpoints, md)) {
+  @media screen and (max-width: map-get($clr-grid-breakpoints, lg)) {
     .main-container {
       .header-hamburger-trigger,
       .header-overflow-trigger {


### PR DESCRIPTION
This is a backport of #328 to 12.x.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

If you load the page on a medium width, the nav links AND the overflow triggers are both hidden.

## What is the new behavior?

If you load the page on a medium width, the overflow triggers are not hidden.

## Does this PR introduce a breaking change?

No