### PR TITLE
feat(datagrid): remove `dategrid*` properties from `ClrCommonStrings`

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -920,14 +920,6 @@ export interface ClrCommonStrings {
     datagridExpandableRowsHelperText?: string;
     datagridFilterAriaLabel?: string;
     datagridFilterDialogAriaLabel?: string;
-    // @deprecated (undocumented)
-    dategridExpandableBeginningOf?: string;
-    // @deprecated (undocumented)
-    dategridExpandableEndOf?: string;
-    // @deprecated (undocumented)
-    dategridExpandableRowContent?: string;
-    // @deprecated (undocumented)
-    dategridExpandableRowsHelperText?: string;
     // (undocumented)
     datepickerCurrentDecade: string;
     // (undocumented)

--- a/projects/angular/src/data/datagrid/datagrid-row-detail.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row-detail.spec.ts
@@ -54,19 +54,12 @@ export default function (): void {
       const commonStrings = new ClrCommonStringsService();
       const rows: HTMLElement[] = context.clarityElement.querySelectorAll('.clr-sr-only');
 
-      // TODO: @deprecated - dategrid* keys are deprecated. Remove in v14.
       const first = [
-        commonStrings.keys.dategridExpandableBeginningOf,
-        commonStrings.keys.dategridExpandableRowContent,
-        commonStrings.keys.dategridExpandableRowsHelperText,
-        commonStrings.keys.dategridExpandableBeginningOf || commonStrings.keys.datagridExpandableBeginningOf,
-        commonStrings.keys.dategridExpandableRowContent || commonStrings.keys.datagridExpandableRowContent,
-        commonStrings.keys.dategridExpandableRowsHelperText || commonStrings.keys.datagridExpandableRowsHelperText,
+        commonStrings.keys.datagridExpandableBeginningOf,
+        commonStrings.keys.datagridExpandableRowContent,
+        commonStrings.keys.datagridExpandableRowsHelperText,
       ];
-      const last = [
-        commonStrings.keys.dategridExpandableEndOf || commonStrings.keys.datagridExpandableEndOf,
-        commonStrings.keys.dategridExpandableRowContent || commonStrings.keys.datagridExpandableRowContent,
-      ];
+      const last = [commonStrings.keys.datagridExpandableEndOf, commonStrings.keys.datagridExpandableRowContent];
 
       expect(rows[0].innerText.trim()).toBe(first.join(' ').trim());
       expect(rows[1].innerText.trim()).toBe(last.join(' ').trim());

--- a/projects/angular/src/data/datagrid/datagrid-row-detail.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row-detail.ts
@@ -21,11 +21,10 @@ import { Selection } from './providers/selection';
  */
 @Component({
   selector: 'clr-dg-row-detail',
-  // TODO: @deprecated - dategrid* keys are deprecated. Remove in v14.
   template: `
     <div class="clr-sr-only">
       {{ beginningOfExpandableContentAriaText }}
-      {{ commonStrings.keys.dategridExpandableRowsHelperText || commonStrings.keys.datagridExpandableRowsHelperText }}
+      {{ commonStrings.keys.datagridExpandableRowsHelperText }}
     </div>
     <ng-content></ng-content>
     <div class="clr-sr-only">{{ endOfExpandableContentAriaText }}</div>
@@ -71,25 +70,21 @@ export class ClrDatagridRowDetail implements AfterContentInit, OnDestroy {
     this.subscriptions.forEach(sub => sub.unsubscribe());
   }
 
-  // TODO: @deprecated - dategrid* keys are deprecated. Remove in v14.
   @Input('clrRowDetailBeginningAriaText') _beginningOfExpandableContentAriaText: string;
   get beginningOfExpandableContentAriaText() {
     return (
       this._beginningOfExpandableContentAriaText ||
-      `${
-        this.commonStrings.keys.dategridExpandableBeginningOf || this.commonStrings.keys.datagridExpandableBeginningOf
-      } 
-      ${this.commonStrings.keys.dategridExpandableRowContent || this.commonStrings.keys.datagridExpandableRowContent}`
+      `${this.commonStrings.keys.datagridExpandableBeginningOf} 
+      ${this.commonStrings.keys.datagridExpandableRowContent}`
     );
   }
 
-  // TODO: @deprecated - dategrid* keys are deprecated. Remove in v14.
   @Input('clrRowDetailEndAriaText') _endOfExpandableContentAriaText: string;
   get endOfExpandableContentAriaText() {
     return (
       this._endOfExpandableContentAriaText ||
-      `${this.commonStrings.keys.dategridExpandableEndOf || this.commonStrings.keys.datagridExpandableEndOf} 
-      ${this.commonStrings.keys.dategridExpandableRowContent || this.commonStrings.keys.datagridExpandableRowContent}`
+      `${this.commonStrings.keys.datagridExpandableEndOf} 
+      ${this.commonStrings.keys.datagridExpandableRowContent}`
     );
   }
 }

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -241,22 +241,6 @@ export interface ClrCommonStrings {
   timelineStepProcessing: string;
 
   // Datagrid Helper text for expandable rows
-  /**
-   * @deprecated Should be removed in v14
-   */
-  dategridExpandableBeginningOf?: string;
-  /**
-   * @deprecated Should be removed in v14
-   */
-  dategridExpandableEndOf?: string;
-  /**
-   * @deprecated Should be removed in v14
-   */
-  dategridExpandableRowContent?: string;
-  /**
-   * @deprecated Should be removed in v14
-   */
-  dategridExpandableRowsHelperText?: string;
   datagridExpandableBeginningOf?: string;
   datagridExpandableEndOf?: string;
   datagridExpandableRowContent?: string;


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Remove deprecated feature.

## What is the current behavior?

There are two sets of common strings for the same things, one of which is misspelled.

## What is the new behavior?

The `dategrid*` common strings are removed in favor of the `datagrid*` properties.

## Does this PR introduce a breaking change?

Yes. The misspelled `dategrid*` common strings are removed. Please rename these properties to `datagrid*`.