### PR TITLE
fix(tooltip): prevent flashing when hovering trigger (backport to 13.x)

### DIFF
--- a/projects/angular/src/popover/tooltip/_tooltips.clarity.scss
+++ b/projects/angular/src/popover/tooltip/_tooltips.clarity.scss
@@ -55,6 +55,8 @@
     }
     border-#{$dirB}: $arrow-height solid transparent;
     border-#{$oppA}: $arrow-width solid transparent;
+
+    pointer-events: none;
   }
 }
 
@@ -89,6 +91,8 @@
     }
     border-bottom: $arrow-height solid transparent;
     border-#{$oppA}: $arrow-width solid transparent;
+
+    pointer-events: none;
   }
 }
 


### PR DESCRIPTION
When a tooltip trigger is hovered, there is a tiny chance that the `::before` pseudo-element of the tooltip content will pop up under the mouse pointer and cause the tooltip trigger to no longer be hovered and the tooltip content (with its `::before` pseudo-element) to disappear. Then the mouse pointer hovers over the tooltip trigger again, and the tooltip content pops up, and this cycle repeats, causing the tooltip content to flash cyclically.

With this fix, no matter where the mouse pointer hovers over the tooltip trigger, once the tooltip content appears, its `::before` pseudo-element will not be the target of pointer events, so the tooltip trigger's hover state will not change.

This is a backport of 98a5ec9080e71e420cc923abd64246e2e0505fe4 (#560) to 13.x.