### PR TITLE
feat(stack-view): remove dead stack view `setsize` and `posinset` inputs 

### DIFF
--- a/.storybook/stories/stack-view/stack-block.stories.ts
+++ b/.storybook/stories/stack-view/stack-block.stories.ts
@@ -39,8 +39,6 @@ const defaultParameters: Parameters = {
   argTypes: {
     // inputs
     clrSbNotifyChange: { control: { disable: true }, table: { disable: true } }, // experimental
-    clrStackViewPosinset: { control: { disable: true }, table: { disable: true } }, // deprecated
-    clrStackViewSetsize: { control: { disable: true }, table: { disable: true } }, // deprecated
     // outputs
     clrSbExpandedChange: { control: { disable: true }, table: { disable: true } },
     // methods

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -3684,10 +3684,6 @@ export class ClrStackBlock implements OnInit {
     // (undocumented)
     get ariaExpanded(): string;
     ariaLevel: number;
-    // @deprecated (undocumented)
-    ariaPosinset: number;
-    // @deprecated (undocumented)
-    ariaSetsize: number;
     // (undocumented)
     get caretDirection(): string;
     // (undocumented)
@@ -3725,7 +3721,7 @@ export class ClrStackBlock implements OnInit {
     // (undocumented)
     uniqueId: string;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrStackBlock, "clr-stack-block", never, { "expanded": "clrSbExpanded"; "expandable": "clrSbExpandable"; "setChangedValue": "clrSbNotifyChange"; "ariaLevel": "clrStackViewLevel"; "ariaSetsize": "clrStackViewSetsize"; "ariaPosinset": "clrStackViewPosinset"; }, { "expandedChange": "clrSbExpandedChange"; }, ["stackBlockTitle"], ["clr-stack-label", "*", "clr-stack-block"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrStackBlock, "clr-stack-block", never, { "expanded": "clrSbExpanded"; "expandable": "clrSbExpandable"; "setChangedValue": "clrSbNotifyChange"; "ariaLevel": "clrStackViewLevel"; }, { "expandedChange": "clrSbExpandedChange"; }, ["stackBlockTitle"], ["clr-stack-label", "*", "clr-stack-block"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrStackBlock, [{ optional: true; skipSelf: true; }, null]>;
 }

--- a/projects/angular/src/data/stack-view/stack-block.spec.ts
+++ b/projects/angular/src/data/stack-view/stack-block.spec.ts
@@ -15,11 +15,7 @@ import { ClrStackViewModule } from './stack-view.module';
 
 @Component({
   template: `
-    <clr-stack-block
-      [clrStackViewLevel]="ariaLevel"
-      [clrStackViewSetsize]="ariaSetsize"
-      [clrStackViewPosinset]="ariaPosinset"
-    >
+    <clr-stack-block [clrStackViewLevel]="ariaLevel">
       <clr-stack-label>Label</clr-stack-label>
       <clr-stack-content>Content</clr-stack-content>
     </clr-stack-block>
@@ -28,8 +24,6 @@ import { ClrStackViewModule } from './stack-view.module';
 class BasicBlock {
   @ViewChild(ClrStackBlock) blockInstance: ClrStackBlock;
   ariaLevel: number;
-  ariaSetsize: number;
-  ariaPosinset: number;
 }
 
 @Component({

--- a/projects/angular/src/data/stack-view/stack-block.ts
+++ b/projects/angular/src/data/stack-view/stack-block.ts
@@ -133,24 +133,6 @@ export class ClrStackBlock implements OnInit {
    */
   @Input('clrStackViewLevel') ariaLevel: number;
 
-  /**
-   * @deprecated
-   * Total number of rows in a given group
-   * - removed per a11y (see: VPAT-592)
-   * - remains here and unused to avoid breaking change to the public API
-   * - remove in v14
-   */
-  @Input('clrStackViewSetsize') ariaSetsize: number;
-
-  /**
-   * @deprecated
-   * The position of the row inside the grouped by level rows
-   * - removed per a11y (see: VPAT-592)
-   * - remains here and unused to avoid breaking change to the public API
-   * - remove in v14
-   */
-  @Input('clrStackViewPosinset') ariaPosinset: number;
-
   /*
    * This would be more efficient with @ContentChildren, with the parent ClrStackBlock
    * querying for children StackBlocks, but this feature is not available when downgrading


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
  - vmware-clarity/website#51
- [N/A] If applicable, have a visual design approval

## PR Type

Remove dead code.

## What is the current behavior?

Dead inputs exist.

## What is the new behavior?

Dead inputs are removed.

## Does this PR introduce a breaking change?

Yes.

- The `clrStackViewSetsize` input has been removed.
- The `clrStackViewPosinset` input has been removed.
- These inputs had no effect. The functionality was previously removed.