### PR TITLE
fix(datagrid): set non-selectable multi select rows to disabled on initial render

### DIFF
--- a/.storybook/stories/datagrid/datagrid-row.stories.ts
+++ b/.storybook/stories/datagrid/datagrid-row.stories.ts
@@ -40,7 +40,7 @@ const defaultStory: Story = args => ({
       <clr-dg-row
         *clrDgItems="let element of elements; let index = index"
         [clrDgExpanded]="clrDgExpanded && index === 0"
-        [clrDgSelectable]="clrDgSelectable && index === 0"
+        [clrDgSelectable]="index !== 0 || clrDgSelectable"
         [clrDgSelected]="clrDgSelected && index === 0"
         [clrDgDetailOpenLabel]="clrDgDetailOpenLabel"
         [clrDgDetailCloseLabel]="clrDgDetailCloseLabel"
@@ -61,7 +61,7 @@ const defaultStory: Story = args => ({
           <clr-dg-row-detail *clrIfExpanded>{{element|json}}</clr-dg-row-detail>
         </ng-container>
       </clr-dg-row>
-      
+
       <clr-dg-footer>
         <clr-dg-pagination #pagination>
           <clr-dg-page-size [clrPageSizeOptions]="[10,20,50,100]">Elements per page</clr-dg-page-size>

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1704,7 +1704,9 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     globalExpandable: ExpandableRowsCount;
     // (undocumented)
     id: string;
-    item: T;
+    set item(item: T);
+    // (undocumented)
+    get item(): T;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)

--- a/projects/angular/src/data/datagrid/datagrid-row.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.spec.ts
@@ -134,6 +134,20 @@ export default function (): void {
         TestBed.get(Items).all = [{ id: 1 }, { id: 2 }];
       });
 
+      it('renders correctly if item is set after clrDgSelectable', fakeAsync(function () {
+        selectionProvider.selectionType = SelectionType.Multi;
+        const tempItem = context.testComponent.item;
+        context.testComponent.item = undefined;
+        context.detectChanges();
+        context.testComponent.clrDgSelectable = false;
+        context.testComponent.item = tempItem;
+        context.detectChanges();
+        checkbox = context.clarityElement.querySelector("input[type='checkbox']");
+
+        expect(checkbox.getAttribute('disabled')).toBeDefined();
+        expect(checkbox.getAttribute('aria-disabled')).toBe('true');
+      }));
+
       it('should provide a selection input aria-labels', fakeAsync(function () {
         // Test multi select rows
         selectionProvider.selectionType = SelectionType.Multi;
@@ -149,7 +163,6 @@ export default function (): void {
 
       it('should toggle when clrDgSelectable is false for type SelectionType.Multi', () => {
         selectionProvider.selectionType = SelectionType.Multi;
-        context.detectChanges();
         context.testComponent.clrDgSelectable = false;
         context.detectChanges();
         checkbox = context.clarityElement.querySelector("input[type='checkbox']");

--- a/projects/angular/src/data/datagrid/datagrid-row.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.ts
@@ -68,10 +68,19 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
 
   @ViewChild(ClrExpandableAnimation) expandAnimation: ClrExpandableAnimation;
 
+  private _item: T;
   /**
    * Model of the row, to use for selection
    */
-  @Input('clrDgItem') item: T;
+  @Input('clrDgItem')
+  set item(item: T) {
+    this._item = item;
+    this.clrDgSelectable = this._selectable;
+  }
+
+  get item(): T {
+    return this._item;
+  }
 
   replaced: boolean;
 
@@ -160,10 +169,15 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     }
   }
 
-  // By default every item is selectable; it becomes not selectable only if it's explicitly set to false
+  // By default, every item is selectable; it becomes not selectable only if it's explicitly set to false
+  private _selectable: boolean | string = true;
   @Input('clrDgSelectable')
   set clrDgSelectable(value: boolean | string) {
-    this.selection.lockItem(this.item, value === false);
+    if (this.item) {
+      this.selection.lockItem(this.item, value === 'false' || value === false);
+    }
+    // Store this value locally, to be initialized when item is initialized
+    this._selectable = value;
   }
 
   get clrDgSelectable() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently, when using a multi selectable datagrid, the rows do not render in their correct state (based on clrDgSelectable). Since the clrDgSelectable and item values are both Inputs, the clrDgSelectable state may be set within the component prior to the item, which results in the selectable state being lost. This change introduces a private local variable to keep track of the clrDgSelectable state, and introduces a setter for the item that sets the value when item is available. 

Issue Number: #157 

## What is the new behavior?
When rendering a multi-select datagrid, rows will properly respect the clrDgSelectable input when initially rendered. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
