### PR TITLE
fix(vertical-nav): add aria list structure to vertical nav links 

### DIFF
--- a/projects/angular/src/layout/vertical-nav/vertical-nav-link.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav-link.ts
@@ -18,7 +18,9 @@ import { VerticalNavGroupService } from './providers/vertical-nav-group.service'
       <ng-content></ng-content>
     </span>
   `,
-  host: { class: 'nav-link' },
+  host: {
+    class: 'nav-link',
+  },
 })
 export class ClrVerticalNavLink implements OnDestroy {
   private destroy$ = new Subject<void>();

--- a/projects/angular/src/layout/vertical-nav/vertical-nav-link.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav-link.ts
@@ -20,6 +20,7 @@ import { VerticalNavGroupService } from './providers/vertical-nav-group.service'
   `,
   host: {
     class: 'nav-link',
+    role: 'listitem',
   },
 })
 export class ClrVerticalNavLink implements OnDestroy {

--- a/projects/angular/src/layout/vertical-nav/vertical-nav.html
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav.html
@@ -21,7 +21,9 @@
   ></cds-icon>
 </button>
 <div class="nav-content">
-  <ng-content></ng-content>
+  <div role="list">
+    <ng-content></ng-content>
+  </div>
   <button
     (click)="collapsed = false"
     class="nav-btn"

--- a/projects/angular/src/layout/vertical-nav/vertical-nav.html
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav.html
@@ -20,7 +20,6 @@
     [attr.title]="(this.collapsed) ? commonStrings.keys.expand : commonStrings.keys.collapse"
   ></cds-icon>
 </button>
-<!-- Click handler on .nav-content is bad but required :-( -->
 <div class="nav-content">
   <ng-content></ng-content>
   <button


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

We recommend setting `aria-current="page"` on the vertical nav link for the current page, but `aria-current` is not valid outside of a list structure.

Issue Number: VPAT-17226

## What is the new behavior?

The vertical nav component will now project content into a `role="list"` element, and the `clrVerticalNavLink` directive will add `role="listitem"` to each link.

## Does this PR introduce a breaking change?

No.