### PR TITLE
fix(drag-and-drop): clear constant collection on component destroy

### DIFF
--- a/projects/demo/src/app/drag-and-drop/grouping.demo.ts
+++ b/projects/demo/src/app/drag-and-drop/grouping.demo.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component } from '@angular/core';
+import { Component, HostListener, OnDestroy } from '@angular/core';
 import { ClrDragEvent } from '@clr/angular';
 
 const FILES = [
@@ -18,7 +18,7 @@ const FILES = [
   styleUrls: ['./drag-and-drop.demo.scss'],
   templateUrl: './grouping.demo.html',
 })
-export class GroupingDemo {
+export class GroupingDemo implements OnDestroy {
   files: any[];
 
   droppedImages: any[] = [];
@@ -56,6 +56,13 @@ export class GroupingDemo {
       this.moveItem(dragEvent.dragDataTransfer, this.files, this.droppedMovies);
     } else if (this.droppedImages.indexOf(dragEvent.dragDataTransfer) > -1) {
       this.moveItem(dragEvent.dragDataTransfer, this.files, this.droppedImages);
+    }
+  }
+
+  @HostListener('unloaded')
+  ngOnDestroy(): void {
+    if (FILES && FILES.length) {
+      FILES.splice(0, FILES.length);
     }
   }
 }


### PR DESCRIPTION
Unwanted references to the FILES  collection is causing memory to leak. It is recommended to clear all large collections explicitly when component destroys.

Signed-off-by: Arooba Shahoor <arooba.shahoor@gmail.com>

Hello 👋 
As part of our project, we are using Facebook's new Memlab tool to detect memory leaks in SPA applications. 
While running the tool and analyzing the code of ng-clarity, we saw that your project does a very good job of ensuring that all async operations are cancelled when the component unmounts. However, as per Memlab execution results, we found a dangling collection that was causing the memory to leak (screenshots below).

[before]
<img width="1096" alt="Screen Shot 2023-01-28 at 12 10 49 PM" src="https://user-images.githubusercontent.com/56495631/215299319-5bcd34d6-3b75-47ab-bf10-f3a97ddc4b72.png">

<br />
Hence we added the fix by clearing the collection in destructor and you can see the heap size and # of leaks reducing noticeably:
 <br />
<img width="1136" alt="Screen Shot 2023-01-28 at 12 43 08 PM" src="https://user-images.githubusercontent.com/56495631/215299353-b829e2bb-1418-4849-accb-73d63b728361.png">

Note: We used `splice` instead of the more conventional approach of `.length = 0`, so as to cater for any future modifications such as changing the FILES object to a type that has a `length` property but is not assignable.

As per the contribution guidelines, we ran the unit test cases; all 3547 tests were completed successfully.
You can analyze this and other potential leak sources, if you like, by running [Memlab](https://facebook.github.io/memlab/) with a scenario file covering the maximum # of use cases.

Following is a sample of the scenario file we used (it needs to be a .js file but attaching here in .txt form):
[ng-clarity-memlab-scenario.txt](https://github.com/vmware-clarity/ng-clarity/files/10528755/ng-clarity-memlab-scenario.txt)

Note that some other reported leaks (in Memlab) originated from Angular's internal objects, and hence were ignored.