### PR TITLE
chore: auto accept merged visual changes

### DIFF
--- a/.github/workflows/accept-merged-visual-changes.yml
+++ b/.github/workflows/accept-merged-visual-changes.yml
@@ -1,0 +1,26 @@
+name: Accept Merged Visual Changes
+on:
+  push:
+    branches: main
+jobs:
+  accept-merged-visual-changes:
+    timeout-minutes: 10
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version-file: '.nvmrc'
+      - name: Install Dependencies
+        run: npm ci
+      - name: Build
+        run: npm run build
+      - name: Deploy Chromatic
+        timeout-minutes: 5
+        env:
+          CHROMATIC_PROJECT_TOKEN: ${{secrets.CHROMATIC_PROJECT_TOKEN}}
+        run: npx chromatic --storybook-build-dir ./dist/docs --auto-accept-changes main


### PR DESCRIPTION
When a PR is rebased and merged, the SHA of the commit that lands in the base branch is different than the SHA of the commit in the PR. This makes Chromatic report the same visual change in subsequent PRs because it uses the incorrect baseline build.

The Chromatic GitHub app is supposed to fix this, but it doesn't.

This commit reverts #321 and reapplies #295.