### PR TITLE
 fix(datagrid): apply correct styles to parent datagrid when detail open

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1653,8 +1653,8 @@
     min-width: $clr_baselineRem_10;
   }
 
-  .datagrid-detail-open > .datagrid-outer-wrapper > .datagrid-inner-wrapper {
-    & {
+  .datagrid-detail-open {
+    & > .datagrid-outer-wrapper > .datagrid-inner-wrapper {
       div.datagrid-table-wrapper {
         /**
          * So the content with no spaces in the cell doesn't get cut when and the row selected indicator is not hidden

--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1654,35 +1654,37 @@
   }
 
   .datagrid-detail-open > .datagrid-outer-wrapper > .datagrid-inner-wrapper {
-    div.datagrid-table-wrapper {
-      /**
+    & {
+      div.datagrid-table-wrapper {
+        /**
          * So the content with no spaces in the cell doesn't get cut when and the row selected indicator is not hidden
          * e.g. Helloworldthisisaveryveryveryveryverylongcontent
          */
-      display: block;
-      /**
+        display: block;
+        /**
          * To get rid of detail-pane overlapping the content inside the rows
          */
-      overflow: hidden;
-    }
+        overflow: hidden;
+      }
 
-    clr-dg-cell {
+      clr-dg-cell {
+        /**
+         * Since we use inline width of each column in order to maintain manual resizing,
+         * we need to use !important to override the inline width.
+         */
+        width: 100% !important;
+      }
+
       /**
-           * Since we use inline width of each column in order to maintain manual resizing,
-           * we need to use !important to override the inline width.
-           */
-      width: 100% !important;
-    }
-
-    /**
        * Needed to prevent hidding the sorting and filtering icons
        */
-    clr-dg-column:first-child {
-      /**
-           * Since we use inline width of each column in order to maintain manual resizing,
-           * we need to use !important to override the inline width.
-           */
-      width: auto !important;
+      clr-dg-column:first-child {
+        /**
+          * Since we use inline width of each column in order to maintain manual resizing,
+          * we need to use !important to override the inline width.
+          */
+        width: auto !important;
+      }
     }
 
     .datagrid {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The datagrid detail pane did not take 2/3 of the space when open. This is a regression that I introduced in #339.

Issue Number: #432

## What is the new behavior?

The datagrid detail pane did takes 2/3 of the space when open. Some other styles are also fixed on the parent datagrid.

## Does this PR introduce a breaking change?

No.