### PR TITLE
fix(datagrid): add workaround to enable `clrDgSelectable` with `*ngFor` (13.x backport)

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1203,7 +1203,9 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     // (undocumented)
     singleSelectedChanged: EventEmitter<T>;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagrid<any>, "clr-datagrid", never, { "loading": "clrDgLoading"; "selected": "clrDgSelected"; "singleSelected": "clrDgSingleSelected"; "clrDgSingleSelectionAriaLabel": "clrDgSingleSelectionAriaLabel"; "clrDgSingleActionableAriaLabel": "clrDgSingleActionableAriaLabel"; "clrDetailExpandableAriaLabel": "clrDetailExpandableAriaLabel"; "clrDgDisablePageFocus": "clrDgDisablePageFocus"; "clrDgPreserveSelection": "clrDgPreserveSelection"; "rowSelectionMode": "clrDgRowSelection"; }, { "refresh": "clrDgRefresh"; "selectedChanged": "clrDgSelectedChange"; "singleSelectedChanged": "clrDgSingleSelectedChange"; }, ["iterator", "placeholder", "columns", "rows"], ["clr-dg-action-bar", "clr-dg-placeholder", "clr-dg-footer", "[clrIfDetail],clr-dg-detail"]>;
+    set trackBy(value: ClrDatagridItemsTrackByFunction<T>);
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagrid<any>, "clr-datagrid", never, { "loading": "clrDgLoading"; "selected": "clrDgSelected"; "singleSelected": "clrDgSingleSelected"; "clrDgSingleSelectionAriaLabel": "clrDgSingleSelectionAriaLabel"; "clrDgSingleActionableAriaLabel": "clrDgSingleActionableAriaLabel"; "clrDetailExpandableAriaLabel": "clrDetailExpandableAriaLabel"; "clrDgDisablePageFocus": "clrDgDisablePageFocus"; "clrDgPreserveSelection": "clrDgPreserveSelection"; "rowSelectionMode": "clrDgRowSelection"; "trackBy": "clrDgItemsTrackBy"; }, { "refresh": "clrDgRefresh"; "selectedChanged": "clrDgSelectedChange"; "singleSelectedChanged": "clrDgSingleSelectedChange"; }, ["iterator", "placeholder", "columns", "rows"], ["clr-dg-action-bar", "clr-dg-placeholder", "clr-dg-footer", "[clrIfDetail],clr-dg-detail"]>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrDatagrid<any>, never>;
 }
@@ -1585,6 +1587,9 @@ export class ClrDatagridItemsTrackBy<T = any> {
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrDatagridItemsTrackBy<any>, [{ optional: true; }]>;
 }
+
+// @public (undocumented)
+export type ClrDatagridItemsTrackByFunction<T> = (item: T) => any;
 
 // @public (undocumented)
 export class ClrDatagridModule {

--- a/projects/angular/src/data/datagrid/datagrid-items-trackby.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-items-trackby.spec.ts
@@ -38,10 +38,10 @@ export default function (): void {
     });
 
     it('receives an input for the trackBy option', function () {
-      expect(this.itemsProvider.trackBy).toBeUndefined();
+      expect(this.itemsProvider.iteratorTrackBy).toBeUndefined();
       this.testComponent.trackBy = (index: number) => index;
       this.fixture.detectChanges();
-      expect(this.itemsProvider.trackBy).toBe(this.testComponent.trackBy);
+      expect(this.itemsProvider.iteratorTrackBy).toBe(this.testComponent.trackBy);
     });
   });
 }

--- a/projects/angular/src/data/datagrid/datagrid-items-trackby.ts
+++ b/projects/angular/src/data/datagrid/datagrid-items-trackby.ts
@@ -17,7 +17,7 @@ export class ClrDatagridItemsTrackBy<T = any> {
   @Input('ngForTrackBy')
   set trackBy(value: TrackByFunction<T>) {
     if (this._items) {
-      this._items.trackBy = value;
+      this._items.iteratorTrackBy = value;
     }
   }
 }

--- a/projects/angular/src/data/datagrid/datagrid-items.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-items.spec.ts
@@ -136,7 +136,7 @@ export default function (): void {
       });
 
       it('items receive the provided trackBy option', function () {
-        expect(this.clarityDirective.items.trackBy).toBe(this.testComponent.trackBy);
+        expect(this.clarityDirective.items.iteratorTrackBy).toBe(this.testComponent.trackBy);
       });
 
       it('correctly mutates and resets an array with trackBy', function () {

--- a/projects/angular/src/data/datagrid/datagrid-items.ts
+++ b/projects/angular/src/data/datagrid/datagrid-items.ts
@@ -36,7 +36,7 @@ export class ClrDatagridItems<T> implements DoCheck, OnDestroy {
 
   @Input('clrDgItemsTrackBy')
   set trackBy(value: TrackByFunction<T>) {
-    this.items.trackBy = value;
+    this.items.iteratorTrackBy = value;
     this.iterableProxy.ngForTrackBy = value;
   }
 

--- a/projects/angular/src/data/datagrid/datagrid.ts
+++ b/projects/angular/src/data/datagrid/datagrid.ts
@@ -39,7 +39,7 @@ import { DetailService } from './providers/detail.service';
 import { DisplayModeService } from './providers/display-mode.service';
 import { FiltersProvider } from './providers/filters';
 import { ExpandableRowsCount } from './providers/global-expandable-rows';
-import { Items } from './providers/items';
+import { ClrDatagridItemsTrackByFunction, Items } from './providers/items';
 import { Page } from './providers/page';
 import { RowActionService } from './providers/row-action-service';
 import { Selection } from './providers/selection';
@@ -186,6 +186,11 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     this.selection.rowSelectionMode = value;
   }
 
+  @Input('clrDgItemsTrackBy')
+  set trackBy(value: ClrDatagridItemsTrackByFunction<T>) {
+    this.items.datagridTrackBy = value;
+  }
+
   /**
    * Indicates if all currently displayed items are selected
    */
@@ -252,9 +257,9 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
 
         // Try to update only when there is something cached and its open.
         if (this.detailService.state && this.detailService.isOpen) {
-          const row = this.rows.find((row, index) => {
-            return this.items.trackBy(index, row.item) === this.items.trackBy(index, this.detailService.state);
-          });
+          const row = this.items.canTrackBy()
+            ? this.rows.find(row => this.items.trackBy(row.item) === this.items.trackBy(this.detailService.state))
+            : undefined;
 
           /**
            * Reopen updated row or close it

--- a/projects/angular/src/data/datagrid/index.ts
+++ b/projects/angular/src/data/datagrid/index.ts
@@ -43,6 +43,8 @@ export * from './built-in/comparators/datagrid-property-comparator';
 
 export * from './datagrid.module';
 
+export { ClrDatagridItemsTrackByFunction } from './providers/items';
+
 export { ClrDatagridSelectionCellDirective as ÇlrDatagridSelectionCellDirective } from './datagrid-selection-cell.directive';
 export { DatagridDetailRegisterer as ÇlrDatagridDetailRegisterer } from './datagrid-detail-registerer';
 export { WrappedCell as ÇlrWrappedCell } from './wrapped-cell';


### PR DESCRIPTION
This is a backport of #539 to 13.x.

closes #157

## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
  - I will open a website PR.
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

You cannot use `[clrDgSelectable]` with `*ngFor` due to use of the iterator `trackBy` function to track selection.

It is impossible (or very difficult) to grab the correct `trackBy` function via the row iterator structural directive. The `ngForTrackBy` directive would grab the `trackBy` function from any `*ngFor` in the datagrid, not just the row iterator.

Further, needing the item index to track selection introduces a race condition when `*ngFor` is used. We don't have the collection of items when the rows inputs are set, so `clrDgSelectable` doesn't work.

Issue Number: #157

## What is the new behavior?

The fix is to pass a "track by" function directly to the datagrid. This change introduces a `clrDgItemsTrackBy` input that will used if provided. Otherwise, the datagrid will fall back to the previous behavior of trying to grab the `trackBy` function from the row iterator structural directive.

## Does this PR introduce a breaking change?

No.

## Other information

The fallback behavior is deprecated and scheduled for removal in v17.