### PR TITLE
fix(button): add mapping of warning button to danger styles

### DIFF
--- a/.storybook/stories/button/button.stories.ts
+++ b/.storybook/stories/button/button.stories.ts
@@ -49,13 +49,14 @@ const defaultParameters: Parameters = {
     // methods
     emitClick: { control: { disable: true }, table: { disable: true } },
     loadingStateChange: { control: { disable: true }, table: { disable: true } },
-    buttonType: {
-      defaultValue: 'primary',
-      control: { type: 'radio', options: buttonTypes },
-    },
     buttonStyle: {
       defaultValue: 'outline',
       control: { type: 'radio', options: buttonStyles },
+    },
+    buttonType: {
+      defaultValue: 'primary',
+      control: { type: 'radio', options: buttonTypes },
+      if: { arg: 'buttonStyle', neq: 'flat' },
     },
   },
   args: {

--- a/projects/angular/src/button/_buttons.clarity.scss
+++ b/projects/angular/src/button/_buttons.clarity.scss
@@ -61,6 +61,14 @@
     @return lookupFromDangerOutlineButtonColors($property);
   }
 
+  @if $type == warning {
+    @return lookupFromWarningButtonColors($property);
+  }
+
+  @if $type == warning-outline {
+    @return lookupFromWarningOutlineButtonColors($property);
+  }
+
   @if $type == link {
     @return lookupFromLinkButtonColors($property);
   }

--- a/projects/angular/src/button/_variables.buttons.scss
+++ b/projects/angular/src/button/_variables.buttons.scss
@@ -475,6 +475,128 @@ $clr-btn-danger-outline-checked-color: $clr-color-neutral-0 !default;
   @return null;
 }
 
+// Warning button colors
+$clr-btn-warning-color: $clr-color-neutral-0 !default;
+$clr-btn-warning-bg-color: $clr-color-danger-700 !default;
+$clr-btn-warning-border-color: $clr-btn-danger-bg-color !default;
+$clr-btn-warning-hover-bg-color: $clr-color-danger-800 !default;
+$clr-btn-warning-hover-color: $clr-btn-danger-color !default;
+$clr-btn-warning-box-shadow-color: $clr-color-danger-900 !default;
+$clr-btn-warning-disabled-color: $clr-color-neutral-700 !default;
+$clr-btn-warning-disabled-bg-color: $clr-color-neutral-400 !default;
+$clr-btn-warning-disabled-border-color: $clr-btn-danger-disabled-color !default;
+$clr-btn-warning-checked-bg-color: $clr-color-danger-800 !default;
+$clr-btn-warning-checked-color: $clr-btn-danger-color !default;
+
+@function lookupFromWarningButtonColors($property: null) {
+  @if $property == color {
+    @return $clr-btn-warning-color;
+  }
+
+  @if $property == border-color {
+    @return $clr-btn-warning-border-color;
+  }
+
+  @if $property == bg-color {
+    @return $clr-btn-warning-bg-color;
+  }
+
+  @if $property == hover-bg-color {
+    @return $clr-btn-warning-hover-bg-color;
+  }
+
+  @if $property == hover-color {
+    @return $clr-btn-warning-hover-color;
+  }
+
+  @if $property == box-shadow-color {
+    @return $clr-btn-warning-box-shadow-color;
+  }
+
+  @if $property == disabled-color {
+    @return $clr-btn-warning-disabled-color;
+  }
+
+  @if $property == disabled-bg-color {
+    @return $clr-btn-warning-disabled-bg-color;
+  }
+
+  @if $property == disabled-border-color {
+    @return $clr-btn-warning-disabled-border-color;
+  }
+
+  @if $property == checked-bg-color {
+    @return $clr-btn-warning-checked-bg-color;
+  }
+
+  @if $property == checked-color {
+    @return $clr-btn-warning-checked-color;
+  }
+
+  @return null;
+}
+
+// Warning outline button colors
+$clr-btn-warning-outline-color: $clr-color-danger-700 !default;
+$clr-btn-warning-outline-bg-color: transparent !default;
+$clr-btn-warning-outline-border-color: $clr-color-danger-800 !default;
+$clr-btn-warning-outline-hover-bg-color: $clr-color-danger-100 !default;
+$clr-btn-warning-outline-hover-color: $clr-color-danger-900 !default;
+$clr-btn-warning-outline-box-shadow-color: $clr-color-danger-200 !default;
+$clr-btn-warning-outline-disabled-color: $clr-color-neutral-700 !default;
+$clr-btn-warning-outline-disabled-bg-color: $clr-btn-danger-outline-bg-color !default;
+$clr-btn-warning-outline-disabled-border-color: $clr-btn-danger-outline-disabled-color !default;
+$clr-btn-warning-outline-checked-bg-color: $clr-color-danger-800 !default;
+$clr-btn-warning-outline-checked-color: $clr-color-neutral-0 !default;
+
+@function lookupFromWarningOutlineButtonColors($property: null) {
+  @if $property == color {
+    @return $clr-btn-warning-outline-color;
+  }
+
+  @if $property == border-color {
+    @return $clr-btn-warning-outline-border-color;
+  }
+
+  @if $property == bg-color {
+    @return $clr-btn-warning-outline-bg-color;
+  }
+
+  @if $property == hover-bg-color {
+    @return $clr-btn-warning-outline-hover-bg-color;
+  }
+
+  @if $property == hover-color {
+    @return $clr-btn-warning-outline-hover-color;
+  }
+
+  @if $property == box-shadow-color {
+    @return $clr-btn-warning-outline-box-shadow-color;
+  }
+
+  @if $property == disabled-color {
+    @return $clr-btn-warning-outline-disabled-color;
+  }
+
+  @if $property == disabled-bg-color {
+    @return $clr-btn-warning-outline-disabled-bg-color;
+  }
+
+  @if $property == disabled-border-color {
+    @return $clr-btn-warning-outline-disabled-border-color;
+  }
+
+  @if $property == checked-bg-color {
+    @return $clr-btn-warning-outline-checked-bg-color;
+  }
+
+  @if $property == checked-color {
+    @return $clr-btn-warning-outline-checked-color;
+  }
+
+  @return null;
+}
+
 // Link button colors
 $clr-btn-link-color: $clr-color-action-600 !default;
 $clr-btn-link-bg-color: transparent !default;

--- a/projects/angular/src/utils/_theme.dark.clarity.scss
+++ b/projects/angular/src/utils/_theme.dark.clarity.scss
@@ -328,6 +328,29 @@ $clr-btn-danger-outline-disabled-color: $clr-btn-outline-disabled-font-color; //
 $clr-btn-danger-outline-disabled-bg-color: transparent; // disabled-background-color
 $clr-btn-danger-outline-disabled-border-color: $clr-btn-disabled-border-color; // disabled-border-color
 
+// Warning button
+$clr-btn-warning-color: hsl(0, 0%, 0%); // color, checked-color,
+$clr-btn-warning-bg-color: hsl(3, 90%, 62%); // background-color, border-color
+$clr-btn-warning-hover-bg-color: hsl(3, 100%, 69%); // hover-background-color
+$clr-btn-warning-hover-color: $clr-btn-danger-color; // hover-color
+$clr-btn-warning-box-shadow-color: hsl(10, 100%, 39%); // active-box-shadow-color
+$clr-btn-warning-checked-bg-color: hsl(10, 100%, 39%); // checked-background-color
+$clr-btn-warning-disabled-color: $clr-btn-disabled-font-color; // disabled-color,
+$clr-btn-warning-disabled-bg-color: $clr-btn-disabled-bg-color; // disabled-background-color
+$clr-btn-warning-disabled-border-color: $clr-btn-disabled-border-color; // disabled-border-color
+
+// Warning outline button
+$clr-btn-warning-outline-border-color: hsl(3, 90%, 62%); // border-color
+$clr-btn-warning-outline-color: hsl(3, 90%, 62%); // color
+$clr-btn-warning-outline-hover-bg-color: hsla(0, 0%, 100%, 0.1); // hover-background-color
+$clr-btn-warning-outline-hover-color: hsl(3, 100%, 69%); // hover-color
+$clr-btn-warning-outline-box-shadow-color: hsl(0, 0%, 0%); // active-box-shadow-color
+$clr-btn-warning-outline-checked-bg-color: hsl(3, 90%, 62%); // checked-background-color
+$clr-btn-warning-outline-checked-color: hsl(0, 0%, 100%); // checked-color
+$clr-btn-warning-outline-disabled-color: $clr-btn-outline-disabled-font-color; // disabled-color
+$clr-btn-warning-outline-disabled-bg-color: transparent; // disabled-background-color
+$clr-btn-warning-outline-disabled-border-color: $clr-btn-disabled-border-color; // disabled-border-color
+
 // Link button
 $clr-btn-link-color: hsl(198, 65%, 57%); // color
 $clr-btn-link-hover-color: hsl(194, 78%, 63%); // hover-color


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Missing dark theme styles and inconsistent application of warning button styles

Issue Number: #425 

## What is the new behavior?
Follows the existing pattern for adding the warning color, and appropriate overrides. Updates the story to hide controls for flat button types (since they don't have the same states as other buttons).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
