### PR TITLE
fix(datepicker): skip updating toggle button attributes when disabled

### DIFF
--- a/projects/angular/src/forms/datepicker/date-container.ts
+++ b/projects/angular/src/forms/datepicker/date-container.ts
@@ -203,10 +203,12 @@ export class ClrDateContainer extends ClrAbstractContainer implements AfterViewI
     return this.dateNavigationService.selectedDayChange
       .pipe(startWith(this.dateNavigationService.selectedDay))
       .subscribe(day => {
-        const label = this.getToggleButtonLabel(day);
-        const toggleEl = this.toggleButton.nativeElement;
-        this.renderer.setAttribute(toggleEl, 'aria-label', label);
-        this.renderer.setAttribute(toggleEl, 'title', label);
+        if (this.isEnabled) {
+          const label = this.getToggleButtonLabel(day);
+          const toggleEl = this.toggleButton.nativeElement;
+          this.renderer.setAttribute(toggleEl, 'aria-label', label);
+          this.renderer.setAttribute(toggleEl, 'title', label);
+        }
       });
   }
 


### PR DESCRIPTION
closes #310

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

On mobile, the native datepicker is used, so the toggle button is not present. This causes errors when the code attempts to update the toggle button's `title` and `aria-label` attributes.

Issue Number: #310

## What is the new behavior?

This fix simply skips updating the toggle button's attributes when it is not present.

## Does this PR introduce a breaking change?

No.