### PR TITLE
chore: remove unnecessary annotation comment

### DIFF
--- a/projects/angular/src/popover/common/abstract-popover.ts
+++ b/projects/angular/src/popover/common/abstract-popover.ts
@@ -22,7 +22,6 @@ import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-t
 import { Point, Popover } from './popover';
 import { PopoverOptions } from './popover-options.interface';
 
-// Literally any annotation would work here, but writing our own @HoneyBadger annotation feels overkill.
 @Directive()
 export abstract class AbstractPopover implements AfterViewChecked, OnDestroy {
   constructor(injector: Injector, @SkipSelf() protected parentHost: ElementRef) {


### PR DESCRIPTION
It is common for base classes of components/directives to use the directive decorator. I think it may even be required now.