### PR TITLE
chore: remove "check if main is merged" step from release workflows

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -11,11 +11,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Check if main is merged
-        run: |
-          git log HEAD..origin/main
-          branch=`git rev-parse --abbrev-ref HEAD`
-          [[ ($branch != "beta" && $branch != "rc") || "$(git log HEAD..origin/main)" == "" ]] || exit 1
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,11 +11,6 @@ jobs:
         uses: actions/checkout@v2
         with:
           fetch-depth: 0
-      - name: Check if main is merged
-        run: |
-          git log HEAD..origin/main
-          branch=`git rev-parse --abbrev-ref HEAD`
-          [[ ($branch != "beta" && $branch != "rc") || "$(git log HEAD..origin/main)" == "" ]] || exit 1
       - name: Setup Node.js
         uses: actions/setup-node@v2
         with:


### PR DESCRIPTION
This step is no longer needed since v15 `beta`/`rc` is now on `main`.