### PR TITLE
Revert "fix(modal): capture and return focus"

### DIFF
--- a/projects/angular/src/modal/modal.html
+++ b/projects/angular/src/modal/modal.html
@@ -4,7 +4,7 @@
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
-<div cdkTrapFocus [cdkTrapFocusAutoCapture]="true" class="modal" *ngIf="_open">
+<div cdkTrapFocus class="modal" *ngIf="_open">
   <!--fixme: revisit when ngClass works with exit animation-->
   <div
     [@fadeDown]="skipAnimation"


### PR DESCRIPTION
This reverts #455 because it broke initial focus on the modal title.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The modal close button was focused on modal open instead of the title. This was a regression that I introduced in #455.

## What is the new behavior?

The modal title is focused on modal open. The focus is no longer returned to the previously closed element. I will need to find a different solution.

## Does this PR introduce a breaking change?

No.