### PR TITLE
fix(datagrid): prevent "manage columns" from making rows selectable (13.x backport)

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1387,7 +1387,7 @@ export class ClrDatagridColumnToggle implements OnDestroy {
     // Warning: (ae-forgotten-export) The symbol "ColumnState" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)
-    trackByFn: TrackByFunction<ColumnState>;
+    readonly trackByFn: TrackByFunction<ColumnState>;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridColumnToggle, "clr-dg-column-toggle", never, {}, {}, ["customToggleTitle", "customToggleButton"], ["clr-dg-column-toggle-title", "clr-dg-column-toggle-button"]>;
     // (undocumented)

--- a/projects/angular/src/data/datagrid/datagrid-column-toggle-trackby.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column-toggle-trackby.ts
@@ -1,0 +1,15 @@
+/*
+ * Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+/**
+ * This file prevents an import cycle.
+ */
+
+import { TrackByFunction } from '@angular/core';
+
+import { ColumnState } from './interfaces/column-state.interface';
+
+export const columnToggleTrackByFn: TrackByFunction<ColumnState> = index => index;

--- a/projects/angular/src/data/datagrid/datagrid-column-toggle.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column-toggle.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ContentChild, ElementRef, OnDestroy, TrackByFunction, ViewChild } from '@angular/core';
+import { Component, ContentChild, ElementRef, OnDestroy, ViewChild } from '@angular/core';
 import { Subscription } from 'rxjs';
 
 import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
@@ -18,6 +18,7 @@ import { ClrPopoverPositionService } from '../../utils/popover/providers/popover
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
 import { ClrDatagridColumnToggleButton } from './datagrid-column-toggle-button';
 import { ClrDatagridColumnToggleTitle } from './datagrid-column-toggle-title';
+import { columnToggleTrackByFn } from './datagrid-column-toggle-trackby';
 import { DatagridColumnChanges } from './enums/column-changes.enum';
 import { ColumnState } from './interfaces/column-state.interface';
 import { ColumnsService } from './providers/columns.service';
@@ -119,7 +120,7 @@ export class ClrDatagridColumnToggle implements OnDestroy {
 
   // Without tracking the checkboxes get rerendered on model update, which leads
   // to loss of focus after checkbox toggle.
-  trackByFn: TrackByFunction<ColumnState> = index => index;
+  readonly trackByFn = columnToggleTrackByFn;
 
   constructor(
     public commonStrings: ClrCommonStringsService,

--- a/projects/angular/src/data/datagrid/datagrid-items-trackby.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-items-trackby.spec.ts
@@ -7,6 +7,7 @@
 import { Component, TrackByFunction, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
+import { columnToggleTrackByFn } from './datagrid-column-toggle-trackby';
 import { ClrDatagridItems } from './datagrid-items';
 import { ClrDatagridModule } from './datagrid.module';
 import { FiltersProvider } from './providers/filters';
@@ -42,6 +43,13 @@ export default function (): void {
       this.testComponent.trackBy = (index: number) => index;
       this.fixture.detectChanges();
       expect(this.itemsProvider.trackBy).toBe(this.testComponent.trackBy);
+    });
+
+    it('ignores the column toggle trackBy function', function () {
+      const initialTrackByFn = this.itemsProvider.trackBy;
+      this.testComponent.trackBy = columnToggleTrackByFn;
+      this.fixture.detectChanges();
+      expect(this.itemsProvider.trackBy).toBe(initialTrackByFn);
     });
   });
 }

--- a/projects/angular/src/data/datagrid/datagrid-items-trackby.ts
+++ b/projects/angular/src/data/datagrid/datagrid-items-trackby.ts
@@ -6,6 +6,7 @@
 
 import { Directive, Input, Optional, TrackByFunction } from '@angular/core';
 
+import { columnToggleTrackByFn } from './datagrid-column-toggle-trackby';
 import { Items } from './providers/items';
 
 @Directive({
@@ -16,6 +17,17 @@ export class ClrDatagridItemsTrackBy<T = any> {
 
   @Input('ngForTrackBy')
   set trackBy(value: TrackByFunction<T>) {
+    /**
+     * This is a workaround to prevent the items `trackBy` function from
+     * being replaced when the "manage columns" button is clicked. This is
+     * not a complete solution. If there is another `ngForTrackBy` function
+     * within the datagrid in application code, it could sill replace the
+     * items `trackBy` function whether it is the row iterator or not.
+     */
+    if (value === columnToggleTrackByFn) {
+      return;
+    }
+
     if (this._items) {
       this._items.trackBy = value;
     }


### PR DESCRIPTION
This is a backport of #538 to 13.x.

closes #475
closes #503

## PR Checklist

- [X] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

Clicking the "manage columns" button will make unselectable rows selectable.

Issue Number: #475 and #503

## What is the new behavior?

Clicking the "manage columns" button will not make unselectable rows selectable

## Does this PR introduce a breaking change?

No.

## Other information

This is a workaround to prevent the items `trackBy` function from being replaced when the "manage columns" button is clicked. This is not a complete solution. If there is another `ngForTrackBy` function within the datagrid in application code, it could sill replace the items `trackBy` function whether it is the row iterator or not.