### PR TITLE
chore(datagrid): remove old sorting bindings from column story

### DIFF
--- a/.storybook/stories/datagrid/datagrid-column.stories.ts
+++ b/.storybook/stories/datagrid/datagrid-column.stories.ts
@@ -36,13 +36,11 @@ const defaultStory: Story = args => ({
         [clrDgColType]="clrDgColType"
         clrDgField="name"
         [clrDgSortBy]="clrDgSortBy"
-        [clrDgSorted]="clrDgSorted"
         [clrDgSortOrder]="ClrDatagridSortOrder[clrDgSortOrder]"
         [clrFilterNumberMaxPlaceholder]="clrFilterNumberMaxPlaceholder"
         [clrFilterNumberMinPlaceholder]="clrFilterNumberMinPlaceholder"
         [clrFilterStringPlaceholder]="clrFilterStringPlaceholder"
         [clrFilterValue]="clrFilterValue"
-        (clrDgSortedChange)="clrDgSortedChange($event)"
         (clrDgSortOrderChange)="clrDgSortOrderChange($event)"
         (clrFilterValueChange)="clrFilterValueChange($event)"
       >
@@ -93,7 +91,6 @@ const defaultParameters: Parameters = {
     clrDgColType: { defaultValue: 'string' },
     clrDgField: { control: { disable: true } },
     clrDgSortBy: { type: 'string' },
-    clrDgSorted: { defaultValue: false, control: { type: 'boolean' } },
     clrDgSortOrder: {
       defaultValue: ClrDatagridSortOrder[ClrDatagridSortOrder.UNSORTED],
       control: {
@@ -106,7 +103,6 @@ const defaultParameters: Parameters = {
     clrFilterStringPlaceholder: { defaultValue: commonStringsService.keys.filterItems },
     clrFilterValue: { defaultValue: '', type: 'string' },
     // outputs
-    clrDgSortedChange: { control: { disable: true } },
     clrDgSortOrderChange: { control: { disable: true } },
     clrFilterValueChange: { control: { disable: true } },
     // methods


### PR DESCRIPTION
I missed this in 6af3832fe6b4e0ea7acd225cb3b0a1db2587231b.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Storybook fix