### PR TITLE
feat: remove `datepickerToggle` fallback common string property

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -914,8 +914,6 @@ export interface ClrCommonStrings {
     // (undocumented)
     datepickerSelectYearText: string;
     // (undocumented)
-    datepickerToggle: string;
-    // (undocumented)
     datepickerToggleChangeDateLabel: string;
     // (undocumented)
     datepickerToggleChooseDateLabel: string;

--- a/projects/angular/src/forms/datepicker/date-container.ts
+++ b/projects/angular/src/forms/datepicker/date-container.ts
@@ -187,13 +187,11 @@ export class ClrDateContainer extends ClrAbstractContainer implements AfterViewI
     if (day) {
       const formattedDate = this.dateIOService.toLocaleDisplayFormatString(day.toDate());
 
-      return (
-        this.commonStrings.parse(this.commonStrings.keys.datepickerToggleChangeDateLabel, {
-          SELECTED_DATE: formattedDate,
-        }) || this.commonStrings.keys.datepickerToggle
-      );
+      return this.commonStrings.parse(this.commonStrings.keys.datepickerToggleChangeDateLabel, {
+        SELECTED_DATE: formattedDate,
+      });
     }
-    return this.commonStrings.keys.datepickerToggleChooseDateLabel || this.commonStrings.keys.datepickerToggle;
+    return this.commonStrings.keys.datepickerToggleChooseDateLabel;
   }
 
   private listenForDateChanges() {

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -57,7 +57,6 @@ export const commonStringsDefault: ClrCommonStrings = {
   alertCloseButtonAriaLabel: 'Close alert',
   // Date Picker
   datepickerDialogLabel: 'Choose date',
-  datepickerToggle: 'Toggle datepicker',
   datepickerToggleChooseDateLabel: 'Choose date',
   datepickerToggleChangeDateLabel: 'Change date, {SELECTED_DATE}',
   datepickerPreviousMonth: 'Previous month',

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -207,7 +207,6 @@ export interface ClrCommonStrings {
    * Datepicker UI labels
    */
   datepickerDialogLabel: string;
-  datepickerToggle: string;
   datepickerToggleChooseDateLabel: string;
   datepickerToggleChangeDateLabel: string;
   datepickerPreviousMonth: string;


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
  - https://github.com/vmware-clarity/website/pull/58
- [N/A] If applicable, have a visual design approval

## PR Type

Remove unnecessary code.

## What is the current behavior?

The `datepickerToggle` exists and is only used as a fallback.

## What is the new behavior?

The `datepickerToggleChooseDateLabel` and `datepickerToggleChangeDateLabel` strings should be used instead.

## Does this PR introduce a breaking change?

Yes. The `datepickerToggle` common string property was removed. Use `datepickerToggleChooseDateLabel` and `datepickerToggleChangeDateLabel` instead.