### PR TITLE
fix(modal): capture and return focus

### DIFF
--- a/projects/angular/src/modal/modal.html
+++ b/projects/angular/src/modal/modal.html
@@ -4,7 +4,7 @@
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
-<div cdkTrapFocus class="modal" *ngIf="_open">
+<div cdkTrapFocus [cdkTrapFocusAutoCapture]="true" class="modal" *ngIf="_open">
   <!--fixme: revisit when ngClass works with exit animation-->
   <div
     [@fadeDown]="skipAnimation"


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

- Focus was not captured on a focusable element inside the modal upon open.
- Focus was not returned to the previous focused element upon close of a modal.

## What is the new behavior?

- Focus is captured on a focusable element inside the modal upon open.
- Focus is returned to the previous focused element upon close of a modal.

This change contributes to fixing VPAT-735.

## Does this PR introduce a breaking change?

No.