### PR TITLE
fix(wizard): restore wizard sidenav scss variables

### DIFF
--- a/projects/angular/src/utils/_overwrites.clarity.scss
+++ b/projects/angular/src/utils/_overwrites.clarity.scss
@@ -800,8 +800,11 @@ $clr-spinner-opacity: null; // 0.15
 /*================================================================================*/
 
 $clr-wizard-main-bgcolor: null; // $clr-color-neutral-0
+$clr-wizard-sidenav-bgcolor: null; // $clr-color-neutral-50
 $clr-wizard-default-space: null; // $clr_baselineRem_1
 $clr-wizard-main-textColor: null; // $clr-color-on-neutral-0
+$clr-wizard-sidenav-text: null; // $clr-color-neutral-900
+$clr-wizard-sidenav-text--active: null; // $clr-global-on-selection-color
 $clr-wizard-title-text: null; // $clr-color-neutral-1000
 $clr-wizard-stepnav-border-size: null; // $clr_baselineRem_4px
 $clr-wizard-stepnav-border-color: null; // $clr-color-neutral-200

--- a/projects/angular/src/utils/_theme.dark.clarity.scss
+++ b/projects/angular/src/utils/_theme.dark.clarity.scss
@@ -821,10 +821,13 @@ $clr-vertical-nav-trigger-divider-border-color: hsl(199, 19%, 17%);
   *
   * Usage: ../wizard/_wizard.clarity.scss
   */
+$clr-wizard-sidenav-bgcolor: hsl(201, 30%, 15%);
+$clr-wizard-sidenav-text--active: hsl(0, 0%, 100%);
 $clr-wizard-stepnav-active-bgcolor: hsl(203, 32%, 29%);
 $clr-wizard-stepnav-border-color: hsl(201, 14%, 27%);
 $clr-wizard-stepnav-border-color--active: hsl(92, 79%, 40%);
 $clr-wizard-step-nav-border-color: hsl(200, 30%, 12%);
+$clr-wizard-sidenav-text: hsl(203, 16%, 72%);
 $clr-wizard-title-text: hsl(210, 16%, 93%);
 $clr-wizard-main-textColor: hsl(203, 16%, 72%);
 $clr-wizard-stepnav-error-color: hsl(3, 90%, 62%);


### PR DESCRIPTION
This fixes mistakes I made in #368.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

Some wizard sidenav scss variables were missing.

## What is the new behavior?

The missing wizard sidenav scss variables are restored.

## Does this PR introduce a breaking change?

No.