### PR TITLE
feat(dropdown): remove `disabled` attribute from `clrDropdownItem`

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -2112,16 +2112,11 @@ export class ClrDropdownItem {
     set disabled(value: boolean | string);
     // (undocumented)
     get disabled(): boolean | string;
-    set disabledDeprecated(value: boolean | string);
-    // (undocumented)
-    get disabledDeprecated(): boolean | string;
     set dropdownItemId(value: string);
     // (undocumented)
     get dropdownItemId(): string;
     // (undocumented)
-    setByDeprecatedDisabled: boolean;
-    // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<ClrDropdownItem, "[clrDropdownItem]", never, { "disabled": "clrDisabled"; "disabledDeprecated": "disabled"; "dropdownItemId": "id"; }, {}, never, never, false, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<ClrDropdownItem, "[clrDropdownItem]", never, { "disabled": "clrDisabled"; "dropdownItemId": "id"; }, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrDropdownItem, never>;
 }

--- a/projects/angular/src/popover/dropdown/dropdown-item.spec.ts
+++ b/projects/angular/src/popover/dropdown/dropdown-item.spec.ts
@@ -70,34 +70,5 @@ export default function (): void {
       this.detectChanges();
       expect(this.getClarityProvider(FocusableItem).disabled).toBe(false);
     });
-
-    /*
-     * @deprecated since 3.0, remove in 4.0. tests for the deprecated [disabled] attribute
-     */
-    it('sets the disabled attribute if set by input', function (this: Context) {
-      expect(this.clarityElement.getAttribute('disabled')).toBeNull();
-      this.hostComponent.disabledDeprecated = true;
-      this.detectChanges();
-      expect(this.clarityElement.getAttribute('disabled')).toBe('');
-    });
-
-    it('sets aria-disabled to true if the FocusableItem is disabled', function (this: Context) {
-      expect(this.clarityElement.getAttribute('aria-disabled')).toBe('false');
-      this.hostComponent.disabledDeprecated = true;
-      this.detectChanges();
-      expect(this.clarityElement.getAttribute('aria-disabled')).toBe('true');
-    });
-
-    it('updates the disabled property of the FocusableItem', function (this: Context) {
-      this.hostComponent.disabledDeprecated = true;
-      this.detectChanges();
-      expect(this.getClarityProvider(FocusableItem).disabled).toBe(true);
-      this.hostComponent.disabledDeprecated = false;
-      this.detectChanges();
-      expect(this.getClarityProvider(FocusableItem).disabled).toBe(false);
-    });
-    /*
-     * End @deprecated section
-     */
   });
 }

--- a/projects/angular/src/popover/dropdown/dropdown-item.ts
+++ b/projects/angular/src/popover/dropdown/dropdown-item.ts
@@ -18,7 +18,6 @@ import { RootDropdownService } from './providers/dropdown.service';
     '[class.dropdown-item]': 'true',
     '[attr.role]': '"menuitem"',
     '[attr.aria-disabled]': 'disabled',
-    '[attr.disabled]': "(disabled && setByDeprecatedDisabled)? '' : null",
     '[attr.id]': 'dropdownItemId',
   },
   providers: [BASIC_FOCUSABLE_ITEM_PROVIDER],
@@ -30,8 +29,6 @@ export class ClrDropdownItem {
     private focusableItem: FocusableItem
   ) {}
 
-  setByDeprecatedDisabled = false;
-
   @Input('clrDisabled')
   set disabled(value: boolean | string) {
     // Empty string attribute evaluates to false but should disable the item, so we need to add a special case for it.
@@ -39,20 +36,6 @@ export class ClrDropdownItem {
   }
 
   get disabled() {
-    return this.focusableItem.disabled;
-  }
-
-  /*
-   * @deprecated since 3.0, remove in 4.0. the presence of this attribute makes it not-focusable in IE11. Use [clrDisabled] input instead.
-   */
-  @Input('disabled')
-  set disabledDeprecated(value: boolean | string) {
-    // Empty string attribute evaluates to false but should disable the item, so we need to add a special case for it.
-    this.focusableItem.disabled = !!value || value === '';
-    this.setByDeprecatedDisabled = true;
-  }
-
-  get disabledDeprecated() {
     return this.focusableItem.disabled;
   }
 


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
  - The docs already explain this.
- [N/A] If applicable, have a visual design approval

## PR Type

Remove deprecated feature.

## What is the current behavior?

The `clrDropdownItem` directive supports the `disabled` attribute. Using the `disabled` attribute on a `clrDropdownItem` that is a `button` element breaks keyboard navigation. Focus gets lost on the disabled item.

## What is the new behavior?

The `clrDropdownItem` directive does not support the `disabled` attribute.

## Does this PR introduce a breaking change?

Yes. Use `clrDisabled` instead of `disabled` to disable a `clrDropdownItem`.