### PR TITLE
fix(datagrid): show "not allowed" cursor in disabled selection cell

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -544,6 +544,13 @@
       input {
         cursor: pointer;
       }
+
+      &.clr-form-control-disabled {
+        &,
+        input {
+          cursor: not-allowed;
+        }
+      }
     }
 
     .datagrid-signpost-trigger .signpost {


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The "hand" cursor is used when hovering the selection cell when selection is disabled.

## What is the new behavior?

The "not allowed" cursor is used when hovering the selection cell when selection is disabled.

## Does this PR introduce a breaking change?

No.

## Other information

This fixes a mistake I made in #478.
