### PR TITLE
feat: apply app background color to `body` element

### DIFF
--- a/projects/angular/src/layout/main-container/_layout.clarity.scss
+++ b/projects/angular/src/layout/main-container/_layout.clarity.scss
@@ -9,7 +9,6 @@
     display: flex;
     flex-direction: column;
     height: 100vh;
-    @include css-var(background, clr-global-app-background, $clr-global-app-background, $clr-use-custom-properties);
 
     .alert.alert-app-level {
       flex: 0 0 auto;

--- a/projects/angular/src/utils/_components.clarity.scss
+++ b/projects/angular/src/utils/_components.clarity.scss
@@ -11,6 +11,9 @@
 @import '../utils/variables/variables';
 @import '../utils/variables/properties';
 
+// Global styles
+@import '../utils/global.clarity';
+
 // Layout/Grid
 @import '../layout/grid/grid';
 

--- a/projects/angular/src/utils/_global.clarity.scss
+++ b/projects/angular/src/utils/_global.clarity.scss
@@ -1,0 +1,9 @@
+/*
+ * Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+body {
+  @include css-var(background, clr-global-app-background, $clr-global-app-background, $clr-use-custom-properties);
+}


### PR DESCRIPTION
_I need this change to add the @clr/ui Dark Theme to the storybook. (#494)_

I don't think a `.main-container` element should be required to get the app background color. This change also applies the app background in the storybook.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Feature

## What is the current behavior?

- The app background color is applied to the `.main-container` element.
- The @clr/ui Light Theme in the storybook doesn't have the app background color.

## What is the new behavior?

- The app background color is applied to the `body` element.
- The @clr/ui Light Theme in the storybook has the app background color.

## Does this PR introduce a breaking change?

No.