### PR TITLE
fix: include minified cds-core shim in `@clr/ui` package (13.x backbort)

### DIFF
--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "_build:ui:optimize": "npm-run-all _build:ui:optimize:*",
     "_build:ui:optimize:clr-ui": "csso ./dist/clr-ui/clr-ui.css --output ./dist/clr-ui/clr-ui.min.css --source-map file --no-restructure",
     "_build:ui:optimize:clr-ui-dark": "csso ./dist/clr-ui/clr-ui-dark.css --output ./dist/clr-ui/clr-ui-dark.min.css --source-map file --no-restructure",
+    "_build:ui:optimize:cds-core-shim": "csso ./dist/clr-ui/shim.cds-core.css --output ./dist/clr-ui/shim.cds-core.min.css --source-map file --no-restructure",
     "_build:ui:src": "cpy \"**/*.scss\" ./../../dist/clr-ui --cwd=./projects/angular --parents",
     "_build:ui:package": "cpy ./projects/ui/package.json ./projects/ui/README.md ./dist/clr-ui",
     "_build:ui": "npm-run-all _build:ui:css _build:ui:prefix _build:ui:optimize _build:ui:src _build:ui:package",


### PR DESCRIPTION
I missed this in #486.

This is a backport of #517 to 13.x

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Build related changes

## What is the current behavior?

The `shim.cds-core.min.css` is not in the `@clr/ui` package.

## What is the new behavior?

The `shim.cds-core.min.css` is in the `@clr/ui` package.

## Does this PR introduce a breaking change?

No.