### PR TITLE
fix(vertical-nav): stop unnecessarily animating `overflow-y`

### DIFF
--- a/projects/angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
+++ b/projects/angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
@@ -159,6 +159,10 @@
       }
     }
 
+    .nav-group-children {
+      overflow-y: hidden;
+    }
+
     .nav-trigger,
     .nav-group-trigger {
       //Display

--- a/projects/angular/src/layout/vertical-nav/vertical-nav-group.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav-group.ts
@@ -24,7 +24,7 @@ const COLLAPSED_STATE = 'collapsed';
   animations: [
     trigger('clrExpand', [
       state(EXPANDED_STATE, style({ height: '*' })),
-      state(COLLAPSED_STATE, style({ height: 0, 'overflow-y': 'hidden', visibility: 'hidden' })),
+      state(COLLAPSED_STATE, style({ height: 0, visibility: 'hidden' })),
       transition(`${EXPANDED_STATE} <=> ${COLLAPSED_STATE}`, animate('0.2s ease-in-out')),
     ]),
   ],


### PR DESCRIPTION
This prevents an Angular 14 developer warning.

closes #323

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

When opening/closing a vertical nav group, the following developer warning is logged by Angular 14:

>The animation trigger "clrExpand" is attempting to animate the following not animatable properties: overflowY

Issue Number: #323

## What is the new behavior?

No warning. The animation is unchanged visually.

## Does this PR introduce a breaking change?

No.