### PR TITLE
fix(forms): form items set touched too late

### DIFF
--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter.spec.ts
@@ -11,6 +11,7 @@ import { DomAdapter } from '../../../../utils/dom-adapter/dom-adapter';
 import { ClrPopoverEventsService } from '../../../../utils/popover/providers/popover-events.service';
 import { ClrPopoverPositionService } from '../../../../utils/popover/providers/popover-position.service';
 import { ClrPopoverToggleService } from '../../../../utils/popover/providers/popover-toggle.service';
+import { animationFrameTick } from '../../../../utils/testing/helpers.spec';
 import { TestContext } from '../../helpers.spec';
 import { ClrDatagridNumericFilterInterface } from '../../interfaces/numeric-filter.interface';
 import { CustomFilter } from '../../providers/custom-filter';
@@ -127,8 +128,7 @@ export default function (): void {
       const input: HTMLInputElement = document.querySelector("input[type='number']");
       spyOn(input, 'focus');
       expect(input.focus).not.toHaveBeenCalled();
-      // The `requestAnimationFrame` is mocked through `setTimeout(fn, 16)`.
-      tick(16);
+      animationFrameTick();
       expect(input.focus).toHaveBeenCalled();
     }));
 

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-string-filter.spec.ts
@@ -11,6 +11,7 @@ import { DomAdapter } from '../../../../utils/dom-adapter/dom-adapter';
 import { ClrPopoverEventsService } from '../../../../utils/popover/providers/popover-events.service';
 import { ClrPopoverPositionService } from '../../../../utils/popover/providers/popover-position.service';
 import { ClrPopoverToggleService } from '../../../../utils/popover/providers/popover-toggle.service';
+import { animationFrameTick } from '../../../../utils/testing/helpers.spec';
 import { TestContext } from '../../helpers.spec';
 import { ClrDatagridStringFilterInterface } from '../../interfaces/string-filter.interface';
 import { CustomFilter } from '../../providers/custom-filter';
@@ -109,7 +110,7 @@ export default function (): void {
       const input: HTMLInputElement = document.querySelector("input[type='text']");
       spyOn(input, 'focus');
       expect(input.focus).not.toHaveBeenCalled();
-      tick(16);
+      animationFrameTick();
       expect(input.focus).toHaveBeenCalled();
     }));
 

--- a/projects/angular/src/forms/common/if-control-state/if-control-state.service.spec.ts
+++ b/projects/angular/src/forms/common/if-control-state/if-control-state.service.spec.ts
@@ -4,6 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { fakeAsync, tick } from '@angular/core/testing';
 import { FormControl } from '@angular/forms';
 
 import { NgControlService } from '../providers/ng-control.service';
@@ -29,16 +30,17 @@ export default function (): void {
       expect(() => service.triggerStatusChange()).not.toThrowError();
     });
 
-    it('provides observable for statusChanges, return valid when touched and no rules added', () => {
+    it('provides observable for statusChanges, return valid when touched and no rules added', fakeAsync(() => {
       const cb = jasmine.createSpy('cb');
       const sub = service.statusChanges.subscribe((control: CONTROL_STATE) => cb(control));
       ngControlService.setControl(testControl);
       // Change the state of the input to trigger statusChange
       testControl.markAsTouched();
       testControl.updateValueAndValidity();
+      tick();
       expect(cb).toHaveBeenCalledWith(CONTROL_STATE.VALID);
       sub.unsubscribe();
-    });
+    }));
 
     it('should allow a manual trigger of status observable, return NONE', () => {
       const cb = jasmine.createSpy('cb');
@@ -91,7 +93,7 @@ export default function (): void {
       sub.unsubscribe();
     });
 
-    it('should return state INVALID', () => {
+    it('should return state INVALID', fakeAsync(() => {
       const cb = jasmine.createSpy('cb');
       const sub = service.statusChanges.subscribe((control: CONTROL_STATE) => cb(control));
       const fakeControl = {
@@ -107,11 +109,12 @@ export default function (): void {
       };
       ngControlService.setControl(fakeControl);
       service.triggerStatusChange();
+      tick();
       expect(cb).toHaveBeenCalledWith(CONTROL_STATE.INVALID);
       sub.unsubscribe();
-    });
+    }));
 
-    it('should return state VALID', () => {
+    it('should return state VALID', fakeAsync(() => {
       const cb = jasmine.createSpy('cb');
       const sub = service.statusChanges.subscribe((control: CONTROL_STATE) => cb(control));
       const fakeControl = {
@@ -127,8 +130,9 @@ export default function (): void {
       };
       ngControlService.setControl(fakeControl);
       service.triggerStatusChange();
+      tick();
       expect(cb).toHaveBeenCalledWith(CONTROL_STATE.VALID);
       sub.unsubscribe();
-    });
+    }));
   });
 }

--- a/projects/angular/src/forms/common/if-control-state/if-control-state.service.ts
+++ b/projects/angular/src/forms/common/if-control-state/if-control-state.service.ts
@@ -51,9 +51,14 @@ export class IfControlStateService implements OnDestroy {
       // These status values are mutually exclusive, so a control
       // cannot be both valid AND invalid or invalid AND disabled.
       const status = CONTROL_STATE[this.control.status];
-      this._statusChanges.next(
-        this.control.touched && ['VALID', 'INVALID'].includes(status) ? status : CONTROL_STATE.NONE
-      );
+      // At some point, with Angular 14, we started receiving the update for the control.touched
+      // later than this moment in code. It depends on the order of imports of ClarityModule and
+      // the FormsModule. This delay makes sure the touched state is properly updated.
+      setTimeout(() => {
+        this._statusChanges.next(
+          this.control.touched && ['VALID', 'INVALID'].includes(status) ? status : CONTROL_STATE.NONE
+        );
+      });
     }
   }
 

--- a/projects/angular/src/forms/common/if-control-state/if-error.spec.ts
+++ b/projects/angular/src/forms/common/if-control-state/if-error.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { Component } from '@angular/core';
-import { TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormControl, FormsModule, Validators } from '@angular/forms';
 
 import { ClrIconModule } from '../../../icon/icon.module';
@@ -73,15 +73,16 @@ export default function (): void {
         expect(fixture.nativeElement.innerHTML).not.toContain(errorMessage);
       });
 
-      it('displays the error message after touched on general errors', () => {
+      it('displays the error message after touched on general errors', fakeAsync(() => {
         expect(fixture.nativeElement.innerHTML).not.toContain(errorMessage);
         const control = new FormControl('', Validators.required);
         control.markAsTouched();
         ngControlService.setControl(control);
         ifControlStateService.triggerStatusChange();
         fixture.detectChanges();
+        tick();
         expect(fixture.nativeElement.innerHTML).toContain(errorMessage);
-      });
+      }));
     });
 
     describe('specific error', () => {
@@ -102,47 +103,52 @@ export default function (): void {
         expect(fixture.nativeElement.innerHTML).not.toContain(errorMessage);
       });
 
-      it('displays the error when the specific error is defined', () => {
+      it('displays the error when the specific error is defined', fakeAsync(() => {
         expect(fixture.nativeElement.innerHTML).not.toContain(errorMessage);
         const control = new FormControl('', [Validators.required, Validators.minLength(5)]);
         control.markAsTouched();
         ngControlService.setControl(control);
         ifControlStateService.triggerStatusChange();
+        tick();
         fixture.detectChanges();
         expect(fixture.nativeElement.innerHTML).toContain(errorMessage);
-      });
+      }));
 
-      it('hides the message even when it is invalid due to a different validation error', () => {
+      it('hides the message even when it is invalid due to a different validation error', fakeAsync(() => {
         expect(fixture.nativeElement.innerHTML).not.toContain(errorMessage);
         const control = new FormControl('abc', [Validators.required, Validators.minLength(5)]);
         ngControlService.setControl(control);
         ifControlStateService.triggerStatusChange();
+        tick();
         fixture.detectChanges();
         expect(fixture.nativeElement.innerHTML).not.toContain(errorMessage);
         expect(fixture.nativeElement.innerHTML).toContain(minLengthMessage);
-      });
+      }));
 
-      it('displays the error message with values from error object in context', () => {
+      it('displays the error message with values from error object in context', fakeAsync(() => {
         const control = new FormControl('abcdef', [Validators.maxLength(5)]);
         ngControlService.setControl(control);
         ifControlStateService.triggerStatusChange();
+        tick();
         fixture.detectChanges();
         expect(fixture.nativeElement.innerHTML).toContain(`${maxLengthMessage}-5-6`);
-      });
+      }));
 
-      it('updates the error message with values from error object in context', () => {
+      it('updates the error message with values from error object in context', fakeAsync(() => {
         const control = new FormControl('abcdef', [Validators.maxLength(5)]);
         ngControlService.setControl(control);
         ifControlStateService.triggerStatusChange();
+        tick();
         fixture.detectChanges();
         expect(fixture.nativeElement.innerHTML).toContain(`${maxLengthMessage}-5-6`);
 
         control.setValue('abcdefg');
+        tick();
         fixture.detectChanges();
         expect(fixture.nativeElement.innerHTML).toContain(`${maxLengthMessage}-5-7`);
-      });
+      }));
 
-      it('should show error only when they are required', () => {
+      it('should show error only when they are required', fakeAsync(() => {
         const control = new FormControl(undefined, [
           Validators.required,
           Validators.minLength(4),
@@ -151,6 +157,7 @@ export default function (): void {
         control.markAsTouched();
         ngControlService.setControl(control);
         ifControlStateService.triggerStatusChange();
+        tick();
         fixture.detectChanges();
 
         // Required message
@@ -160,6 +167,7 @@ export default function (): void {
 
         // MinLength message
         control.setValue('abc');
+        tick();
         fixture.detectChanges();
         expect(fixture.nativeElement.innerHTML).not.toContain(errorMessage);
         expect(fixture.nativeElement.innerHTML).toContain(minLengthMessage);
@@ -167,6 +175,7 @@ export default function (): void {
 
         // MaxLength message
         control.setValue('abcdef');
+        tick();
         fixture.detectChanges();
         expect(fixture.nativeElement.innerHTML).not.toContain(errorMessage);
         expect(fixture.nativeElement.innerHTML).not.toContain(minLengthMessage);
@@ -174,11 +183,12 @@ export default function (): void {
 
         // No errors
         control.setValue('abcde');
+        tick();
         fixture.detectChanges();
         expect(fixture.nativeElement.innerHTML).not.toContain(errorMessage);
         expect(fixture.nativeElement.innerHTML).not.toContain(minLengthMessage);
         expect(fixture.nativeElement.innerHTML).not.toContain(maxLengthMessage);
-      });
+      }));
     });
   });
 }

--- a/projects/angular/src/forms/tests/container.spec.ts
+++ b/projects/angular/src/forms/tests/container.spec.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { async, TestBed } from '@angular/core/testing';
+import { fakeAsync, TestBed, tick, waitForAsync } from '@angular/core/testing';
 import { FormsModule, NgControl, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
@@ -194,14 +194,15 @@ function fullSpec(description, testContainer, directives: any | any[], testCompo
       expect(container.controlClass()).not.toContain('clr-col-12');
     });
 
-    it('tracks the validity of the form control', () => {
+    it('tracks the validity of the form control', fakeAsync(() => {
       expect(container.showInvalid).toBeFalse();
       markControlService.markAsTouched();
       fixture.detectChanges();
+      tick();
       expect(container.showInvalid).toBeTrue();
-    });
+    }));
 
-    it('tracks the disabled state', async(() => {
+    it('tracks the disabled state', waitForAsync(() => {
       const test = fixture.debugElement.componentInstance;
       test.disabled = true;
       fixture.detectChanges();

--- a/projects/angular/src/utils/testing/helpers.spec.ts
+++ b/projects/angular/src/utils/testing/helpers.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { DebugElement, InjectionToken, ModuleWithProviders, Type } from '@angular/core';
-import { ComponentFixture, TestBed, TestBedStatic, TestModuleMetadata } from '@angular/core/testing';
+import { ComponentFixture, TestBed, TestBedStatic, TestModuleMetadata, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { RouterModule } from '@angular/router';
 
@@ -156,6 +156,21 @@ export function addHelpersDeprecated(
       this._context.fixture.destroy();
     }
   });
+}
+
+/**
+ * Helper for testing requestAnimationFrame code. FakeAssync internally mocks requestAnimationFrame as setTimeout(16).
+ * That's why we need to test it with tick(16). 16 is not a truly magic number, it's the approximated single frame time
+ * of a 60 FPS refresh rate.
+ * @param fixture If fixture is provided we will also run change detection. Unlike the usual fakeAsync/tick scenario,
+ * where tick() follows the changeDetection, requestAnimationFrame may be used to setup preconditions for a change detection
+ * cycle, so it should precede a detectChanges call.
+ */
+export function animationFrameTick(fixture?: ComponentFixture<any>) {
+  tick(16);
+  if (fixture) {
+    fixture.detectChanges();
+  }
 }
 
 /*


### PR DESCRIPTION
Can be observed when FormsModule (ReactiveFormsModule) is imported after ClarityModule.
Due to the special module order requirements it can't be reproduced in tests, storybook or demo app.
This StackBlitz represents a patched version of the fix, which can be manually tested:
https://stackblitz.com/edit/input-on-blur-issue?file=src%2Fapp%2Fapp.component.html,src%2Fapp%2Fapp.module.ts,src%2Fapp%2Fapp.component.ts

Closes #385 

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Two blur events are needed to run validation. ClarityModule should be imported before ReactiveFormsModule.

Issue Number: #385

## What is the new behavior?
Evaluation of the validation state is postponed to next frame, so the import-dependent change of the "touched" property is guaranteed to be finalized.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
