### PR TITLE
fix(modal): prevent scrolling content under modal when tabbing

### DIFF
--- a/projects/angular/src/modal/modal.html
+++ b/projects/angular/src/modal/modal.html
@@ -4,9 +4,11 @@
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 
-<div cdkTrapFocus [cdkTrapFocusAutoCapture]="true" class="modal" *ngIf="_open">
+<div class="modal" *ngIf="_open">
   <!--fixme: revisit when ngClass works with exit animation-->
   <div
+    cdkTrapFocus
+    [cdkTrapFocusAutoCapture]="true"
     [@fadeDown]="skipAnimation"
     (@fadeDown.done)="fadeDone($event)"
     class="modal-dialog"


### PR DESCRIPTION
This fixes a regression I introduced in #431.

## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The content behind the modal would be scrolled when the user tabs through the modal.

## What is the new behavior?

The content behind the modal is not scrolled when the user tabs through the modal.

## Does this PR introduce a breaking change?

No.