### PR TITLE
fix(combobox): rename incorrect css var (missing -color)

### DIFF
--- a/projects/angular/src/forms/combobox/_properties.combobox.scss
+++ b/projects/angular/src/forms/combobox/_properties.combobox.scss
@@ -11,7 +11,7 @@
       --clr-combobox-font-size: #{$clr-p2-font-size};
       --clr-combobox-border-color: #{$clr-combobox-border-color};
       --clr-combobox-border-radius: #{$clr-combobox-border-radius};
-      --clr-combobox-input-background: #{$clr-combobox-input-background-color};
+      --clr-combobox-input-background-color: #{$clr-combobox-input-background-color};
       --clr-combobox-pill-background-color: #{$clr-combobox-pill-background-color};
       --clr-combobox-pill-border-color: #{$clr-combobox-pill-border-color};
       --clr-combobox-pill-border-radius: #{$clr-combobox-pill-border-radius};


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The css variable is incorrect, causing the styles to be applied via the fallback but not allowing for changes via the css variable. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

The css variable is using the correct name to align with our lookup functionality. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
