### PR TITLE
fix(forms): fix template-driven forms validation regression

### DIFF
--- a/.storybook/stories/forms/forms-reactive.stories.ts
+++ b/.storybook/stories/forms/forms-reactive.stories.ts
@@ -1,0 +1,121 @@
+/*
+ * Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { FormControl, FormGroup, Validators } from '@angular/forms';
+import { ClrFormLayout, ClrFormsModule, ClrLayoutModule } from '@clr/angular';
+import { Parameters } from '@storybook/addons';
+import { Story } from '@storybook/angular';
+
+import { setupStorybook } from '../../helpers/setup-storybook.helpers';
+
+const formMappingKey = 'form-mapping-key';
+const patterns = {
+  alphaNumeric: /^[a-z\d]+$/i,
+  letters: /[a-z]/i,
+  numbers: /\d/i,
+};
+
+const defaultStory: Story = args => ({
+  template: `
+    <form clrForm [formGroup]="form" [clrLayout]="clrLayout" [clrLabelSize]="clrLabelSize">
+      <span class="clr-sr-only">{{screenReaderContent}}</span>
+      <clr-input-container>
+        <label>Name</label>
+        <input clrInput formControlName="name" required [placeholder]="namePlaceholder"/>
+        <clr-control-helper>Helper text that shows while it is pristine and valid</clr-control-helper>
+        <clr-control-success>Name is valid</clr-control-success>
+        <clr-control-error *clrIfError="'required'">Name is required</clr-control-error>
+        <clr-control-error *clrIfError="'minlength'">Must be at least 5 characters</clr-control-error>
+        <clr-control-error *clrIfError="'pattern'">Must contain only alpha-numeric characters</clr-control-error>
+      </clr-input-container>
+      <clr-input-container>
+        <label>Age</label>
+        <input clrInput formControlName="age" type="number" min="0" required />
+        <clr-control-helper>Helper text that shows while it is pristine and valid</clr-control-helper>
+        <clr-control-success>Age is valid</clr-control-success>
+        <clr-control-error *clrIfError="'required'">Age is required</clr-control-error>
+        <clr-control-error *clrIfError="'min'">Must be at least 5 years old</clr-control-error>
+        <clr-control-error *clrIfError="'max'">Must be less than 100 years old</clr-control-error>
+      </clr-input-container>
+      <clr-password-container>
+        <label>Password</label>
+        <input clrPassword formControlName="password" required />
+        <clr-control-helper>Helper text that shows while it is pristine and valid</clr-control-helper>
+        <clr-control-success>Password is valid</clr-control-success>
+        <clr-control-error *clrIfError="'required'">Password is required</clr-control-error>
+        <clr-control-error *clrIfError="'minlength'">Must be at least 8 characters</clr-control-error>
+        <clr-control-error *clrIfError="'pattern'; error as error">
+          <ng-container [ngSwitch]="error.requiredPattern">
+            <ng-container *ngSwitchCase="patterns.alphaNumeric.toString()">Must contain only letters and numbers</ng-container>
+            <ng-container *ngSwitchCase="patterns.letters.toString()">Must contain at least one letter</ng-container>
+            <ng-container *ngSwitchCase="patterns.numbers.toString()">Must contain at least one number</ng-container>
+          </ng-container>
+        </clr-control-error>
+      </clr-password-container>
+      <clr-textarea-container>
+        <label>Description</label>
+        <textarea clrTextarea formControlName="description" required></textarea>
+        <clr-control-helper>Helper text that shows while it is pristine and valid</clr-control-helper>
+        <clr-control-success>Description is valid</clr-control-success>
+        <clr-control-error *clrIfError="'required'">Description is required</clr-control-error>
+        <clr-control-error *clrIfError="'minlength'">Must be at least 5 characters</clr-control-error>
+        <clr-control-error *clrIfError="'pattern'">Must contain only alpha-numeric characters</clr-control-error>
+      </clr-textarea-container>
+    </form>
+  `,
+  props: { ...args },
+});
+
+const defaultParameters: Parameters = {
+  title: 'Forms/Reactive',
+  argTypes: {
+    // inputs
+    clrLabelSize: { defaultValue: 2, control: { type: 'number', min: 1, max: 12 } },
+    // story helpers
+    patterns: { control: { disable: true }, table: { disable: true } },
+    form: { control: { disable: true }, table: { disable: true }, mapping: { [formMappingKey]: getForm() } },
+    clrLayout: {
+      control: { type: 'radio', options: Object.values(ClrFormLayout).filter(value => typeof value === 'string') },
+    },
+  },
+  args: {
+    // story helpers
+    patterns,
+    clrLayout: ClrFormLayout.HORIZONTAL,
+    screenReaderContent: 'Please fill out the form',
+    form: formMappingKey,
+    namePlaceholder: '',
+  },
+};
+
+const variants: Parameters[] = [
+  {},
+  {
+    namePlaceholder: 'Test placeholder',
+  },
+  {
+    clrLayout: ClrFormLayout.VERTICAL,
+  },
+  {
+    clrLayout: ClrFormLayout.COMPACT,
+  },
+];
+
+setupStorybook([ClrFormsModule, ClrLayoutModule], defaultStory, defaultParameters, variants);
+
+function getForm() {
+  return new FormGroup({
+    name: new FormControl(null, [Validators.minLength(5), Validators.pattern(/^[a-z\d ]+$/i)]),
+    age: new FormControl(null, [Validators.min(5), Validators.max(99)]),
+    password: new FormControl(null, [
+      Validators.minLength(8),
+      Validators.pattern(patterns.alphaNumeric),
+      Validators.pattern(patterns.letters),
+      Validators.pattern(patterns.numbers),
+    ]),
+    description: new FormControl(null, [Validators.minLength(5), Validators.pattern(/^[a-z\d ]+$/i)]),
+  });
+}

--- a/.storybook/stories/forms/forms-template-driven.stories.ts
+++ b/.storybook/stories/forms/forms-template-driven.stories.ts
@@ -4,7 +4,6 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { FormControl, FormGroup, Validators } from '@angular/forms';
 import { ClrFormLayout, ClrFormsModule, ClrLayoutModule } from '@clr/angular';
 import { Parameters } from '@storybook/addons';
 import { Story } from '@storybook/angular';
@@ -19,12 +18,12 @@ const patterns = {
 };
 
 const defaultStory: Story = args => ({
-  template: `
-    <form clrForm [formGroup]="form" [clrLayout]="clrLayout" [clrLabelSize]="clrLabelSize">
+  template: ` 
+    <form clrForm [clrLayout]="clrLayout" [clrLabelSize]="clrLabelSize">
       <span class="clr-sr-only">{{screenReaderContent}}</span>
       <clr-input-container>
         <label>Name</label>
-        <input clrInput formControlName="name" required [placeholder]="namePlaceholder"/>
+        <input clrInput [(ngModel)]="data.name" required name="name"/>
         <clr-control-helper>Helper text that shows while it is pristine and valid</clr-control-helper>
         <clr-control-success>Name is valid</clr-control-success>
         <clr-control-error *clrIfError="'required'">Name is required</clr-control-error>
@@ -33,7 +32,7 @@ const defaultStory: Story = args => ({
       </clr-input-container>
       <clr-input-container>
         <label>Age</label>
-        <input clrInput formControlName="age" type="number" min="0" required />
+        <input clrInput [(ngModel)]="data.age" type="number" min="0" required name="age"/>
         <clr-control-helper>Helper text that shows while it is pristine and valid</clr-control-helper>
         <clr-control-success>Age is valid</clr-control-success>
         <clr-control-error *clrIfError="'required'">Age is required</clr-control-error>
@@ -42,7 +41,7 @@ const defaultStory: Story = args => ({
       </clr-input-container>
       <clr-password-container>
         <label>Password</label>
-        <input clrPassword formControlName="password" required />
+        <input clrPassword [(ngModel)]="data.password" required name="password"/>
         <clr-control-helper>Helper text that shows while it is pristine and valid</clr-control-helper>
         <clr-control-success>Password is valid</clr-control-success>
         <clr-control-error *clrIfError="'required'">Password is required</clr-control-error>
@@ -57,7 +56,7 @@ const defaultStory: Story = args => ({
       </clr-password-container>
       <clr-textarea-container>
         <label>Description</label>
-        <textarea clrTextarea formControlName="description" required></textarea>
+        <textarea clrTextarea [(ngModel)]="data.description" required name="description"></textarea>
         <clr-control-helper>Helper text that shows while it is pristine and valid</clr-control-helper>
         <clr-control-success>Description is valid</clr-control-success>
         <clr-control-error *clrIfError="'required'">Description is required</clr-control-error>
@@ -70,13 +69,13 @@ const defaultStory: Story = args => ({
 });
 
 const defaultParameters: Parameters = {
-  title: 'Forms/Form',
+  title: 'Forms/Template Driven',
   argTypes: {
     // inputs
     clrLabelSize: { defaultValue: 2, control: { type: 'number', min: 1, max: 12 } },
     // story helpers
     patterns: { control: { disable: true }, table: { disable: true } },
-    form: { control: { disable: true }, table: { disable: true }, mapping: { [formMappingKey]: getForm() } },
+    data: { control: { disable: true }, table: { disable: true }, mapping: { [formMappingKey]: getForm() } },
     clrLayout: {
       control: { type: 'radio', options: Object.values(ClrFormLayout).filter(value => typeof value === 'string') },
     },
@@ -86,36 +85,19 @@ const defaultParameters: Parameters = {
     patterns,
     clrLayout: ClrFormLayout.HORIZONTAL,
     screenReaderContent: 'Please fill out the form',
-    form: formMappingKey,
-    namePlaceholder: '',
+    data: formMappingKey,
   },
 };
 
-const variants: Parameters[] = [
-  {},
-  {
-    namePlaceholder: 'Test placeholder',
-  },
-  {
-    clrLayout: ClrFormLayout.VERTICAL,
-  },
-  {
-    clrLayout: ClrFormLayout.COMPACT,
-  },
-];
+const variants: Parameters[] = [];
 
 setupStorybook([ClrFormsModule, ClrLayoutModule], defaultStory, defaultParameters, variants);
 
 function getForm() {
-  return new FormGroup({
-    name: new FormControl(null, [Validators.minLength(5), Validators.pattern(/^[a-z\d ]+$/i)]),
-    age: new FormControl(null, [Validators.min(5), Validators.max(99)]),
-    password: new FormControl(null, [
-      Validators.minLength(8),
-      Validators.pattern(patterns.alphaNumeric),
-      Validators.pattern(patterns.letters),
-      Validators.pattern(patterns.numbers),
-    ]),
-    description: new FormControl(null, [Validators.minLength(5), Validators.pattern(/^[a-z\d ]+$/i)]),
-  });
+  return {
+    name: '',
+    age: null,
+    password: '',
+    description: '',
+  };
 }

--- a/projects/angular/src/forms/common/abstract-container.ts
+++ b/projects/angular/src/forms/common/abstract-container.ts
@@ -51,7 +51,7 @@ export abstract class ClrAbstractContainer implements DynamicWrapper, OnDestroy,
 
     return (
       /* Helper Component exist and the state of the form is NONE (not touched) */
-      (!!this.controlHelperComponent && this.state === CONTROL_STATE.NONE) ||
+      (!!this.controlHelperComponent && (!this.touched || this.state === CONTROL_STATE.NONE)) ||
       /* or there is no success component but the state of the form is VALID - show helper information */
       (!!this.controlSuccessComponent === false && this.state === CONTROL_STATE.VALID) ||
       /* or there is no error component but the state of the form is INVALID - show helper information */
@@ -60,11 +60,11 @@ export abstract class ClrAbstractContainer implements DynamicWrapper, OnDestroy,
   }
 
   get showValid(): boolean {
-    return this.state === CONTROL_STATE.VALID && !!this.controlSuccessComponent;
+    return this.touched && this.state === CONTROL_STATE.VALID && !!this.controlSuccessComponent;
   }
 
   get showInvalid(): boolean {
-    return this.state === CONTROL_STATE.INVALID && !!this.controlErrorComponent;
+    return this.touched && this.state === CONTROL_STATE.INVALID && !!this.controlErrorComponent;
   }
 
   constructor(
@@ -106,7 +106,7 @@ export abstract class ClrAbstractContainer implements DynamicWrapper, OnDestroy,
      *   - container is valid but no success component is implemented - use helper class
      *   - container is valid and success component is implemented - use success class
      */
-    if (!this.controlSuccessComponent && this.state === CONTROL_STATE.VALID) {
+    if ((!this.controlSuccessComponent && this.state === CONTROL_STATE.VALID) || !this.touched) {
       return this.controlClassService.controlClass(CONTROL_STATE.NONE, this.addGrid());
     }
     /**
@@ -128,5 +128,9 @@ export abstract class ClrAbstractContainer implements DynamicWrapper, OnDestroy,
         showValid: this.showValid,
       });
     }
+  }
+
+  private get touched() {
+    return this.control?.touched;
   }
 }

--- a/projects/angular/src/forms/datepicker/date-container.spec.ts
+++ b/projects/angular/src/forms/datepicker/date-container.spec.ts
@@ -73,6 +73,11 @@ export default function () {
       container = context.clarityDirective;
     });
 
+    function setValid(valid: boolean) {
+      dateFormControlService.markAsTouched();
+      container.state = valid ? CONTROL_STATE.VALID : CONTROL_STATE.INVALID;
+    }
+
     // @deprecated these tests refer to the old forms layout only and can be removed when its removed
     describe('View Basics', () => {
       beforeEach(() => {
@@ -182,13 +187,13 @@ export default function () {
 
       it('should add/remove success icon and text', () => {
         /* valid */
-        container.state = CONTROL_STATE.VALID;
+        setValid(true);
         context.detectChanges();
         expect(context.clarityElement.querySelector('clr-control-success')).toBeTruthy();
         expect(context.clarityElement.querySelector('cds-icon[shape=check-circle]')).toBeTruthy();
 
         /* invalid */
-        container.state = CONTROL_STATE.INVALID;
+        setValid(false);
         context.detectChanges();
         expect(context.clarityElement.querySelector('clr-control-success')).toBeNull();
         expect(context.clarityElement.querySelector('cds-icon[shape=check-circle]')).toBeNull();
@@ -206,12 +211,12 @@ export default function () {
         expect(context.clarityDirective.controlClass()).toContain('clr-col-md-10');
         expect(context.clarityDirective.controlClass()).toContain('clr-col-12');
         expect(context.clarityDirective.controlClass()).not.toContain('clr-error');
-        container.state = CONTROL_STATE.INVALID;
+        setValid(false);
         expect(context.clarityDirective.controlClass()).toContain('clr-error');
         const controlClassService = context.getClarityProvider(ControlClassService);
         const layoutService = context.getClarityProvider(LayoutService);
         layoutService.layout = ClrFormLayout.VERTICAL;
-        container.state = CONTROL_STATE.VALID;
+        setValid(true);
         expect(context.clarityDirective.controlClass()).not.toContain('clr-error');
         expect(context.clarityDirective.controlClass()).not.toContain('clr-col-md-10');
         controlClassService.className = 'clr-col-2';

--- a/projects/demo/src/app/forms/forms.demo.module.ts
+++ b/projects/demo/src/app/forms/forms.demo.module.ts
@@ -33,9 +33,9 @@ import { FormsLayoutHorizontalGridDemo } from './layout/layout-horizontal-grid';
 import { FormsLayoutModalDemo } from './layout/layout-modal';
 import { FormsLayoutVerticalDemo } from './layout/layout-vertical';
 import { FormsLayoutVerticalGridDemo } from './layout/layout-vertical-grid';
-import { FormsReactiveDemo } from './reactive/reactive';
+import { FormsReactiveDemo, FormsReactiveOnPushDemo } from './reactive/reactive';
 import { FormsResetDemo } from './reset/reset';
-import { FormsTemplateDrivenDemo } from './template-driven/template-driven';
+import { FormsTemplateDrivenDemo, FormsTemplateDrivenOnPushDemo } from './template-driven/template-driven';
 import { FormsValidationDemo } from './validation/validation';
 
 @NgModule({
@@ -62,7 +62,9 @@ import { FormsValidationDemo } from './validation/validation';
     FormsSelectDemo,
     FormsTextareaDemo,
     FormsTemplateDrivenDemo,
+    FormsTemplateDrivenOnPushDemo,
     FormsReactiveDemo,
+    FormsReactiveOnPushDemo,
     FormsResetDemo,
     FormsA11yDemo,
     FormsGenericContainerDemo,
@@ -88,7 +90,9 @@ import { FormsValidationDemo } from './validation/validation';
     FormsSelectDemo,
     FormsTextareaDemo,
     FormsTemplateDrivenDemo,
+    FormsTemplateDrivenOnPushDemo,
     FormsReactiveDemo,
+    FormsReactiveOnPushDemo,
     FormsResetDemo,
     FormsA11yDemo,
     FormsGenericContainerDemo,

--- a/projects/demo/src/app/forms/forms.demo.routing.ts
+++ b/projects/demo/src/app/forms/forms.demo.routing.ts
@@ -29,9 +29,9 @@ import { FormsLayoutHorizontalGridDemo } from './layout/layout-horizontal-grid';
 import { FormsLayoutModalDemo } from './layout/layout-modal';
 import { FormsLayoutVerticalDemo } from './layout/layout-vertical';
 import { FormsLayoutVerticalGridDemo } from './layout/layout-vertical-grid';
-import { FormsReactiveDemo } from './reactive/reactive';
+import { FormsReactiveDemo, FormsReactiveOnPushDemo } from './reactive/reactive';
 import { FormsResetDemo } from './reset/reset';
-import { FormsTemplateDrivenDemo } from './template-driven/template-driven';
+import { FormsTemplateDrivenDemo, FormsTemplateDrivenOnPushDemo } from './template-driven/template-driven';
 import { FormsValidationDemo } from './validation/validation';
 
 const ROUTES: Routes = [
@@ -60,7 +60,9 @@ const ROUTES: Routes = [
       { path: 'text', component: FormsTextDemo },
       { path: 'textarea', component: FormsTextareaDemo },
       { path: 'template-driven', component: FormsTemplateDrivenDemo },
+      { path: 'template-driven-onpush', component: FormsTemplateDrivenOnPushDemo },
       { path: 'reactive', component: FormsReactiveDemo },
+      { path: 'reactive-onpush', component: FormsReactiveOnPushDemo },
       { path: 'reset', component: FormsResetDemo },
       { path: 'a11y', component: FormsA11yDemo },
       { path: 'generic-container', component: FormsGenericContainerDemo },

--- a/projects/demo/src/app/forms/forms.demo.ts
+++ b/projects/demo/src/app/forms/forms.demo.ts
@@ -39,7 +39,9 @@ import { Component } from '@angular/core';
       <li><a [routerLink]="['./textarea']">Textarea</a></li>
       <li><a [routerLink]="['./select']">Select</a></li>
       <li><a [routerLink]="['./template-driven']">Template Driven</a></li>
+      <li><a [routerLink]="['./template-driven-onpush']">Template Driven (OnPush)</a></li>
       <li><a [routerLink]="['./reactive']">Reactive</a></li>
+      <li><a [routerLink]="['./reactive-onpush']">Reactive (OnPush)</a></li>
       <li><a [routerLink]="['./reset']">Reset</a></li>
       <li><a [routerLink]="['./a11y']">a11y</a></li>
       <li><a [routerLink]="['./generic-container']">Generic Container</a></li>

--- a/projects/demo/src/app/forms/reactive/reactive.ts
+++ b/projects/demo/src/app/forms/reactive/reactive.ts
@@ -4,13 +4,10 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 import { FormControl, FormGroup, Validators } from '@angular/forms';
 
-@Component({
-  templateUrl: './reactive.html',
-})
-export class FormsReactiveDemo {
+class BasicReactiveDemo {
   model = new FormGroup({
     basic: new FormControl(''),
     container: new FormControl(''),
@@ -21,3 +18,14 @@ export class FormsReactiveDemo {
     console.log(this);
   }
 }
+
+@Component({
+  templateUrl: './reactive.html',
+})
+export class FormsReactiveDemo extends BasicReactiveDemo {}
+
+@Component({
+  templateUrl: './reactive.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FormsReactiveOnPushDemo extends BasicReactiveDemo {}

--- a/projects/demo/src/app/forms/template-driven/template-driven.ts
+++ b/projects/demo/src/app/forms/template-driven/template-driven.ts
@@ -4,12 +4,9 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component } from '@angular/core';
+import { ChangeDetectionStrategy, Component } from '@angular/core';
 
-@Component({
-  templateUrl: './template-driven.html',
-})
-export class FormsTemplateDrivenDemo {
+class BasicTemplateDrivenDemo {
   model = {
     basic: '',
     container: '',
@@ -20,3 +17,14 @@ export class FormsTemplateDrivenDemo {
     console.log(this);
   }
 }
+
+@Component({
+  templateUrl: './template-driven.html',
+})
+export class FormsTemplateDrivenDemo extends BasicTemplateDrivenDemo {}
+
+@Component({
+  templateUrl: './template-driven.html',
+  changeDetection: ChangeDetectionStrategy.OnPush,
+})
+export class FormsTemplateDrivenOnPushDemo extends BasicTemplateDrivenDemo {}


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Forms validation regressed multiple times, after certain Angular update, after which the order of imports of Angular's FormsModule and ClarityModule started to matter for the order of receiving `touched` event and angular validation status event.
Previously, we were trying to augment our internal validity state, based on whether `touched` had arrived or not. With the race condition described above, this was causing different side effects, depending on the fix attempted, including:
- form elements only got validated on the second `blur`
- form elements got validated immediately, when page was opened
Additional problem was that `touched` changes do not have an event handler in the Angular Control object, which makes manual synchronization in the above pattern nearly impossible.

Issue Number: #511 

## What is the new behavior?

Validity is now updated only after the first `blur`  on the element.
We are no longer augmenting the internal validity state, which was making it different from the Angular validity state.
Now both Clarity and Angular validity states are in sync.
The decision. whether to display the element as valid, or not yet validated, based on the `touched` state is not handled in the control state service, but in the Form component itself, which allows us to use the standard Angular data bindings to actively monitor both validation state and `touched` state. With this approach, the elements validity classes get updated regardless of the order in which validity and `touched` state changes arrive.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Due to the complex nature of the setup in which these issues are observed, we are aiming for them to be covered by future visual regression testing.
For this purpose, two storybook pages are defined - for reactive and for template-driven setup.
So far, I am unable to create a story with OnPush change detection in storybook, so I have added two more pages to the Clarity demo app, for the OnPush scenarios.

I recommend a manual testing procedure to be run on the following pages in the Dev App:
- Template Driven
- Template Driven (OnPush)
- Reactive
- Reactive (OnPush)

The procedure would require testing that:
- No field on the pages is pre-validated. 
- The field marked as `required` gets validated on the first `blur` event on the element.
- The field marked as `required` does not need a second `blur` event to get validated.

This will need to get back ported.