### PR TITLE
fix(datagrid): disable row checkbox/radio button in Angular v15 (13.x backport)

### DIFF
--- a/projects/angular/src/data/datagrid/datagrid-row.html
+++ b/projects/angular/src/data/datagrid/datagrid-row.html
@@ -48,7 +48,7 @@
               [ngModel]="selected"
               (ngModelChange)="toggle($event)"
               [id]="checkboxId"
-              [attr.disabled]="clrDgSelectable ? null : true"
+              [disabled]="clrDgSelectable ? null : true"
               [attr.aria-disabled]="clrDgSelectable ? null : true"
               [attr.aria-label]="clrDgRowAriaLabel"
             />
@@ -76,7 +76,7 @@
             [value]="item"
             [(ngModel)]="selection.currentSingle"
             [checked]="selection.currentSingle === item"
-            [attr.disabled]="clrDgSelectable ? null : true"
+            [disabled]="clrDgSelectable ? null : true"
             [attr.aria-disabled]="clrDgSelectable ? null : true"
             [attr.aria-label]="clrDgRowAriaLabel"
           />

--- a/projects/angular/src/data/datagrid/datagrid-row.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.spec.ts
@@ -105,7 +105,7 @@ export default function (): void {
         context.detectChanges();
         checkbox = context.clarityElement.querySelector("input[type='checkbox']");
 
-        expect(checkbox.getAttribute('disabled')).toBe('true');
+        expect(checkbox.getAttribute('disabled')).toBeDefined();
         expect(checkbox.getAttribute('aria-disabled')).toBe('true');
 
         context.clarityDirective.toggle();
@@ -154,7 +154,7 @@ export default function (): void {
         context.detectChanges();
         checkbox = context.clarityElement.querySelector("input[type='checkbox']");
 
-        expect(checkbox.getAttribute('disabled')).toBe('true');
+        expect(checkbox.getAttribute('disabled')).toBeDefined();
         expect(checkbox.getAttribute('aria-disabled')).toBe('true');
 
         context.clarityDirective.toggle();


### PR DESCRIPTION
This is a backport of #521 to 13.x.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

Setting `[clrDgSelectable]="false"` does not disable the checkbox/radio **button in Angular v15.**

Issue Number: #520

## What is the new behavior?

Setting `[clrDgSelectable]="false"` disables the checkbox/radio button in Angular v15.

## Does this PR introduce a breaking change?

No.

## Other information

This is a workaround for a regression that was introduced in Angular v15. See angular/angular#48350 for details.