### PR TITLE
chore(datagrid): remove unused sort event handler in column story

### DIFF
--- a/.storybook/stories/datagrid/datagrid-column.stories.ts
+++ b/.storybook/stories/datagrid/datagrid-column.stories.ts
@@ -113,7 +113,6 @@ const defaultParameters: Parameters = {
   },
   args: {
     // outputs
-    clrDgSortedChange: action('clrDgSortedChange'),
     clrDgSortOrderChange: action('clrDgSortOrderChange'),
     clrFilterValueChange: action('clrFilterValueChange'),
     // story helpers


### PR DESCRIPTION
I missed this in #545. Ugh.