### PR TITLE
fix(button): navigate menu via keyboard without moving focus

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -529,6 +529,10 @@ export class ClrButton implements LoadingListener {
     // (undocumented)
     ngAfterViewInit(): void;
     // (undocumented)
+    get role(): string;
+    // (undocumented)
+    get tabIndex(): string;
+    // (undocumented)
     templateRef: TemplateRef<ClrButton>;
     // (undocumented)
     get type(): string;
@@ -540,8 +544,9 @@ export class ClrButton implements LoadingListener {
 }
 
 // @public (undocumented)
-export class ClrButtonGroup implements AfterContentInit {
-    constructor(buttonGroupNewService: ButtonInGroupService, toggleService: ClrPopoverToggleService, commonStrings: ClrCommonStringsService, destroy$: ClrDestroyService);
+export class ClrButtonGroup implements AfterContentInit, AfterViewInit {
+    // Warning: (ae-forgotten-export) The symbol "ButtonGroupNavigationHandler" needs to be exported by the entry point index.d.ts
+    constructor(buttonGroupNewService: ButtonInGroupService, toggleService: ClrPopoverToggleService, commonStrings: ClrCommonStringsService, destroy$: ClrDestroyService, navigationHandler: ButtonGroupNavigationHandler);
     // (undocumented)
     buttonGroupNewService: ButtonInGroupService;
     // (undocumented)
@@ -551,18 +556,30 @@ export class ClrButtonGroup implements AfterContentInit {
     // (undocumented)
     commonStrings: ClrCommonStringsService;
     getMoveIndex(buttonToMove: ClrButton): number;
+    // Warning: (ae-forgotten-export) The symbol "InitialItem" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    InitialItem: typeof InitialItem;
     // (undocumented)
     initializeButtons(): void;
     // (undocumented)
     inlineButtons: ClrButton[];
     // (undocumented)
+    menu: ElementRef;
+    // (undocumented)
     menuButtons: ClrButton[];
     // (undocumented)
     get menuPosition(): string;
     set menuPosition(pos: string);
+    // (undocumented)
+    menuToggle: ElementRef;
     ngAfterContentInit(): void;
     // (undocumented)
+    ngAfterViewInit(): void;
+    // (undocumented)
     get open(): boolean;
+    // (undocumented)
+    openMenu(event: any, initialItem: InitialItem): void;
     // (undocumented)
     popoverId: string;
     // (undocumented)
@@ -5072,7 +5089,7 @@ export class ÇlrWrappedRow implements DynamicWrapper, AfterViewInit, OnDestroy 
 
 // Warnings were encountered during analysis:
 //
-// dist/clr-angular/button/button-group/button-group.d.ts:54:217 - (ae-forgotten-export) The symbol "i1_6" needs to be exported by the entry point index.d.ts
+// dist/clr-angular/button/button-group/button-group.d.ts:63:217 - (ae-forgotten-export) The symbol "i1_6" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/projects/angular/src/button/all.spec.ts
+++ b/projects/angular/src/button/all.spec.ts
@@ -6,10 +6,12 @@
 
 import ButtonGroupSpecs from './button-group/button-group.spec';
 import ButtonSpecs from './button-group/button.spec';
+import ButtonGroupNavigationHandlerSpecs from './providers/button-group-navigation-handler.spec';
 import ButtonInGroupServiceSpecs from './providers/button-in-group.service.spec';
 
 describe('Button Group Directives', () => {
   ButtonSpecs();
   ButtonInGroupServiceSpecs();
   ButtonGroupSpecs();
+  ButtonGroupNavigationHandlerSpecs();
 });

--- a/projects/angular/src/button/button-group/button-group.html
+++ b/projects/angular/src/button/button-group/button-group.html
@@ -10,16 +10,21 @@
 <ng-container *ngIf="menuButtons.length > 0">
   <div class="btn-group-overflow open" [ngClass]="menuPosition" #anchor>
     <button
+      #menuToggle
       class="btn dropdown-toggle"
       clrPopoverAnchor
       clrPopoverOpenCloseButton
+      (keydown.arrowup)="openMenu($event, InitialItem.LAST)"
+      (keydown.arrowdown)="openMenu($event, InitialItem.FIRST)"
       [attr.aria-controls]="popoverId"
       [attr.aria-expanded]="open"
       [attr.aria-label]="clrToggleButtonAriaLabel"
+      aria-haspopup="true"
     >
       <cds-icon shape="ellipsis-horizontal" [attr.title]="commonStrings.keys.more"></cds-icon>
     </button>
     <div
+      #menu
       role="menu"
       class="dropdown-menu clr-button-group-menu"
       [id]="popoverId"

--- a/projects/angular/src/button/button-group/button.spec.ts
+++ b/projects/angular/src/button/button-group/button.spec.ts
@@ -107,8 +107,6 @@ export default function (): void {
 
       it('supports a id input', () => {
         expect(componentInstance.button1.id).toBe('button1');
-        expect(componentInstance.button2.id).toBeNull();
-        expect(componentInstance.button3.id).toBeNull();
       });
 
       it('supports a disabled input which is set to an empty string when the user passes a value', () => {
@@ -234,8 +232,6 @@ export default function (): void {
       });
 
       it('sets the id correctly', () => {
-        expect(buttons[0].id).toBe('');
-        expect(buttons[1].id).toBe('');
         expect(buttons[2].id).toBe('button3');
       });
 

--- a/projects/angular/src/button/button-group/button.ts
+++ b/projects/angular/src/button/button-group/button.ts
@@ -6,6 +6,7 @@
 
 import { Component, EventEmitter, Input, Optional, Output, SkipSelf, TemplateRef, ViewChild } from '@angular/core';
 
+import { uniqueIdFactory } from '../../utils/id-generator/id-generator.service';
 import { ClrLoadingState } from '../../utils/loading/loading';
 import { LoadingListener } from '../../utils/loading/loading-listener';
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
@@ -21,6 +22,8 @@ import { ButtonInGroupService } from '../providers/button-in-group.service';
         [attr.type]="type"
         [attr.name]="name"
         [attr.disabled]="disabled"
+        [attr.tabindex]="tabIndex"
+        [attr.role]="role"
         [attr.id]="id"
       >
         <span class="spinner spinner-inline" *ngIf="loading"></span>
@@ -42,6 +45,14 @@ export class ClrButton implements LoadingListener {
     public buttonInGroupService: ButtonInGroupService,
     private toggleService: ClrPopoverToggleService
   ) {}
+
+  get role(): string {
+    return this.inMenu ? 'menuitem' : null;
+  }
+
+  get tabIndex(): string {
+    return this.inMenu ? '-1' : null;
+  }
 
   private _inMenu = false;
 
@@ -105,7 +116,7 @@ export class ClrButton implements LoadingListener {
     }
   }
 
-  private _id: string = null;
+  private _id: string = uniqueIdFactory();
 
   get id(): string {
     return this._id;

--- a/projects/angular/src/button/providers/button-group-navigation-handler.service.ts
+++ b/projects/angular/src/button/providers/button-group-navigation-handler.service.ts
@@ -1,0 +1,175 @@
+/*
+ * Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Injectable, Renderer2 } from '@angular/core';
+
+import { ClrPopoverToggleService } from '../../utils';
+import { Keys } from '../../utils/enums/keys.enum';
+import { ArrowKeyDirection } from '../../utils/focus/arrow-key-direction.enum';
+import { Linkers } from '../../utils/focus/focusable-item/linkers';
+import { ButtonGroupNavigationItem } from './button-group-navigation-item';
+import { InitialItem } from './button-group-navigation.enum';
+
+@Injectable()
+export class ButtonGroupNavigationHandler {
+  private initialItem: InitialItem = InitialItem.FIRST;
+  private _unlistenFuncs: (() => void)[] = [];
+  private _menuOpened: boolean;
+  private _current: ButtonGroupNavigationItem | null = null;
+  private buttons: ButtonGroupNavigationItem[];
+  menuToggle: HTMLElement;
+  menu: HTMLElement;
+
+  get current(): ButtonGroupNavigationItem | null {
+    return this._current;
+  }
+
+  get menuOpened(): boolean {
+    return this._menuOpened;
+  }
+
+  set menuOpened(value: boolean) {
+    this._menuOpened = value;
+    if (this._menuOpened) {
+      this.initialize();
+    } else {
+      this.detachListeners();
+    }
+  }
+
+  constructor(private renderer: Renderer2, private toggleService: ClrPopoverToggleService) {}
+
+  setInitialItem(initialItem: InitialItem) {
+    this.initialItem = initialItem;
+  }
+
+  setCurrentItem(current: ButtonGroupNavigationItem) {
+    this._current = current;
+    this.buttons.forEach(button => {
+      if (button.id === this.current.id) {
+        button.element.classList.add('clr-focus');
+      } else {
+        button.element.classList.remove('clr-focus');
+      }
+    });
+  }
+
+  focusMenuToggle() {
+    this.menuToggle.focus();
+  }
+
+  initialize() {
+    this.listenToKeys(this.menuToggle);
+    this.buttons = this.linkButtons();
+    switch (this.initialItem) {
+      case InitialItem.LAST:
+        this.selectLastItem();
+        break;
+      default:
+        this.selectFirstItem();
+        break;
+    }
+  }
+
+  isCurrent(id: string) {
+    return this.current?.id === id;
+  }
+
+  private listenToKeys(el: HTMLElement) {
+    this._unlistenFuncs.push(this.renderer.listen(el, 'keydown.tab', е => this.closeOnTab(е)));
+    this._unlistenFuncs.push(this.renderer.listen(el, 'keydown.shift.tab', е => this.closeOnTab(е)));
+    // The following listeners return false when there was an action to take for the key pressed,
+    // in order to prevent the default behavior of that key.
+    this._unlistenFuncs.push(this.renderer.listen(el, 'keydown.enter', () => !this.trigger(Keys.Enter)));
+    this._unlistenFuncs.push(this.renderer.listen(el, 'keydown.space', () => !this.trigger(Keys.Space)));
+    this._unlistenFuncs.push(this.renderer.listen(el, 'keydown.arrowup', () => !this.move(ArrowKeyDirection.UP)));
+    this._unlistenFuncs.push(this.renderer.listen(el, 'keydown.arrowdown', () => !this.move(ArrowKeyDirection.DOWN)));
+  }
+
+  private closeOnTab(event: KeyboardEvent) {
+    if (this.toggleService.open) {
+      this.toggleService.toggleWithEvent(event);
+    }
+  }
+
+  private trigger(key: Keys) {
+    if (this.menuOpened && [Keys.Enter, Keys.Space].includes(key)) {
+      this.current.click();
+      return true;
+    }
+    return false;
+  }
+
+  private handleButtonHover(index) {
+    this.setCurrentItem(this.buttons[index]);
+  }
+
+  private move(direction: ArrowKeyDirection): boolean {
+    let moved = false;
+    switch (direction) {
+      case ArrowKeyDirection.UP:
+        if (this.current[direction]) {
+          this.setCurrentItem(this.current[direction] as ButtonGroupNavigationItem);
+        } else {
+          this.selectLastItem();
+        }
+        moved = true;
+        break;
+      case ArrowKeyDirection.DOWN:
+        if (this.current[direction]) {
+          this.setCurrentItem(this.current[direction] as ButtonGroupNavigationItem);
+        } else {
+          this.selectFirstItem();
+        }
+        moved = true;
+        break;
+    }
+    return moved;
+  }
+
+  private linkButtons() {
+    const buttonElements = Array.from(this.menu.children) as HTMLElement[];
+    const buttons = buttonElements.map<ButtonGroupNavigationItem>((buttonElement, index) => {
+      this._unlistenFuncs.push(this.renderer.listen(buttonElement, 'click', this.focusMenuToggle.bind(this)));
+      this._unlistenFuncs.push(
+        this.renderer.listen(buttonElement, 'mouseenter', this.handleButtonHover.bind(this, index))
+      );
+      return {
+        id: buttonElement.id,
+        element: buttonElement,
+        focus: () => buttonElement.focus(),
+        blur: () => buttonElement.blur(),
+        click: () => buttonElement.click(),
+      };
+    });
+
+    Linkers.linkVertical(buttons, false);
+
+    return buttons;
+  }
+
+  private selectFirstItem(): void {
+    if (this.buttons.length) {
+      this.setCurrentItem(this.buttons[0]);
+    }
+    this.setInitialItem(InitialItem.FIRST);
+  }
+
+  private selectLastItem(): void {
+    if (this.buttons.length) {
+      this.setCurrentItem(this.buttons[this.buttons.length - 1]);
+    }
+    this.setInitialItem(InitialItem.FIRST);
+  }
+
+  private detachListeners() {
+    this._unlistenFuncs.forEach(unlisten => unlisten());
+  }
+}
+
+export const BUTTON_GROUP_NAVIGATION_HANDLER_PROVIDER = {
+  provide: ButtonGroupNavigationHandler,
+};

--- a/projects/angular/src/button/providers/button-group-navigation-handler.spec.ts
+++ b/projects/angular/src/button/providers/button-group-navigation-handler.spec.ts
@@ -1,0 +1,117 @@
+/*
+ * Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, ViewChild } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { ClrPopoverToggleService } from '../../utils';
+import { Keys } from '../../utils/enums/keys.enum';
+import { ClrButtonGroupModule } from '../button-group';
+import { ClrButtonGroup } from '../button-group/button-group';
+import {
+  BUTTON_GROUP_NAVIGATION_HANDLER_PROVIDER,
+  ButtonGroupNavigationHandler,
+} from './button-group-navigation-handler.service';
+import { InitialItem } from './button-group-navigation.enum';
+
+@Component({
+  template: `
+    <clr-button-group>
+      <clr-button>Button 1</clr-button>
+      <clr-button>Button 2</clr-button>
+      <clr-button [clrInMenu]="true">Button 3</clr-button>
+      <clr-button [clrInMenu]="true">Button 4</clr-button>
+      <clr-button [clrInMenu]="true">Button 5</clr-button>
+    </clr-button-group>
+  `,
+  providers: [BUTTON_GROUP_NAVIGATION_HANDLER_PROVIDER, ClrPopoverToggleService],
+})
+class BtnGroupViewContainer {
+  @ViewChild(ClrButtonGroup) btnGroup: ClrButtonGroup;
+}
+
+interface TestContext {
+  fixture: ComponentFixture<BtnGroupViewContainer>;
+  compiled: any;
+  navigationHandler: ButtonGroupNavigationHandler;
+  outside: HTMLElement;
+  menu: HTMLElement;
+  menuToggle: HTMLElement;
+  testBtnGroup: ClrButtonGroup;
+}
+
+export default function (): void {
+  describe('ButtonGroupNavigationHandler', function () {
+    describe('Default Button Group', function () {
+      beforeEach(function (this: TestContext) {
+        TestBed.configureTestingModule({ imports: [ClrButtonGroupModule], declarations: [BtnGroupViewContainer] });
+        this.fixture = TestBed.createComponent(BtnGroupViewContainer);
+        this.navigationHandler = this.fixture.debugElement.injector.get(ButtonGroupNavigationHandler);
+
+        this.fixture.detectChanges();
+        this.compiled = this.fixture.nativeElement;
+        this.testBtnGroup = this.fixture.componentInstance.btnGroup;
+
+        this.menuToggle = this.testBtnGroup.menuToggle.nativeElement;
+        this.menuToggle.click();
+        this.fixture.detectChanges();
+
+        this.menu = this.testBtnGroup.menu.nativeElement;
+        this.outside = document.createElement('button');
+
+        this.navigationHandler.menu = this.menu;
+        this.navigationHandler.menuToggle = this.menuToggle;
+
+        // We need this element in the DOM to be able to focus it
+        document.body.append(this.outside);
+      });
+
+      afterEach(function (this: TestContext) {
+        document.body.removeChild(this.outside);
+        this.fixture.destroy();
+      });
+
+      it('declares a ButtonGroupNavigationHandler provider', function (this: TestContext) {
+        expect(this.navigationHandler).not.toBeNull();
+      });
+
+      it('initializes the buttons correctly', function (this: TestContext) {
+        expect(this.testBtnGroup.inlineButtons.length).toBe(2);
+        expect(this.testBtnGroup.menuButtons.length).toBe(3);
+      });
+
+      it('button group menu is opened', function (this: TestContext) {
+        expect(this.testBtnGroup.open).toBeTruthy();
+      });
+
+      it('first child is with clr-focus class after open', function (this: TestContext) {
+        this.navigationHandler.menuOpened = true;
+        const firstChild = this.menu.children[0];
+        expect(firstChild.classList.contains('clr-focus')).toBe(true);
+      });
+      it('last child is with clr-focus class after open', function (this: TestContext) {
+        this.navigationHandler.setInitialItem(InitialItem.LAST);
+        this.navigationHandler.menuOpened = true;
+        const lastChild = this.menu.children[this.menu.children.length - 1];
+        expect(lastChild.classList.contains('clr-focus')).toBe(true);
+      });
+
+      it('last button in the menu is with clr-focus on key down events', function (this: TestContext) {
+        this.navigationHandler.menuOpened = true;
+        this.menuToggle.dispatchEvent(new KeyboardEvent('keydown', { key: Keys.ArrowDown }));
+        this.menuToggle.dispatchEvent(new KeyboardEvent('keydown', { key: Keys.ArrowDown }));
+        const lastChild = this.menu.children[this.menu.children.length - 1];
+        expect(lastChild.classList.contains('clr-focus')).toBe(true);
+      });
+
+      it('does not prevent moving focus to a different part of the page', function (this: TestContext) {
+        this.navigationHandler.menuOpened = true;
+        this.outside.focus();
+        expect(document.activeElement).toBe(this.outside);
+      });
+    });
+  });
+}

--- a/projects/angular/src/button/providers/button-group-navigation-item.ts
+++ b/projects/angular/src/button/providers/button-group-navigation-item.ts
@@ -1,0 +1,13 @@
+/*
+ * Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { FocusableItem } from '../../utils/focus/focusable-item/focusable-item';
+
+export abstract class ButtonGroupNavigationItem extends FocusableItem {
+  abstract click?(): void;
+
+  element: HTMLElement;
+}

--- a/projects/angular/src/button/providers/button-group-navigation.enum.ts
+++ b/projects/angular/src/button/providers/button-group-navigation.enum.ts
@@ -1,0 +1,10 @@
+/*
+ * Copyright (c) 2016-2023 VMware, Inc. All Rights Reserved.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export enum InitialItem {
+  FIRST = 'first', // Focus first item
+  LAST = 'last', // Focus last item
+}

--- a/projects/angular/src/popover/dropdown/_menu-mixins.clarity.scss
+++ b/projects/angular/src/popover/dropdown/_menu-mixins.clarity.scss
@@ -56,6 +56,7 @@
   width: 100%;
   text-transform: none;
 
+  &.clr-focus,
   &:hover {
     @include css-var(
       background-color,

--- a/projects/angular/src/utils/focus/focus.service.ts
+++ b/projects/angular/src/utils/focus/focus.service.ts
@@ -33,8 +33,8 @@ export class FocusService {
     this._unlistenFuncs.push(this.renderer.listen(el, 'keydown.arrowright', () => !this.move(ArrowKeyDirection.RIGHT)));
   }
 
-  registerContainer(el: HTMLElement) {
-    this.renderer.setAttribute(el, 'tabindex', '0');
+  registerContainer(el: HTMLElement, tabIndex = '0') {
+    this.renderer.setAttribute(el, 'tabindex', tabIndex);
     this.listenToArrowKeys(el);
     // The following listeners return false when there was an action to take for the key pressed,
     // in order to prevent the default behavior of that key.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- Changed the behavior of the keyboard navigation in menu to support all a11y requirements. 
- Keyboard navigation is now handled with having a current item in the menu while the focus is not changed and it's staying on the toggle button as required. This help us resolve all a11y issues which were not resolved with the previous functionality. 

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [X] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behaviour ?

- Currently the service we created was working with another "FocusService" and the navigation was happening trough focusing different items. 

Issue Number: CDE-68

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
