### PR TITLE
fix(modal): focus modal title when modal opened

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -2691,7 +2691,7 @@ export class ClrModalModule {
     // Warning: (ae-forgotten-export) The symbol "i2_23" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrModalModule, [typeof i1_30.ClrModal, typeof i2_23.ClrModalBody], [typeof i6.CommonModule, typeof i39.CdkTrapFocusModule, typeof i3_2.ClrIconModule, typeof i7_6.ClrFocusOnViewInitModule], [typeof i1_30.ClrModal, typeof i2_23.ClrModalBody, typeof i3_2.ClrIconModule, typeof i7_6.ClrFocusOnViewInitModule]>;
+    static ɵmod: i0.ɵɵNgModuleDeclaration<ClrModalModule, [typeof i1_30.ClrModal, typeof i2_23.ClrModalBody], [typeof i6.CommonModule, typeof i39.CdkTrapFocusModule, typeof i3_2.ClrIconModule], [typeof i1_30.ClrModal, typeof i2_23.ClrModalBody, typeof i3_2.ClrIconModule]>;
 }
 
 // @public (undocumented)

--- a/projects/angular/src/modal/modal.html
+++ b/projects/angular/src/modal/modal.html
@@ -25,7 +25,7 @@
 
       <div class="modal-content">
         <div class="modal-header--accessible">
-          <div class="modal-title-wrapper" id="{{modalId}}" clrFocusOnViewInit>
+          <div class="modal-title-wrapper" id="{{modalId}}" cdkFocusInitial tabindex="-1">
             <ng-content select=".modal-title"></ng-content>
           </div>
           <button

--- a/projects/angular/src/modal/modal.module.ts
+++ b/projects/angular/src/modal/modal.module.ts
@@ -10,16 +10,15 @@ import { ClarityIcons, windowCloseIcon } from '@cds/core/icon';
 
 import { ClrIconModule } from '../icon/icon.module';
 import { CdkTrapFocusModule } from '../utils/cdk/cdk-trap-focus.module';
-import { ClrFocusOnViewInitModule } from '../utils/focus/focus-on-view-init/focus-on-view-init.module';
 import { ClrModal } from './modal';
 import { ClrModalBody } from './modal-body';
 
 export const CLR_MODAL_DIRECTIVES: Type<any>[] = [ClrModal, ClrModalBody];
 
 @NgModule({
-  imports: [CommonModule, CdkTrapFocusModule, ClrIconModule, ClrFocusOnViewInitModule],
+  imports: [CommonModule, CdkTrapFocusModule, ClrIconModule],
   declarations: [CLR_MODAL_DIRECTIVES],
-  exports: [CLR_MODAL_DIRECTIVES, ClrIconModule, ClrFocusOnViewInitModule],
+  exports: [CLR_MODAL_DIRECTIVES, ClrIconModule],
 })
 export class ClrModalModule {
   constructor() {

--- a/projects/angular/src/modal/modal.spec.ts
+++ b/projects/angular/src/modal/modal.spec.ts
@@ -67,7 +67,7 @@ describe('Modal', () => {
   let modal: ClrModal;
   const commonStrings = new ClrCommonStringsService();
 
-  beforeEach(() => {
+  beforeEach(async () => {
     TestBed.configureTestingModule({
       imports: [CdkTrapFocusModule, ClrModalModule, NoopAnimationsModule],
       declarations: [TestComponent, TestDefaultsComponent],
@@ -77,6 +77,8 @@ describe('Modal', () => {
     fixture.detectChanges();
     compiled = fixture.nativeElement;
     modal = fixture.componentInstance.modalInstance;
+
+    await fixture.whenStable();
   });
 
   function flushAndExpectOpen(componentFixture: ComponentFixture<any>, open: boolean): void {

--- a/projects/angular/src/wizard/wizard.spec.ts
+++ b/projects/angular/src/wizard/wizard.spec.ts
@@ -23,11 +23,13 @@ export default function (): void {
         let wizard: ClrWizard;
         let component: UnopenedWizardTestComponent;
 
-        beforeEach(function () {
+        beforeEach(async function () {
           context = this.create(ClrWizard, UnopenedWizardTestComponent);
           wizard = context.clarityDirective;
           component = context.hostComponent;
           context.detectChanges();
+
+          await context.fixture.whenStable();
         });
 
         describe('open', () => {
@@ -105,12 +107,14 @@ export default function (): void {
         let pageCollectionService: PageCollectionService;
         let wizard: ClrWizard;
 
-        beforeEach(function () {
+        beforeEach(async function () {
           context = this.create(ClrWizard, BasicWizardTestComponent);
           wizardNavigationService = context.getClarityProvider(WizardNavigationService);
           pageCollectionService = context.getClarityProvider(PageCollectionService);
           wizard = context.clarityDirective;
           context.detectChanges();
+
+          await context.fixture.whenStable();
         });
 
         describe('currentPage', () => {
@@ -234,10 +238,12 @@ export default function (): void {
       let context: TestContext<ClrWizard, TemplateApiWizardTestComponent>;
       let wizard: ClrWizard;
 
-      beforeEach(function () {
+      beforeEach(async function () {
         context = this.create(ClrWizard, TemplateApiWizardTestComponent);
         wizard = context.clarityDirective;
         context.detectChanges();
+
+        await context.fixture.whenStable();
       });
 
       describe('Current page onchange', () => {
@@ -616,10 +622,12 @@ export default function (): void {
       let context: TestContext<ClrWizard, DynamicWizardTestComponent>;
       let wizard: ClrWizard;
 
-      beforeEach(function () {
+      beforeEach(async function () {
         context = this.create(ClrWizard, DynamicWizardTestComponent);
         wizard = context.clarityDirective;
         context.detectChanges();
+
+        await context.fixture.whenStable();
       });
 
       it('pages can be added via an ngFor', () => {
@@ -726,10 +734,12 @@ export default function (): void {
       let context: TestContext<ClrWizard, TemplateApiWizardTestComponent>;
       let wizard: ClrWizard;
 
-      beforeEach(function () {
+      beforeEach(async function () {
         context = this.create(ClrWizard, TemplateApiWizardTestComponent);
         wizard = context.clarityDirective;
         context.detectChanges();
+
+        await context.fixture.whenStable();
       });
 
       describe('Page title focus', () => {
@@ -746,10 +756,12 @@ export default function (): void {
       let context: TestContext<ClrWizard, TemplateApiWizardTestComponent>;
       let wizard: ClrWizard;
 
-      beforeEach(function () {
+      beforeEach(async function () {
         context = this.create(ClrWizard, TemplateApiWizardTestComponent);
         wizard = context.clarityDirective;
         context.detectChanges();
+
+        await context.fixture.whenStable();
       });
 
       describe('aria-labelledby', () => {


### PR DESCRIPTION
This fixes a regression I introduced in #455.

## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The modal close button was focused on modal open instead of the title. This was a regression that I introduced in #455.

## What is the new behavior?

This modal title is focused on modal open.

## Does this PR introduce a breaking change?

Yes. The `ModalModule` no longer exports `ClrFocusOnViewInitModule`.