### PR TITLE
fix(dropdown): manage focus correctly when a modal is opened

### DIFF
--- a/.storybook/stories/dropdown/dropdown-item-that-opens-modal.stories.ts
+++ b/.storybook/stories/dropdown/dropdown-item-that-opens-modal.stories.ts
@@ -1,0 +1,55 @@
+/*
+ * Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ClrDropdownModule, ClrModalModule } from '@clr/angular';
+import { Parameters } from '@storybook/addons';
+import { Story } from '@storybook/angular';
+
+import { setupStorybook } from '../../helpers/setup-storybook.helpers';
+
+const defaultStory: Story = args => ({
+  template: `
+    <clr-dropdown [clrCloseMenuOnItemClick]="clrCloseMenuOnItemClick">
+      <button class="btn btn-outline-primary" clrDropdownTrigger>
+        Dropdown
+        <cds-icon shape="angle" direction="down"></cds-icon>
+      </button>
+      <clr-dropdown-menu>
+        <div clrDropdownItem (click)="modalOpen = true">Open Modal</div>
+        <div clrDropdownItem>Do Nothing</div>
+        <clr-dropdown>
+          <button clrDropdownTrigger>Nested Trigger</button>
+          <clr-dropdown-menu>
+            <div clrDropdownItem (click)="modalOpen = true">Open Modal</div>
+            <div clrDropdownItem>Do Nothing</div>
+          </clr-dropdown-menu>
+        </clr-dropdown>
+      </clr-dropdown-menu>
+    </clr-dropdown>
+
+    <clr-modal [(clrModalOpen)]="modalOpen">
+      <h3 class="modal-title">Modal</h3>
+      <div class="modal-body">
+        This is a modal.
+      </div>
+      <div class="modal-footer">
+        <button type="button" class="btn btn-primary" (click)="modalOpen = false">Close</button>
+      </div>
+    </clr-modal>
+  `,
+  props: { ...args },
+});
+
+const defaultParameters: Parameters = {
+  title: 'Dropdown/Dropdown Item That Opens Modal',
+  args: {
+    clrCloseMenuOnItemClick: true,
+  },
+};
+
+const variants: Parameters[] = [];
+
+setupStorybook([ClrModalModule, ClrDropdownModule], defaultStory, defaultParameters, variants);

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -2086,7 +2086,11 @@ export class ClrDestroyService extends Subject<void> implements OnDestroy {
 // @public (undocumented)
 export class ClrDropdown implements OnDestroy {
     // Warning: (ae-forgotten-export) The symbol "RootDropdownService" needs to be exported by the entry point index.d.ts
-    constructor(parent: ClrDropdown, toggleService: ClrPopoverToggleService, cdr: ChangeDetectorRef, dropdownService: RootDropdownService);
+    constructor(parent: ClrDropdown, toggleService: ClrPopoverToggleService, focusHandler: DropdownFocusHandler, cdr: ChangeDetectorRef, dropdownService: RootDropdownService);
+    // Warning: (ae-forgotten-export) The symbol "DropdownFocusHandler" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    focusHandler: DropdownFocusHandler;
     // (undocumented)
     isMenuClosable: boolean;
     // (undocumented)
@@ -2098,7 +2102,7 @@ export class ClrDropdown implements OnDestroy {
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<ClrDropdown, "clr-dropdown", never, { "isMenuClosable": "clrCloseMenuOnItemClick"; }, {}, never, ["*"], false, [{ directive: typeof i1_6.PopoverHostDirective; inputs: {}; outputs: {}; }]>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<ClrDropdown, [{ optional: true; skipSelf: true; }, null, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<ClrDropdown, [{ optional: true; skipSelf: true; }, null, null, null, null]>;
 }
 
 // @public (undocumented)
@@ -2121,7 +2125,6 @@ export class ClrDropdownItem {
 //
 // @public (undocumented)
 export class ClrDropdownMenu extends AbstractPopover implements AfterContentInit, OnDestroy {
-    // Warning: (ae-forgotten-export) The symbol "DropdownFocusHandler" needs to be exported by the entry point index.d.ts
     constructor(injector: Injector, parentHost: ElementRef<HTMLElement>, nested: ClrDropdownMenu, focusHandler: DropdownFocusHandler);
     // (undocumented)
     items: QueryList<FocusableItem>;

--- a/projects/angular/src/popover/dropdown/dropdown-item.ts
+++ b/projects/angular/src/popover/dropdown/dropdown-item.ts
@@ -52,6 +52,17 @@ export class ClrDropdownItem {
 
   @HostListener('click')
   private onDropdownItemClick(): void {
+    // Move focus back to the root dropdown trigger.
+    // This is done BEFORE the dropdown is closed so that focus gets moved properly if a modal is opened.
+    if (this.dropdown.isMenuClosable && !this.disabled && this.dropdown.toggleService.open) {
+      const rootDropdown = this.findRootDropdown();
+
+      rootDropdown.focusHandler.focus();
+      // Prevent moving focus back to the trigger when the dropdown menu is closed.
+      // Without this line, focus could be "stolen" from a modal that was opened from a dropdown item.
+      rootDropdown.focusHandler.focusBackOnTriggerWhenClosed = false;
+    }
+
     // Ensure that the dropdown is closed after custom dropdown item click event handlers have run.
     setTimeout(() => {
       if (this.dropdown.isMenuClosable && !this.disabled) {
@@ -74,5 +85,15 @@ export class ClrDropdownItem {
     if (this.disabled) {
       $event.stopImmediatePropagation();
     }
+  }
+
+  private findRootDropdown() {
+    let rootDropdown = this.dropdown;
+
+    while (rootDropdown.parent) {
+      rootDropdown = rootDropdown.parent;
+    }
+
+    return rootDropdown;
   }
 }

--- a/projects/angular/src/popover/dropdown/dropdown.ts
+++ b/projects/angular/src/popover/dropdown/dropdown.ts
@@ -10,7 +10,7 @@ import { Subscription } from 'rxjs';
 import { FOCUS_SERVICE_PROVIDER } from '../../utils/focus/focus.service';
 import { PopoverHostDirective } from '../../utils/popover/popover-host.directive';
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
-import { DROPDOWN_FOCUS_HANDLER_PROVIDER } from './providers/dropdown-focus-handler.service';
+import { DROPDOWN_FOCUS_HANDLER_PROVIDER, DropdownFocusHandler } from './providers/dropdown-focus-handler.service';
 import { ROOT_DROPDOWN_PROVIDER, RootDropdownService } from './providers/dropdown.service';
 
 @Component({
@@ -31,6 +31,7 @@ export class ClrDropdown implements OnDestroy {
     @Optional()
     public parent: ClrDropdown,
     public toggleService: ClrPopoverToggleService,
+    public focusHandler: DropdownFocusHandler,
     private cdr: ChangeDetectorRef,
     dropdownService: RootDropdownService
   ) {

--- a/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.service.ts
+++ b/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.service.ts
@@ -62,7 +62,7 @@ export class DropdownFocusHandler implements OnDestroy, FocusableItem {
     this._unlistenFuncs.push(() => subscription.unsubscribe());
   }
 
-  private focusBackOnTrigger = false;
+  focusBackOnTriggerWhenClosed = false;
 
   /**
    * Focus on the menu when it opens, and focus back on the root trigger when the whole dropdown becomes closed
@@ -73,11 +73,11 @@ export class DropdownFocusHandler implements OnDestroy, FocusableItem {
         // We reset the state of the focus service both on initialization and when closing.
         this.focusService.reset(this);
         // But we only actively focus the trigger when closing, not on initialization.
-        if (this.focusBackOnTrigger) {
+        if (this.focusBackOnTriggerWhenClosed) {
           this.focus();
         }
       }
-      this.focusBackOnTrigger = open;
+      this.focusBackOnTriggerWhenClosed = open;
     });
 
     this._unlistenFuncs.push(() => subscription.unsubscribe());
@@ -156,7 +156,7 @@ export class DropdownFocusHandler implements OnDestroy, FocusableItem {
             }
           }
           // We let the user move focus to where the want, we don't force the focus back on the trigger
-          this.focusBackOnTrigger = false;
+          this.focusBackOnTriggerWhenClosed = false;
           this.toggleService.open = false;
         })
       );


### PR DESCRIPTION
Say you have a dropdown item that opens a modal.

This is what happened before this fix:
1. The `clrDropdownItem` is clicked/activated.
2. The modal is opened and focus is moved to the modal title. (This is the custom dropdown item click event handler.)
3. The dropdown menu is closed and focus is moved to the dropdown trigger.
4. The user has to tab or click into the modal to use it.
5. When the modal is closed, focus is not moved back the dropdown trigger.

This is what happens after this fix:
1. The `clrDropdownItem` is clicked/activated.
2. Focus is moved to the dropdown trigger, but the dropdown menu remains open.
3. The modal is opened and focus is moved to the modal title. (This is the custom dropdown item click event handler.)
3. The dropdown menu is closed.
5. The user does NOT have to tab or click into the modal to use it.
6. When the modal is closed, focus is moved back to the dropdown trigger.

This could have been fixed by closing the dropdown menu after custom dropdown item click event handlers have run by removing the `setTimeout` in the `onDropdownItemClick` method; however, that would break event handlers in nested components when `*clrIfOpen` is used since the nested component would be destroyed before it has the chance to handle any events.

To work around that, I changed the code to move focus to the dropdown trigger without closing the dropdown menu. Note that it only does this if the dropdown is going to be closed. If the dropdown is configured to remain open after an item is clicked, focus is not moved.