### PR TITLE
chore: fix storybook livereload of files in repo (shim)

### DIFF
--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,15 +10,18 @@ import { loadCoreIconSet, loadEssentialIconSet } from '@cds/core/icon';
 import { setCompodocJson } from '@storybook/addon-docs/angular';
 
 import docs from '../documentation.json';
-import clrUiStyles from 'raw-loader!../dist/clr-ui/clr-ui.css';
-import clrUiDarkStyles from 'raw-loader!../dist/clr-ui/clr-ui-dark.css';
 import resetStyles from 'raw-loader!../node_modules/@cds/core/styles/module.reset.min.css';
 import tokensStyles from 'raw-loader!../node_modules/@cds/core/styles/module.tokens.min.css';
 import layoutStyles from 'raw-loader!../node_modules/@cds/core/styles/module.layout.min.css';
 import typographyStyles from 'raw-loader!../node_modules/@cds/core/styles/module.typography.min.css';
 import darkThemeStyles from 'raw-loader!../node_modules/@cds/core/styles/theme.dark.min.css';
 import highContrastThemeStyles from 'raw-loader!../node_modules/@cds/core/styles/theme.high-contrast.min.css';
-import shimStyles from 'raw-loader!../dist/clr-ui/shim.cds-core.css';
+
+// Styles that should be watched/reloaded
+import clrUiStyles from 'raw-loader!sass-loader!../projects/ui/src/clr-ui.scss';
+import clrUiDarkStyles from 'raw-loader!sass-loader!../projects/ui/src/clr-ui-dark.scss';
+import shimStyles from 'raw-loader!sass-loader!../projects/ui/src/shim.cds-core.scss';
+
 import { getClrUiAppBackgroundColor } from './helpers/clr-ui-theme.helpers';
 import { THEMES } from './helpers/constants';
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: 

## What is the current behavior?

Storybook styles loaded via the dist folder aren't watched for live changes. 

Issue Number: N/A

## What is the new behavior?

Styles that are within the repo are referenced directly with sass-loader, so when changed they cause storybook to reload. This also ensures that changes to the shim will result in updated snapshots. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
