### PR TITLE
fix(tabs): ensure tabs are announced in the correct order

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -4179,8 +4179,6 @@ export class ClrTabs implements AfterContentInit, OnDestroy {
     // (undocumented)
     resetKeyFocusCurrentToActive(event: FocusEvent): void;
     // (undocumented)
-    get tabIds(): string;
-    // (undocumented)
     get tabLinkDirectives(): ClrTabLink[];
     // (undocumented)
     tabLinkElements: HTMLElement[];

--- a/projects/angular/src/layout/tabs/tabs.ts
+++ b/projects/angular/src/layout/tabs/tabs.ts
@@ -37,7 +37,6 @@ import { TABS_ID, TABS_ID_PROVIDER } from './tabs-id.provider';
     <ul
       class="nav"
       role="tablist"
-      [attr.aria-owns]="tabIds"
       [clrKeyFocus]="tabLinkElements"
       clrDirection="both"
       (clrFocusChange)="toggleOverflowOnPosition($event)"
@@ -149,10 +148,6 @@ export class ClrTabs implements AfterContentInit, OnDestroy {
 
   get activeTabPosition() {
     return this._tabLinkDirectives.findIndex(link => link.active);
-  }
-
-  get tabIds() {
-    return this.tabsService.children.map(tab => tab.tabLink.tabLinkId).join(' ');
   }
 
   get isCurrentInOverflow() {


### PR DESCRIPTION
closes: #451

aria-owns is not needed when dom structure conveys the correct order. it was leading to issues with screen readers when some tabs were conditionally rendered.

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Screen reader will report tabs in wrong order, because of the messed up aria-owns. Reproducible in Chrome.

Issue Number: #451 

## What is the new behavior?

Tabs are read in the correct order

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
