### PR TITLE
fix(datagrid): show full border when detail pane is open

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1695,12 +1695,12 @@
 
   .datagrid-detail-open {
     & > .datagrid-outer-wrapper > .datagrid-inner-wrapper {
-      div.datagrid-table-wrapper {
+      div.datagrid-table {
         /**
          * So the content with no spaces in the cell doesn't get cut when and the row selected indicator is not hidden
          * e.g. Helloworldthisisaveryveryveryveryverylongcontent
          */
-        display: block;
+        max-width: 100%;
         /**
          * To get rid of detail-pane overlapping the content inside the rows
          */


### PR DESCRIPTION
This fixes a regression that was introduced in #302.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The border between the column and the detail pane does not extend to the placeholder element below the rows.

![image](https://user-images.githubusercontent.com/7399499/211078756-04f6de30-a0f0-40cd-a9b9-b3322ec9a53a.png)

## What is the new behavior?

The border between the column and the detail pane extends to the placeholder element below the rows.

![image](https://user-images.githubusercontent.com/7399499/211079191-e92427e4-4812-48f2-9167-cb0108edb3d0.png)

## Does this PR introduce a breaking change?

No.