### PR TITLE
feat(stepper): remove `aria-live` announcement for error state

### DIFF
--- a/projects/angular/src/accordion/accordion-panel.html
+++ b/projects/angular/src/accordion/accordion-panel.html
@@ -1,8 +1,4 @@
 <ng-container *ngIf="panel | async; let panel">
-  <div *ngIf="panel.status !== AccordionStatus.Inactive" aria-live="assertive" class="clr-sr-only">
-    <ng-container *ngIf="panel.status === AccordionStatus.Error">{{commonStrings.keys.danger}}</ng-container>
-  </div>
-
   <div [ngClass]="getPanelStateClasses(panel)">
     <div class="clr-accordion-header">
       <button

--- a/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
+++ b/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
@@ -81,20 +81,6 @@ describe('ClrStep Reactive Forms', () => {
       expect(stepperPanelElement.classList.contains('clr-accordion-panel')).toBe(true);
     });
 
-    it('should show the appropriate aria-live message based on form state', () => {
-      const mockStep = new AccordionPanelModel('groupName', 0);
-      const stepperService = fixture.debugElement.query(By.directive(ClrStepperPanel)).injector.get(StepperService);
-      let liveSection: HTMLElement = fixture.nativeElement.querySelector('[aria-live="assertive"]');
-      expect(liveSection).toBe(null);
-
-      mockStep.status = AccordionStatus.Error;
-      (stepperService as MockStepperService).step.next(mockStep);
-      fixture.detectChanges();
-      liveSection = fixture.nativeElement.querySelector('[aria-live="assertive"]');
-      expect(liveSection).toBeTruthy();
-      expect(liveSection.innerText.trim()).toBe('Error');
-    });
-
     it('should show appropriate screen reader only status in button based on form state', () => {
       const mockStep = new AccordionPanelModel('groupName', 0);
       const stepperService = fixture.debugElement.query(By.directive(ClrStepperPanel)).injector.get(StepperService);

--- a/projects/angular/src/forms/datepicker/daypicker.spec.ts
+++ b/projects/angular/src/forms/datepicker/daypicker.spec.ts
@@ -138,9 +138,7 @@ export default function () {
       });
 
       it('should have text based boundaries for screen readers', () => {
-        const srOnlyElements: HTMLDivElement[] = context.clarityElement.querySelectorAll(
-          '.clr-sr-only:not([aria-live])'
-        );
+        const srOnlyElements: HTMLDivElement[] = context.clarityElement.querySelectorAll('.clr-sr-only');
 
         expect(srOnlyElements[0].innerText).toBe('Beginning of Modal Content');
         expect(srOnlyElements[1].innerText).toBe('End of Modal Content');


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Remove feature.

## What is the current behavior?

Automatic aria-live announcements by the stepper for error state.

## What is the new behavior?

No automatic aria-live announcements by the stepper.

## Does this PR introduce a breaking change?

Yes. The stepper will no longer announce error states. Applications can use `LiveAnnouncer` from `@angular/cdk` to handle any required announcements.