### PR TITLE
fix(header): remove incorrect, duplicate `click` event handler

### DIFF
--- a/projects/angular/src/layout/nav/header.ts
+++ b/projects/angular/src/layout/nav/header.ts
@@ -22,7 +22,6 @@ import { ResponsiveNavCodes } from './responsive-nav-codes';
       [attr.aria-label]="
         openNavLevel !== responsiveNavCodes.NAV_LEVEL_1 ? commonStrings.keys.open : commonStrings.keys.close
       "
-      (click)="toggleNav(responsiveNavCodes.NAV_LEVEL_1)"
       [attr.aria-expanded]="openNavLevel === 1 ? 'true' : 'false'"
       (click)="openNav(responsiveNavCodes.NAV_LEVEL_1)"
     >


### PR DESCRIPTION
This was accidentally introduced in 1ce653a4bb444395d33c6f9d8f57ebcddb98537a.
