### PR TITLE
fix: prevent error on destroy in `StopEscapePropagationDirective`

### DIFF
--- a/projects/angular/src/utils/popover/stop-escape-propagation.directive.ts
+++ b/projects/angular/src/utils/popover/stop-escape-propagation.directive.ts
@@ -25,7 +25,7 @@ export class StopEscapePropagationDirective implements OnInit, OnDestroy {
   }
 
   ngOnDestroy() {
-    this.subscription.unsubscribe();
+    this.subscription?.unsubscribe();
   }
 
   @HostListener('keyup.escape', ['$event'])


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

Unit test error reported by a user:

```
TypeError: Cannot read properties of undefined (reading 'unsubscribe')
    at StopEscapePropagationDirective.call [as ngOnDestroy] (node_modules/@clr/angular/fesm2020/clr-angular.mjs:2620:27)
    at executeOnDestroys (node_modules/@angular/core/fesm2020/core.mjs:6031:32)
    at cleanUpView (node_modules/@angular/core/fesm2020/core.mjs:5941:9)
    at destroyViewTree (node_modules/@angular/core/fesm2020/core.mjs:5774:17)
```

## What is the new behavior?

I am not sure how this is possible. The `ngOnDestroy` method is apparently sometimes called without `ngOnInit` having been called first. I think this is just a possible unit testing issue. In any case, it's a simple fix to conditionally unsubscribe.

## Does this PR introduce a breaking change?

No.