### PR TITLE
fix(combobox): rename incorrect css var (missing -color) (backport 13.x)

### DIFF
--- a/projects/angular/src/forms/combobox/_properties.combobox.scss
+++ b/projects/angular/src/forms/combobox/_properties.combobox.scss
@@ -11,7 +11,7 @@
       --clr-combobox-font-size: #{$clr-p2-font-size};
       --clr-combobox-border-color: #{$clr-combobox-border-color};
       --clr-combobox-border-radius: #{$clr-combobox-border-radius};
-      --clr-combobox-input-background: #{$clr-combobox-input-background-color};
+      --clr-combobox-input-background-color: #{$clr-combobox-input-background-color};
       --clr-combobox-pill-background-color: #{$clr-combobox-pill-background-color};
       --clr-combobox-pill-border-color: #{$clr-combobox-pill-border-color};
       --clr-combobox-pill-border-radius: #{$clr-combobox-pill-border-radius};


### PR DESCRIPTION
Porting of #544 to 13.x branch