### PR TITLE
feat: remove deprecated, unused `$clr-monoFont` scss variable

### DIFF
--- a/projects/angular/src/utils/variables/_variables.typography.scss
+++ b/projects/angular/src/utils/variables/_variables.typography.scss
@@ -9,10 +9,6 @@ $clr-fontSkipBase64: false !default;
 $clr-font: Metropolis, 'Avenir Next', 'Helvetica Neue', Arial, sans-serif !default; //Default font stack for Clarity
 $clr-altFont: $clr-font !default; //TODO: TBD. Alternative font for Clarity
 
-// Usage: ../code/syntax-highlight/_code.clarity.scss
-// @deprecated in 1.0 $clr-monoFont only used in removed code component
-$clr-monoFont: Consolas, Monaco, Courier, monospace !default;
-
 // Usage: ../typography/_typography.clarity.scss
 // Usage: ../utils/_helpers.clarity.scss
 $clr-font-base-size: 14 !default; // Moved to general for now. Needs a better general name


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Remove deprecated thing.

## Does this PR introduce a breaking change?

Yes. The unused `$clr-monoFont` scss variable has been removed.