### PR TITLE
feat(datagrid): include column title in filter toggle button aria-label

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1468,8 +1468,8 @@ export class ClrDatagridDetailHeader {
 // Warning: (ae-forgotten-export) The symbol "CustomFilter" needs to be exported by the entry point index.d.ts
 //
 // @public
-export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements CustomFilter, OnDestroy {
-    constructor(_filters: FiltersProvider<T>, commonStrings: ClrCommonStringsService, smartToggleService: ClrPopoverToggleService, platformId: any);
+export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements CustomFilter, OnChanges, OnDestroy {
+    constructor(_filters: FiltersProvider<T>, commonStrings: ClrCommonStringsService, smartToggleService: ClrPopoverToggleService, platformId: any, elementRef: ElementRef<HTMLElement>);
     get active(): boolean;
     // (undocumented)
     anchor: ElementRef;
@@ -1482,6 +1482,8 @@ export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDa
     // (undocumented)
     set customFilter(filter: ClrDatagridFilterInterface<T> | RegisteredFilter<T, ClrDatagridFilterInterface<T>>);
     // (undocumented)
+    ngOnChanges(): void;
+    // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
     get open(): boolean;
@@ -1492,6 +1494,8 @@ export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDa
     popoverId: string;
     // (undocumented)
     smartPosition: ClrPopoverPosition;
+    // (undocumented)
+    toggleButtonAriaLabel: string;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridFilter<any>, "clr-dg-filter", never, { "open": "clrDgFilterOpen"; "customFilter": "clrDgFilter"; }, { "openChange": "clrDgFilterOpenChange"; }, never, ["*"]>;
     // (undocumented)

--- a/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
@@ -42,7 +42,8 @@ export default function (): void {
           filterService,
           new ClrCommonStringsService(),
           toggleService,
-          'browser' as any
+          'browser' as any,
+          undefined
         );
       });
 
@@ -136,11 +137,9 @@ export default function (): void {
         expect(toggle.getAttribute('aria-expanded')).toBe('true');
       });
 
-      it('has a button with the correct common string for datagridFilterAriaLabel', function () {
+      it('has a button with the correct aria-label', function () {
         const toggle: HTMLButtonElement = context.clarityElement.querySelector('.datagrid-filter-toggle');
-        const commonStrings: ClrCommonStringsService =
-          context.fixture.debugElement.injector.get(ClrCommonStringsService);
-        expect(toggle.getAttribute('aria-label')).toBe(commonStrings.keys.datagridFilterAriaLabel);
+        expect(toggle.getAttribute('aria-label')).toBe('Toggle user filter');
       });
 
       it('has role and label on the filter dialog', function () {

--- a/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
@@ -170,7 +170,7 @@ export default function (): void {
         openBtn.click();
         context.detectChanges();
         const popoverContent = document.querySelector('.clr-popover-content');
-        expect(popoverContent.textContent.trim()).toMatch('Hello world');
+        expect(popoverContent.textContent.trim()).toMatch('Filter content');
       });
 
       it('opens and closes the dropdown when the toggle is clicked', function () {
@@ -218,7 +218,7 @@ class TestFilter implements ClrDatagridFilterInterface<number> {
       [clrDgFilterOpen]="open"
       (clrDgFilterOpenChange)="clrDgFilterOpenChangeFn($event)"
     >
-      Hello world
+      Filter content
     </clr-dg-filter>
   `,
   providers: [ClrPopoverEventsService, ClrPopoverPositionService],

--- a/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
@@ -12,7 +12,7 @@ import { ClrPopoverEventsService } from '../../utils/popover/providers/popover-e
 import { ClrPopoverPositionService } from '../../utils/popover/providers/popover-position.service';
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
 import { ClrDatagridFilter } from './datagrid-filter';
-import { TestContext } from './helpers.spec';
+import { DATAGRID_SPEC_PROVIDERS, TestContext } from './helpers.spec';
 import { ClrDatagridFilterInterface } from './interfaces/filter.interface';
 import { CustomFilter } from './providers/custom-filter';
 import { FiltersProvider } from './providers/filters';
@@ -80,12 +80,7 @@ export default function (): void {
 
       beforeEach(function (this: any) {
         filter = new TestFilter();
-        context = this.create(ClrDatagridFilter, FullTest, [
-          FiltersProvider,
-          Page,
-          StateDebouncer,
-          ClrPopoverToggleService,
-        ]);
+        context = this.create(ClrDatagridFilter, FullTest, DATAGRID_SPEC_PROVIDERS);
         toggleService = context.getClarityProvider(ClrPopoverToggleService);
       });
 
@@ -116,12 +111,7 @@ export default function (): void {
 
       beforeEach(function (this: any) {
         filter = new TestFilter();
-        context = this.create(ClrDatagridFilter, FullTest, [
-          FiltersProvider,
-          Page,
-          StateDebouncer,
-          ClrPopoverToggleService,
-        ]);
+        context = this.create(ClrDatagridFilter, FullTest, DATAGRID_SPEC_PROVIDERS);
         context.testComponent.filter = filter;
       });
 
@@ -213,13 +203,16 @@ class TestFilter implements ClrDatagridFilterInterface<number> {
 
 @Component({
   template: `
-    <clr-dg-filter
-      [clrDgFilter]="filter"
-      [clrDgFilterOpen]="open"
-      (clrDgFilterOpenChange)="clrDgFilterOpenChangeFn($event)"
-    >
-      Filter content
-    </clr-dg-filter>
+    <clr-dg-column>
+      User
+      <clr-dg-filter
+        [clrDgFilter]="filter"
+        [clrDgFilterOpen]="open"
+        (clrDgFilterOpenChange)="clrDgFilterOpenChangeFn($event)"
+      >
+        Filter content
+      </clr-dg-filter>
+    </clr-dg-column>
   `,
   providers: [ClrPopoverEventsService, ClrPopoverPositionService],
 })

--- a/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
@@ -113,6 +113,7 @@ export default function (): void {
         filter = new TestFilter();
         context = this.create(ClrDatagridFilter, FullTest, DATAGRID_SPEC_PROVIDERS);
         context.testComponent.filter = filter;
+        context.detectChanges();
       });
 
       afterEach(function () {

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -49,8 +49,8 @@ export const commonStringsDefault: ClrCommonStrings = {
   singleSelectionAriaLabel: 'Single selection header',
   singleActionableAriaLabel: 'Single actionable header',
   detailExpandableAriaLabel: 'Toggle more row content',
-  datagridFilterAriaLabel: 'Filter dialog',
-  datagridFilterDialogAriaLabel: 'Toggle column filter',
+  datagridFilterAriaLabel: 'Toggle column filter',
+  datagridFilterDialogAriaLabel: 'Filter dialog',
   columnSeparatorAriaLabel: 'Column resize handle',
   columnSeparatorDescription: 'Use left or right key to resize the column',
   // Alert

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -49,7 +49,7 @@ export const commonStringsDefault: ClrCommonStrings = {
   singleSelectionAriaLabel: 'Single selection header',
   singleActionableAriaLabel: 'Single actionable header',
   detailExpandableAriaLabel: 'Toggle more row content',
-  datagridFilterAriaLabel: 'Toggle column filter',
+  datagridFilterAriaLabel: 'Toggle {COLUMN} filter',
   datagridFilterDialogAriaLabel: 'Filter dialog',
   columnSeparatorAriaLabel: 'Column resize handle',
   columnSeparatorDescription: 'Use left or right key to resize the column',


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Feature

## What is the current behavior?

The `aria-label` of all datagrid filter toggle buttons was "Toggle column filter".

Issue Number: VPAT-615

## What is the new behavior?

The `aria-label` of datagrid filter toggle buttons now contains the column name (e.g. "Toggle user filter"). This improves accessibility by providing a unique/specific `aria-label` for each filter toggle button.

## Does this PR introduce a breaking change?

No.

## Other information

If your application localizes the `datagridFilterAriaLabel` string, you will need to add the `{COLUMN}` placeholder to take advantage of this feature. It will work the same as before without the placeholder, so this change is backwards compatible.