### PR TITLE
fix(tree-view): announce active tree node links as selected

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -4515,9 +4515,11 @@ export class ClrTreeNode<T> implements OnInit, AfterContentInit, OnDestroy {
 
 // @public (undocumented)
 export class ClrTreeNodeLink {
-    constructor(el: ElementRef);
+    constructor(el: ElementRef<HTMLElement>);
     // (undocumented)
     activate(): void;
+    // (undocumented)
+    get active(): boolean;
     // (undocumented)
     static ɵdir: i0.ɵɵDirectiveDeclaration<ClrTreeNodeLink, ".clr-treenode-link", never, {}, {}, never>;
     // (undocumented)

--- a/projects/angular/src/data/tree-view/tree-node-link.ts
+++ b/projects/angular/src/data/tree-view/tree-node-link.ts
@@ -10,7 +10,11 @@ import { Directive, ElementRef } from '@angular/core';
   selector: '.clr-treenode-link',
 })
 export class ClrTreeNodeLink {
-  constructor(private el: ElementRef) {}
+  constructor(private el: ElementRef<HTMLElement>) {}
+
+  get active() {
+    return this.el.nativeElement.classList.contains('active');
+  }
 
   activate() {
     if (this.el.nativeElement && this.el.nativeElement.click) {

--- a/projects/angular/src/data/tree-view/tree-node.html
+++ b/projects/angular/src/data/tree-view/tree-node.html
@@ -48,7 +48,7 @@
   </div>
   <div class="clr-treenode-content" (mousedown)="focusTreeNode()">
     <ng-content></ng-content>
-    <div class="clr-sr-only" *ngIf="featuresService.selectable">
+    <div class="clr-sr-only" *ngIf="featuresService.selectable || ariaSelected">
       <span *ngIf="ariaSelected"> selected</span>
       <span *ngIf="!ariaSelected"> unselected</span>
     </div>

--- a/projects/angular/src/data/tree-view/tree-node.html
+++ b/projects/angular/src/data/tree-view/tree-node.html
@@ -49,8 +49,8 @@
   <div class="clr-treenode-content" (mousedown)="focusTreeNode()">
     <ng-content></ng-content>
     <div class="clr-sr-only" *ngIf="featuresService.selectable">
-      <span *ngIf="ariaSelected">selected</span>
-      <span *ngIf="!ariaSelected">unselected</span>
+      <span *ngIf="ariaSelected"> selected</span>
+      <span *ngIf="!ariaSelected"> unselected</span>
     </div>
   </div>
 </div>

--- a/projects/angular/src/data/tree-view/tree-node.spec.ts
+++ b/projects/angular/src/data/tree-view/tree-node.spec.ts
@@ -344,14 +344,14 @@ export default function (): void {
         this.clarityDirective.selected = ClrSelectedState.SELECTED;
         this.detectChanges();
         expect(contentContainer.getAttribute('aria-selected')).toBe('true');
-        expect(contentContainer.textContent.trim()).toBe('Hello world selected');
+        expect(contentContainer.textContent.trim().replace(/\s+/g, ' ')).toBe('Hello world selected');
       });
 
       it('adds the aria-selected attribute and screen reader text to unselected tree nodes', function (this: Context) {
         this.clarityDirective.selected = ClrSelectedState.UNSELECTED;
         this.detectChanges();
         expect(contentContainer.getAttribute('aria-selected')).toBe('false');
-        expect(contentContainer.textContent.trim()).toBe('Hello world unselected');
+        expect(contentContainer.textContent.trim().replace(/\s+/g, ' ')).toBe('Hello world unselected');
       });
 
       it('does not add the aria-selected attribute or screen reader text to non-selectable tree nodes', function (this: Context) {

--- a/projects/angular/src/data/tree-view/tree-node.spec.ts
+++ b/projects/angular/src/data/tree-view/tree-node.spec.ts
@@ -340,22 +340,25 @@ export default function (): void {
         expect(contentContainer.getAttribute('role')).toBe('treeitem');
       });
 
-      it('adds the aria-selected attribute to selected tree nodes', function (this: Context) {
+      it('adds the aria-selected attribute and screen reader text to selected tree nodes', function (this: Context) {
         this.clarityDirective.selected = ClrSelectedState.SELECTED;
         this.detectChanges();
         expect(contentContainer.getAttribute('aria-selected')).toBe('true');
+        expect(contentContainer.textContent.trim()).toBe('Hello world selected');
       });
 
-      it('adds the aria-selected attribute to unselected tree nodes', function (this: Context) {
+      it('adds the aria-selected attribute and screen reader text to unselected tree nodes', function (this: Context) {
         this.clarityDirective.selected = ClrSelectedState.UNSELECTED;
         this.detectChanges();
         expect(contentContainer.getAttribute('aria-selected')).toBe('false');
+        expect(contentContainer.textContent.trim()).toBe('Hello world unselected');
       });
 
-      it('does not add the aria-selected attribute to non-selectable tree nodes', function (this: Context) {
+      it('does not add the aria-selected attribute or screen reader text to non-selectable tree nodes', function (this: Context) {
         this.getClarityProvider(TreeFeaturesService).selectable = false;
         this.detectChanges();
         expect(contentContainer.getAttribute('aria-selected')).toBeNull();
+        expect(contentContainer.textContent.trim()).toBe('Hello world');
       });
 
       it('focuses on node content container', function (this: Context) {

--- a/projects/angular/src/data/tree-view/tree-node.spec.ts
+++ b/projects/angular/src/data/tree-view/tree-node.spec.ts
@@ -37,6 +37,17 @@ class TestComponent {
   expandable: boolean | undefined;
 }
 
+@Component({
+  template: `
+    <clr-tree-node>
+      <a href="href" class="clr-treenode-link" [class.active]="active">Hello world</a>
+    </clr-tree-node>
+  `,
+})
+class LinkTestComponent {
+  active: boolean | undefined;
+}
+
 interface TsApiContext {
   node: ClrTreeNode<void>;
   parent: ClrTreeNode<void>;
@@ -487,6 +498,35 @@ export default function (): void {
         spyOn(focusManager, 'focusParent');
         contentContainer.dispatchEvent(new KeyboardEvent('keydown', { key: KeyCodes.ArrowLeft }));
         expect(focusManager.focusParent).toHaveBeenCalledWith(this.clarityDirective._model);
+      });
+    });
+
+    describe('Ally with link nodes', function () {
+      type Context = TestContext<ClrTreeNode<void>, LinkTestComponent>;
+
+      spec(ClrTreeNode, LinkTestComponent, ClrTreeViewModule, {
+        imports: [NoopAnimationsModule, ClrIconModule],
+        providers: [TreeFocusManagerService],
+      });
+
+      let contentContainer: HTMLElement;
+
+      beforeEach(function () {
+        contentContainer = this.clarityElement.querySelector('.clr-tree-node-content-container');
+      });
+
+      it('adds the aria-selected attribute and screen reader text for active tree node links', function (this: Context) {
+        this.hostComponent.active = true;
+        this.detectChanges();
+        expect(contentContainer.getAttribute('aria-selected')).toBe('true');
+        expect(contentContainer.textContent.trim().replace(/\s+/g, ' ')).toBe('Hello world selected');
+      });
+
+      it('does not add the aria-selected attribute or screen reader text for inactive tree node links', function (this: Context) {
+        this.hostComponent.active = false;
+        this.detectChanges();
+        expect(contentContainer.getAttribute('aria-selected')).toBeNull();
+        expect(contentContainer.textContent.trim()).toBe('Hello world');
       });
     });
   });

--- a/projects/angular/src/data/tree-view/tree-node.spec.ts
+++ b/projects/angular/src/data/tree-view/tree-node.spec.ts
@@ -340,11 +340,19 @@ export default function (): void {
         expect(contentContainer.getAttribute('role')).toBe('treeitem');
       });
 
-      it('adds the aria-selected attribute to all nodes when the tree is selectable', function (this: Context) {
-        expect(contentContainer.getAttribute('aria-selected')).toBe('false');
+      it('adds the aria-selected attribute to selected tree nodes', function (this: Context) {
         this.clarityDirective.selected = ClrSelectedState.SELECTED;
         this.detectChanges();
         expect(contentContainer.getAttribute('aria-selected')).toBe('true');
+      });
+
+      it('adds the aria-selected attribute to unselected tree nodes', function (this: Context) {
+        this.clarityDirective.selected = ClrSelectedState.UNSELECTED;
+        this.detectChanges();
+        expect(contentContainer.getAttribute('aria-selected')).toBe('false');
+      });
+
+      it('does not add the aria-selected attribute to non-selectable tree nodes', function (this: Context) {
         this.getClarityProvider(TreeFeaturesService).selectable = false;
         this.detectChanges();
         expect(contentContainer.getAttribute('aria-selected')).toBeNull();

--- a/projects/angular/src/data/tree-view/tree-node.ts
+++ b/projects/angular/src/data/tree-view/tree-node.ts
@@ -142,7 +142,13 @@ export class ClrTreeNode<T> implements OnInit, AfterContentInit, OnDestroy {
   @Output('clrSelectedChange') selectedChange = new EventEmitter<ClrSelectedState>(false);
 
   get ariaSelected(): boolean {
-    return this.isSelectable() ? this._model.selected.value === ClrSelectedState.SELECTED : null;
+    if (this.isSelectable()) {
+      return this._model.selected.value === ClrSelectedState.SELECTED;
+    } else if (this.treeNodeLink?.active) {
+      return true;
+    } else {
+      return null;
+    }
   }
 
   // Allows the consumer to override our logic deciding if a node is expandable.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

Previously, the `aria-selected` attribute and the selected/unselected screen reader text was only set on selectable tree nodes.

Issue Number: VPAT-603

## What is the new behavior?

Now, the `aria-selected` attribute and selected screen reader text is also set on active tree node links so that this state is indicated to screen reader users.

## Does this PR introduce a breaking change?

No.