### PR TITLE
chore(datagrid): add `clrDgColumnResize` event to column story

### DIFF
--- a/.storybook/stories/datagrid/datagrid-column.stories.ts
+++ b/.storybook/stories/datagrid/datagrid-column.stories.ts
@@ -41,6 +41,7 @@ const defaultStory: Story = args => ({
         [clrFilterNumberMinPlaceholder]="clrFilterNumberMinPlaceholder"
         [clrFilterStringPlaceholder]="clrFilterStringPlaceholder"
         [clrFilterValue]="clrFilterValue"
+        (clrDgColumnResize)="clrDgColumnResize($event)"
         (clrDgSortOrderChange)="clrDgSortOrderChange($event)"
         (clrFilterValueChange)="clrFilterValueChange($event)"
       >
@@ -103,6 +104,7 @@ const defaultParameters: Parameters = {
     clrFilterStringPlaceholder: { defaultValue: commonStringsService.keys.filterItems },
     clrFilterValue: { defaultValue: '', type: 'string' },
     // outputs
+    clrDgColumnResize: { control: { disable: true } },
     clrDgSortOrderChange: { control: { disable: true } },
     clrFilterValueChange: { control: { disable: true } },
     // methods
@@ -113,6 +115,7 @@ const defaultParameters: Parameters = {
   },
   args: {
     // outputs
+    clrDgColumnResize: action('clrDgColumnResize'),
     clrDgSortOrderChange: action('clrDgSortOrderChange'),
     clrFilterValueChange: action('clrFilterValueChange'),
     // story helpers


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
  - vmware-clarity/website#85
- [N/A] If applicable, have a visual design approval

## PR Type

Storybook change

## What is the current behavior?

The `clrDgColumnResize` event is not in the datagrid column story.

## What is the new behavior?

The `clrDgColumnResize` event is in the datagrid column story.

## Does this PR introduce a breaking change?

No.