### PR TITLE
Revert "fix(vertical-nav): add aria list structure to vertical nav links"

### DIFF
--- a/projects/angular/src/layout/vertical-nav/vertical-nav-link.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav-link.ts
@@ -20,7 +20,6 @@ import { VerticalNavGroupService } from './providers/vertical-nav-group.service'
   `,
   host: {
     class: 'nav-link',
-    role: 'listitem',
   },
 })
 export class ClrVerticalNavLink implements OnDestroy {

--- a/projects/angular/src/layout/vertical-nav/vertical-nav.html
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav.html
@@ -21,9 +21,7 @@
   ></cds-icon>
 </button>
 <div class="nav-content">
-  <div role="list">
-    <ng-content></ng-content>
-  </div>
+  <ng-content></ng-content>
   <button
     (click)="collapsed = false"
     class="nav-btn"


### PR DESCRIPTION
This reverts commit part of #480.

Adding `role="listitem"` to `a` element overrides the link role.