### PR TITLE
fix(stackview): fix focus outline in safari

### DIFF
--- a/projects/angular/src/data/stack-view/_stack-view.clarity.scss
+++ b/projects/angular/src/data/stack-view/_stack-view.clarity.scss
@@ -180,7 +180,8 @@ $styledInputs: 'input[type=text], input[type=password], input[type=number], inpu
       }
 
       &:focus {
-        outline: $clr_baselineRem_5px auto -webkit-focus-ring-color;
+        outline: $clr_baselineRem_1px auto -webkit-focus-ring-color;
+        outline-offset: -$clr_baselineRem_1px;
       }
     }
 


### PR DESCRIPTION
Outlines are external to the element. Safari can be more restrictive to such content and will not display it.
Same as in many other places in the project, we need to reposition the outline by some negative outline-offset.


## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Focus outline is not visible in Safari

Issue Number: #31 

## What is the new behavior?

Outline is visible in Safari and Chrome.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
