### PR TITLE
fix(tree-view): associate tree node content with checkbox as label

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -4033,7 +4033,7 @@ export class ClrTree<T> implements AfterContentInit, OnDestroy {
 }
 
 // @public (undocumented)
-export class ClrTreeNode<T> implements OnInit, AfterContentInit, OnDestroy {
+export class ClrTreeNode<T> implements OnInit, AfterContentInit, AfterViewInit, OnDestroy {
     constructor(platformId: any, parent: ClrTreeNode<T>, featuresService: TreeFeaturesService<T>, expandService: IfExpandService, commonStrings: ClrCommonStringsService, focusManager: TreeFocusManagerService<T>, elementRef: ElementRef<HTMLElement>, injector: Injector);
     // (undocumented)
     get ariaSelected(): boolean;
@@ -4068,6 +4068,8 @@ export class ClrTreeNode<T> implements OnInit, AfterContentInit, OnDestroy {
     _model: TreeNodeModel<T>;
     // (undocumented)
     ngAfterContentInit(): void;
+    // (undocumented)
+    ngAfterViewInit(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)

--- a/projects/angular/src/data/tree-view/_tree-view.clarity.scss
+++ b/projects/angular/src/data/tree-view/_tree-view.clarity.scss
@@ -165,20 +165,4 @@
   .clr-tree-node-content-container > .clr-checkbox-wrapper:first-child {
     margin-left: $clr-tree-node-touch-target;
   }
-
-  .clr-treenode-content .label {
-    margin-left: $clr_baselineRem_0_25;
-  }
-
-  @include fixForMsEdge {
-    .clr-treenode-content .label {
-      margin-left: $clr_baselineRem_0_125;
-    }
-  }
-
-  @include fixForIE10AndUp {
-    .clr-treenode-content .label {
-      margin-left: $clr_baselineRem_0_125;
-    }
-  }
 }

--- a/projects/angular/src/data/tree-view/tree-node.html
+++ b/projects/angular/src/data/tree-view/tree-node.html
@@ -44,15 +44,21 @@
       (focus)="focusTreeNode()"
       tabindex="-1"
     />
-    <label for="{{nodeId}}-check" class="clr-control-label"></label>
+    <label for="{{nodeId}}-check">
+      <ng-container [ngTemplateOutlet]="treenodeContent"></ng-container>
+    </label>
   </div>
-  <div class="clr-treenode-content" (mousedown)="focusTreeNode()">
+  <div class="clr-treenode-content" (mousedown)="focusTreeNode()" *ngIf="!featuresService.selectable">
+    <ng-container [ngTemplateOutlet]="treenodeContent"></ng-container>
+  </div>
+
+  <ng-template #treenodeContent>
     <ng-content></ng-content>
     <div class="clr-sr-only" *ngIf="featuresService.selectable || ariaSelected">
       <span *ngIf="ariaSelected"> selected</span>
       <span *ngIf="!ariaSelected"> unselected</span>
     </div>
-  </div>
+  </ng-template>
 </div>
 <div
   class="clr-treenode-children"

--- a/projects/angular/src/data/tree-view/tree-node.ts
+++ b/projects/angular/src/data/tree-view/tree-node.ts
@@ -8,6 +8,7 @@ import { animate, state, style, transition, trigger } from '@angular/animations'
 import { isPlatformBrowser } from '@angular/common';
 import {
   AfterContentInit,
+  AfterViewInit,
   Component,
   ContentChildren,
   ElementRef,
@@ -62,7 +63,7 @@ const TREE_TYPE_AHEAD_TIMEOUT = 200;
     '[class.clr-tree-node]': 'true',
   },
 })
-export class ClrTreeNode<T> implements OnInit, AfterContentInit, OnDestroy {
+export class ClrTreeNode<T> implements OnInit, AfterContentInit, AfterViewInit, OnDestroy {
   STATES = ClrSelectedState;
   private skipEmitChange = false;
   isModelLoading = false;
@@ -207,10 +208,6 @@ export class ClrTreeNode<T> implements OnInit, AfterContentInit, OnDestroy {
   }
 
   ngAfterContentInit() {
-    if (!this._model.textContent) {
-      this._model.textContent = trimAndLowerCase(this.elementRef.nativeElement.textContent);
-    }
-
     this.subscriptions.push(
       this.typeAheadKeyEvent.pipe(debounceTime(TREE_TYPE_AHEAD_TIMEOUT)).subscribe((bufferedKeys: string) => {
         this.focusManager.focusNodeStartsWith(bufferedKeys, this._model);
@@ -218,6 +215,12 @@ export class ClrTreeNode<T> implements OnInit, AfterContentInit, OnDestroy {
         this.typeAheadKeyBuffer = '';
       })
     );
+  }
+
+  ngAfterViewInit() {
+    if (!this._model.textContent) {
+      this._model.textContent = trimAndLowerCase(this.elementRef.nativeElement.textContent);
+    }
   }
 
   ngOnDestroy() {


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The tree node content is not a label for the checkbox; therefore, it is not included in the checkbox's click target.

Issue Number: VPAT-791

## What is the new behavior?

The tree node content is rendered in the checkbox's label; therefore, it is included in the checkbox's click target.

## Does this PR introduce a breaking change?

Technically, yes. The internal DOM structure of the tree node component has been changed. The `.clr-treenode-content` element is no longer rendered for selectable tree nodes; instead, the tree node content is rendered inside the checkbox's label element.