### PR TITLE
fix(stack-view): remove action buttons from h4 element

### DIFF
--- a/projects/angular/src/data/stack-view/stack-header.ts
+++ b/projects/angular/src/data/stack-view/stack-header.ts
@@ -11,8 +11,8 @@ import { ClrStackView } from './stack-view';
 @Component({
   selector: 'clr-stack-header',
   template: `
-    <h4 class="stack-header">
-      <span class="stack-title"><ng-content></ng-content></span>
+    <div class="stack-header">
+      <h4 class="stack-title"><ng-content></ng-content></h4>
 
       <span class="stack-actions">
         <ng-content select=".stack-action"></ng-content>
@@ -27,7 +27,7 @@ import { ClrStackView } from './stack-view';
         </button>
         <!-- End of undocumented experimental feature. -->
       </span>
-    </h4>
+    </div>
   `,
   // Custom elements are inline by default
   styles: [

--- a/projects/demo/src/app/stack-view/stack-view-static.html
+++ b/projects/demo/src/app/stack-view/stack-view-static.html
@@ -5,12 +5,12 @@
   -->
 
 <div class="clr-example">
-  <h4 class="stack-header">
-    <span class="stack-title">Static stack view</span>
+  <div class="stack-header">
+    <h4 class="stack-title">Static stack view</h4>
     <span class="stack-actions">
       <button class="stack-action btn btn-sm btn-link" type="button">Edit</button>
     </span>
-  </h4>
+  </div>
   <div class="stack-view">
     <div class="stack-block">
       <div class="stack-block-label">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
  - vmware-clarity/website#41
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The stack view header action buttons are in an `h4` element.

Issue Number: VPAT-827

## What is the new behavior?

The stack view header action buttons are not in an `h4` element.

## Does this PR introduce a breaking change?

No.