### PR TITLE
fix(datagrid): vertically center filter icons and select all checkbox

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -508,6 +508,11 @@
 
     .datagrid-select {
       min-width: $clr_baselineRem_0_375 - $clr-table-borderwidth; // This fixed an issue that made the cell too wide.
+      align-items: center;
+      .clr-checkbox-wrapper {
+        // compensate for the default checkbox margin, defined in its ::before section
+        margin-top: -1 * $clr_baselineRem_0_25;
+      }
     }
 
     .datagrid-signpost-trigger .signpost {
@@ -687,6 +692,7 @@
         display: flex;
         order: 99;
         margin-left: auto;
+        align-items: center;
       }
 
       .datagrid-filter-input-spacer {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When header text is in multiple lines, select-all checkbox and filter buttons are misaligned with the cell label, which is centered, while the buttons are top-aligned.

Issue Number: #156 

## What is the new behavior?

select-all checkbox and filter buttons are also centered now

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
