### PR TITLE
chore: import scss files directly for chromatic to detect changes

### DIFF
--- a/.github/workflows/accept-merged-visual-changes.yml
+++ b/.github/workflows/accept-merged-visual-changes.yml
@@ -26,4 +26,4 @@ jobs:
         timeout-minutes: 5
         env:
           CHROMATIC_PROJECT_TOKEN: ${{secrets.CHROMATIC_PROJECT_TOKEN}}
-        run: npx chromatic --only-changed --externals "*.scss" --externals "package-lock.json" --storybook-build-dir ./dist/docs --auto-accept-changes main
+        run: npx chromatic --only-changed --externals "*.scss" --storybook-build-dir ./dist/docs --auto-accept-changes main

--- a/.github/workflows/pr-visual-regression.yml
+++ b/.github/workflows/pr-visual-regression.yml
@@ -50,4 +50,4 @@ jobs:
           CHROMATIC_SHA: ${{steps.get_pr_event.outputs.sourceHeadSha}}
           CHROMATIC_BRANCH: ${{steps.get_pr_event.outputs.sourceHeadBranch}}
           CHROMATIC_SLUG: ${{steps.get_pr_event.outputs.sourceHeadRepo}}
-        run: npx chromatic --only-changed --externals "*.scss" --externals "package-lock.json" --storybook-build-dir ./dist/docs --exit-once-uploaded
+        run: npx chromatic --only-changed --externals "*.scss" --storybook-build-dir ./dist/docs --exit-once-uploaded

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -10,15 +10,18 @@ import { loadCoreIconSet, loadEssentialIconSet } from '@cds/core/icon';
 import { setCompodocJson } from '@storybook/addon-docs/angular';
 
 import docs from '../documentation.json';
-import clrUiStyles from 'raw-loader!../dist/clr-ui/clr-ui.css';
-import clrUiDarkStyles from 'raw-loader!../dist/clr-ui/clr-ui-dark.css';
 import resetStyles from 'raw-loader!../node_modules/@cds/core/styles/module.reset.min.css';
 import tokensStyles from 'raw-loader!../node_modules/@cds/core/styles/module.tokens.min.css';
 import layoutStyles from 'raw-loader!../node_modules/@cds/core/styles/module.layout.min.css';
 import typographyStyles from 'raw-loader!../node_modules/@cds/core/styles/module.typography.min.css';
 import darkThemeStyles from 'raw-loader!../node_modules/@cds/core/styles/theme.dark.min.css';
 import highContrastThemeStyles from 'raw-loader!../node_modules/@cds/core/styles/theme.high-contrast.min.css';
-import shimStyles from 'raw-loader!../dist/clr-ui/shim.cds-core.css';
+
+// Styles that should be watched/reloaded
+import clrUiStyles from 'raw-loader!sass-loader!../projects/ui/src/clr-ui.scss';
+import clrUiDarkStyles from 'raw-loader!sass-loader!../projects/ui/src/clr-ui-dark.scss';
+import shimStyles from 'raw-loader!sass-loader!../projects/ui/src/shim.cds-core.scss';
+
 import { getClrUiAppBackgroundColor } from './helpers/clr-ui-theme.helpers';
 import { THEMES } from './helpers/constants';
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "preview": "semantic-release --plugins \"@semantic-release/commit-analyzer\" \"@semantic-release/release-notes-generator\" --dry-run --no-ci",
     "public-api:check": "api-extractor run",
     "public-api:update": "api-extractor run --local",
-    "start": "npm run clean && npm-run-all --parallel docs:json:watch _build:ui:css:watch _start:storybook",
+    "start": "npm run clean && npm-run-all --parallel docs:json:watch _start:storybook",
     "start:demo": "npm run clean && ng serve clr-demo",
     "start:demo:dark": "npm run start:demo -- -c dark",
     "test": "ng test clr-angular --source-map=false --watch=false",
@@ -30,7 +30,6 @@
     "_build:demo": "ng build clr-demo --configuration production",
     "_build:storybook": "npm run docs:json && STORYBOOK_ANGULAR_PROJECT=clr-angular build-storybook --output-dir ./dist/docs --webpack-stats-json",
     "_build:ui:css": "sass ./projects/ui/src:./dist/clr-ui --precision=8",
-    "_build:ui:css:watch": "npm run --silent _build:ui:css -- --watch --load-path=projects",
     "_build:ui:prefix": "postcss ./dist/clr-ui/clr-ui.css ./dist/clr-ui/clr-ui-dark.css --use autoprefixer --dir ./dist/clr-ui",
     "_build:ui:optimize": "npm-run-all _build:ui:optimize:*",
     "_build:ui:optimize:clr-ui": "csso ./dist/clr-ui/clr-ui.css --output ./dist/clr-ui/clr-ui.min.css --source-map file --no-restructure",
@@ -51,7 +50,7 @@
     "_lint:styles:fix": "npm run --silent _lint:styles -- --fix",
     "_lint:styles:changed": "node ./scripts/get-changed-files.js --command \"stylelint\" --filter \"**/*.{css,scss,sass}\"",
     "_lint:styles:changed:fix": "node ./scripts/get-changed-files.js --command \"stylelint --fix\" --filter \"**/*.{css,scss,sass}\"",
-    "_start:storybook": "wait-on ./documentation.json ./dist/clr-ui/clr-ui.css && STORYBOOK_ANGULAR_PROJECT=clr-angular start-storybook -p 6006"
+    "_start:storybook": "wait-on ./documentation.json && STORYBOOK_ANGULAR_PROJECT=clr-angular start-storybook -p 6006"
   },
   "devDependencies": {
     "@amanda-mitchell/semantic-release-npm-multiple": "3.5.0",


### PR DESCRIPTION
Reviving this change to import our scss files directly. Ideally, chromatic will now detect changes to scss files and trigger a full rebuild on any/all scss changes in the library. This also removes the --externals for package-lock, as this behavior *should* be trigger by chromatic. 