### PR TITLE
fix(modal): restore focus to previously-focused element on close

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -2407,7 +2407,7 @@ class ClrExpandableAnimationModule {
 
 // @public (undocumented)
 export class ClrFocusOnViewInit implements AfterViewInit, OnDestroy {
-    constructor(el: ElementRef, platformId: any, focusOnViewInit: boolean, document: any, renderer: Renderer2, ngZone: NgZone);
+    constructor(el: ElementRef, platformId: any, focusOnViewInit: boolean, document: Document, renderer: Renderer2, ngZone: NgZone);
     // (undocumented)
     set isEnabled(value: boolean | string);
     // (undocumented)

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -2415,7 +2415,9 @@ export class ClrFocusOnViewInit implements AfterViewInit, OnDestroy {
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<ClrFocusOnViewInit, "[clrFocusOnViewInit]", never, { "isEnabled": "clrFocusOnViewInit"; }, {}, never>;
+    restoreFocusOnDestroy: boolean;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<ClrFocusOnViewInit, "[clrFocusOnViewInit]", never, { "isEnabled": "clrFocusOnViewInit"; "restoreFocusOnDestroy": "clrFocusOnViewInitRestoreFocusOnDestroy"; }, {}, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrFocusOnViewInit, never>;
 }

--- a/projects/angular/src/modal/modal.html
+++ b/projects/angular/src/modal/modal.html
@@ -25,7 +25,12 @@
 
       <div class="modal-content">
         <div class="modal-header--accessible">
-          <div class="modal-title-wrapper" id="{{modalId}}" clrFocusOnViewInit>
+          <div
+            class="modal-title-wrapper"
+            id="{{modalId}}"
+            clrFocusOnViewInit
+            [clrFocusOnViewInitRestoreFocusOnDestroy]="true"
+          >
             <ng-content select=".modal-title"></ng-content>
           </div>
           <button

--- a/projects/angular/src/modal/modal.spec.ts
+++ b/projects/angular/src/modal/modal.spec.ts
@@ -5,7 +5,7 @@
  */
 
 import { AnimationEvent } from '@angular/animations';
-import { Component, ViewChild } from '@angular/core';
+import { Component, ElementRef, ViewChild } from '@angular/core';
 import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -18,6 +18,8 @@ import { ClrModalModule } from './modal.module';
 
 @Component({
   template: `
+    <button #button></button>
+
     <clr-modal
       [(clrModalOpen)]="opened"
       [clrModalClosable]="closable"
@@ -36,6 +38,7 @@ import { ClrModalModule } from './modal.module';
   `,
 })
 class TestComponent {
+  @ViewChild('button') button: ElementRef<HTMLButtonElement>;
   @ViewChild(ClrModal) modalInstance: ClrModal;
 
   opened = true;
@@ -183,6 +186,22 @@ describe('Modal', () => {
   it('focuses on the title when opened', fakeAsync(() => {
     expect(document.activeElement).toEqual(fixture.nativeElement.querySelector('.modal-title-wrapper'));
   }));
+
+  it('restores focus the previously-focused element when closed', () => {
+    fixture.componentInstance.opened = false;
+    fixture.detectChanges();
+
+    fixture.componentInstance.button.nativeElement.focus();
+    fixture.detectChanges();
+
+    fixture.componentInstance.opened = true;
+    fixture.detectChanges();
+
+    fixture.componentInstance.opened = false;
+    fixture.detectChanges();
+
+    expect(document.activeElement).toEqual(fixture.componentInstance.button.nativeElement);
+  });
 
   it('supports a clrModalSize option', fakeAsync(() => {
     expect(compiled.querySelector('.modal-sm')).toBeNull();

--- a/projects/angular/src/utils/focus-trap/focus-trap.directive.ts
+++ b/projects/angular/src/utils/focus-trap/focus-trap.directive.ts
@@ -127,7 +127,9 @@ export class FocusTrapDirective implements OnInit, AfterViewInit, OnDestroy {
   }
 
   ngOnInit() {
-    if (isPlatformBrowser(this.platformId)) {
+    // We need to preserve the currently-focused element so that `clrFocusOnViewInit` can restore focus if needed.
+    // otherwise; focus the host element.
+    if (isPlatformBrowser(this.platformId) && !this.el.nativeElement.querySelector('[clrFocusOnViewInit]')) {
       this.renderer.setAttribute(this.el.nativeElement, 'tabindex', '-1');
       this.el.nativeElement.focus();
     }

--- a/projects/angular/src/utils/focus/focus-on-view-init/focus-on-view-init.spec.ts
+++ b/projects/angular/src/utils/focus/focus-on-view-init/focus-on-view-init.spec.ts
@@ -17,10 +17,10 @@ const focusOnViewInitProvider = { provide: FOCUS_ON_VIEW_INIT, useValue: true };
   template: `
     <button #dummyButton>dummy button</button>
     <div *ngIf="displayNoExistingTabindex">
-      <h1 clrFocusOnViewInit>Title</h1>
+      <h1 clrFocusOnViewInit [clrFocusOnViewInitRestoreFocusOnDestroy]="restoreFocusOnDestroy">Title</h1>
     </div>
     <div *ngIf="displayExistingTabindex">
-      <h1 clrFocusOnViewInit tabindex="5">Title</h1>
+      <h1 clrFocusOnViewInit [clrFocusOnViewInitRestoreFocusOnDestroy]="restoreFocusOnDestroy" tabindex="5">Title</h1>
     </div>
     <div *ngIf="displayDisabled">
       <h1 [clrFocusOnViewInit]="false">Title</h1>
@@ -28,6 +28,7 @@ const focusOnViewInitProvider = { provide: FOCUS_ON_VIEW_INIT, useValue: true };
   `,
 })
 class TestComponent {
+  restoreFocusOnDestroy = false;
   displayNoExistingTabindex = false;
   displayExistingTabindex = false;
   displayDisabled = false;
@@ -118,6 +119,44 @@ describe('ClrFocusOnViewInit', () => {
       component.displayDisabled = true;
       fixture.detectChanges();
       expect(document.activeElement).toBe(component.buttonElRef.nativeElement);
+    });
+
+    it('should restore focus if option enabled', () => {
+      // enable restore focus
+      component.restoreFocusOnDestroy = true;
+
+      // focus button
+      component.buttonElRef.nativeElement.focus();
+      expect(document.activeElement).toBe(component.buttonElRef.nativeElement);
+
+      // focus title
+      component.displayNoExistingTabindex = true;
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(component.focusOnItElRef.nativeElement);
+
+      // remove title, focus should return to button
+      component.displayNoExistingTabindex = false;
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(component.buttonElRef.nativeElement);
+    });
+
+    it('should not restore focus if option not enabled', () => {
+      // disable restore focus
+      component.restoreFocusOnDestroy = false;
+
+      // focus button
+      component.buttonElRef.nativeElement.focus();
+      expect(document.activeElement).toBe(component.buttonElRef.nativeElement);
+
+      // focus title
+      component.displayNoExistingTabindex = true;
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(component.focusOnItElRef.nativeElement);
+
+      // remove title, focus should default to body
+      component.displayNoExistingTabindex = false;
+      fixture.detectChanges();
+      expect(document.activeElement).toBe(document.body);
     });
   });
 

--- a/projects/angular/src/utils/focus/focus-on-view-init/focus-on-view-init.ts
+++ b/projects/angular/src/utils/focus/focus-on-view-init/focus-on-view-init.ts
@@ -68,14 +68,24 @@ export class ClrFocusOnViewInit implements AfterViewInit, OnDestroy {
     }
   }
 
+  @Input('clrFocusOnViewInitRestoreFocusOnDestroy') restoreFocusOnDestroy = false;
+
+  private previouslyFocusedElement: HTMLElement;
+
   ngAfterViewInit() {
     if (isPlatformBrowser(this.platformId) && this._isEnabled) {
+      this.previouslyFocusedElement = this.document.activeElement as HTMLElement;
+
       this.focusType = focusElement(this.document, this.renderer, this.el.nativeElement);
     }
   }
 
   ngOnDestroy(): void {
     this.destroy$.next();
+
+    if (this.restoreFocusOnDestroy && this.previouslyFocusedElement) {
+      focusElement(this.document, this.renderer, this.previouslyFocusedElement);
+    }
   }
 }
 

--- a/projects/angular/src/utils/focus/focus-on-view-init/focus-on-view-init.ts
+++ b/projects/angular/src/utils/focus/focus-on-view-init/focus-on-view-init.ts
@@ -33,17 +33,11 @@ export class ClrFocusOnViewInit implements AfterViewInit, OnDestroy {
     private el: ElementRef,
     @Inject(PLATFORM_ID) private platformId: any,
     @Inject(FOCUS_ON_VIEW_INIT) private focusOnViewInit: boolean,
-    @Inject(DOCUMENT) document: any,
+    @Inject(DOCUMENT) private document: Document,
     private renderer: Renderer2,
     ngZone: NgZone
   ) {
     this._isEnabled = this.focusOnViewInit;
-
-    // Angular compiler doesn't understand the type Document
-    // when working out the metadata for injectable parameters,
-    // even though it understands the injection token DOCUMENT
-    // https://github.com/angular/angular/issues/20351
-    this.document = document;
 
     ngZone.runOutsideAngular(() =>
       fromEvent(el.nativeElement, 'focusout')
@@ -58,7 +52,6 @@ export class ClrFocusOnViewInit implements AfterViewInit, OnDestroy {
     );
   }
 
-  private document: Document;
   private directFocus = true; // true if the element gets focused without need to set tabindex;
 
   private _isEnabled: boolean;


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

Focus is not restored to the previously-focused element when a modal is closed.

## What is the new behavior?

Focus is restored to the previously-focused element when a modal is closed.

## Does this PR introduce a breaking change?

No.