### PR TITLE
chore: remove @cds/core theme selector in @clr/ui dark theme demo app

### DIFF
--- a/projects/demo/src/app/app.component.html
+++ b/projects/demo/src/app/app.component.html
@@ -33,7 +33,7 @@
           <a href="javascript://" clrDropdownItem><cds-icon shape="user"></cds-icon> About</a>
           <a href="javascript://" clrDropdownItem>Preferences</a>
           <a href="javascript://" clrDropdownItem>Log out</a>
-          <form clrForm clrLayout="vertical">
+          <form *ngIf="!clrUiDarkThemeApplied" clrForm clrLayout="vertical">
             <app-cds-theme-select></app-cds-theme-select>
           </form>
         </clr-dropdown-menu>

--- a/projects/demo/src/app/app.component.ts
+++ b/projects/demo/src/app/app.component.ts
@@ -21,6 +21,7 @@ import {
   loadTravelIconSet,
 } from '@cds/core/icon';
 
+import { environment } from '../environments/environment';
 import { APP_ROUTES } from './app.routing';
 
 @Component({
@@ -29,6 +30,7 @@ import { APP_ROUTES } from './app.routing';
 })
 export class AppComponent {
   routes: Route[] = APP_ROUTES;
+  clrUiDarkThemeApplied = environment.dark;
 
   constructor() {
     loadChartIconSet();

--- a/projects/demo/src/environments/environment.prod.ts
+++ b/projects/demo/src/environments/environment.prod.ts
@@ -6,4 +6,5 @@
 
 export const environment = {
   production: true,
+  dark: false,
 };

--- a/projects/demo/src/environments/environment.ts
+++ b/projects/demo/src/environments/environment.ts
@@ -10,6 +10,7 @@
 
 export const environment = {
   production: false,
+  dark: false,
 };
 
 /*


### PR DESCRIPTION
The @cds/core shim does not work with the @clr/ui dark theme since it does not use CSS custom properties.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Demo app change.

## What is the current behavior?

The @cds/core theme selector is present in the @clr/ui dark theme demo app, but it doesn't work.

## What is the new behavior?

The @cds/core theme selector is not present in the @clr/ui dark theme demo app.

## Does this PR introduce a breaking change?

No.