### PR TITLE
fix(datepicker): add title to next month icon to align with other icons (backport)

### DIFF
--- a/projects/angular/src/forms/datepicker/daypicker.html
+++ b/projects/angular/src/forms/datepicker/daypicker.html
@@ -43,7 +43,7 @@
       (click)="nextMonth()"
       [attr.aria-label]="commonStrings.keys.datepickerNextMonth"
     >
-      <cds-icon shape="angle" direction="right"></cds-icon>
+      <cds-icon shape="angle" direction="right" [attr.title]="commonStrings.keys.datepickerNextMonth"></cds-icon>
     </button>
   </div>
 </div>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The next month icon within the button does not use the title attribute, but other icons within the datepicker use the title attribute to match the aria-label text. 

Issue Number: #450 

## What is the new behavior?

Adds the title attribute to the next month icon to align with other icon usage within the component and library. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [ x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
