### PR TITLE
fix(stack-view): prevent page scroll when block toggled via space key

### DIFF
--- a/projects/angular/src/data/stack-view/stack-block.ts
+++ b/projects/angular/src/data/stack-view/stack-block.ts
@@ -24,11 +24,14 @@ import { ClrStackViewLabel } from './stack-view-custom-tags';
 @Component({
   selector: 'clr-stack-block',
   template: `
+    <!-- The 'preventDefault' for the space keydown event prevents the page
+         from scrolling when a stack block is toggled via the space key. -->
     <div
       class="stack-block-label"
       (click)="toggleExpand()"
       (keyup.enter)="toggleExpand()"
       (keyup.space)="toggleExpand()"
+      (keydown.space)="$event.preventDefault()"
       (focus)="focused = true"
       (blur)="focused = false"
       [id]="uniqueId"


### PR DESCRIPTION


## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

VPAT-636: "When I press space on the live website the page scrolls down in addition to the expanding/collapsing. This should work like the accordion component." -- comment by Amy Li

## What is the new behavior?

The space key toggles the stack block without scrolling the page.

## Does this PR introduce a breaking change?

No.