### PR TITLE
fix(forms): update validation with onpush strategy components

### DIFF
--- a/projects/angular/src/forms/common/if-control-state/if-control-state.service.ts
+++ b/projects/angular/src/forms/common/if-control-state/if-control-state.service.ts
@@ -51,14 +51,7 @@ export class IfControlStateService implements OnDestroy {
       // These status values are mutually exclusive, so a control
       // cannot be both valid AND invalid or invalid AND disabled.
       const status = CONTROL_STATE[this.control.status];
-      // At some point, with Angular 14, we started receiving the update for the control.touched
-      // later than this moment in code. It depends on the order of imports of ClarityModule and
-      // the FormsModule. This delay makes sure the touched state is properly updated.
-      setTimeout(() => {
-        this._statusChanges.next(
-          this.control.touched && ['VALID', 'INVALID'].includes(status) ? status : CONTROL_STATE.NONE
-        );
-      });
+      this._statusChanges.next(['VALID', 'INVALID'].includes(status) ? status : CONTROL_STATE.NONE);
     }
   }
 

--- a/projects/angular/src/forms/datepicker/date-input.validator.spec.ts
+++ b/projects/angular/src/forms/datepicker/date-input.validator.spec.ts
@@ -67,7 +67,10 @@ export default function () {
     });
 
     it('should not allow a date greater than the max date', () => {
-      fixture.componentInstance.formControl.setValue('1/1/2023');
+      // Using the short syntax like below causes ExpressionChangedAfterItHasBeenCheckedError.
+      // Our datepicker automatically updates short syntax to the full one, with leading zeros,
+      // so testing with the latter is acceptable.
+      fixture.componentInstance.formControl.setValue('01/01/2023');
       fixture.detectChanges();
 
       const expectedErrors = {


### PR DESCRIPTION
closes #476

The "touched" control check was nice to have but not required for the proper validation operation. Also, the event order is not stable in different Angular versions and orders of module imports. The setTimeout() was trying to ensure the correct order. But it leads to regressions with OnPush components. This fix removes the setTimeout at the expense of sacrificing the "touched" check.

Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

This fix is the final step of a chain of regressions that came with an Angular 14 update. The last regression was causing form elements in OnPush components to validate on the second `blur` event, skipping the first one.

Issue Number: #476 

## What is the new behavior?

Form elements in OnPush components now validate on first `blur`

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

The possibility to automate this regression chain testing is limited, because it depends on the order of imports of FormsModule and ClarityModule, while the tests run as part of the ClarityModule codebase.
It required manual testing, in a monkey-patched stackblitz instance:
https://stackblitz.com/edit/input-on-blur-issue-on-push

