### PR TITLE
chore: use correct path for @cds/core shim in storybook page

### DIFF
--- a/.storybook/pages/cds-core-shim.stories.mdx
+++ b/.storybook/pages/cds-core-shim.stories.mdx
@@ -23,7 +23,7 @@ override the `@clr/ui` values appropriately.
 @import '@cds/core/global.min.css'; // provides the Clarity Core design tokens
 @import '@cds/core/styles/theme.dark.min.css'; // to allow dark mode with cds-theme="dark"
 @import '@clr/ui/clr-ui.min.css'; // @clr/ui CSS (this should already be imported by your application)
-@import '@cds/ui/shim.cds-core.min.css'; // the shim file
+@import '@clr/ui/shim.cds-core.min.css'; // the shim file
 ```
 
 ## Dark Mode


### PR DESCRIPTION
This fixes a mistake I main in #486.