### PR TITLE
chore(dropdown): remove redundant visual regression test

### DIFF
--- a/.storybook/stories/dropdown/dropdown-item-that-opens-modal.stories.ts
+++ b/.storybook/stories/dropdown/dropdown-item-that-opens-modal.stories.ts
@@ -50,6 +50,4 @@ const defaultParameters: Parameters = {
   },
 };
 
-const variants: Parameters[] = [];
-
-setupStorybook([ClrModalModule, ClrDropdownModule], defaultStory, defaultParameters, variants);
+setupStorybook([ClrModalModule, ClrDropdownModule], defaultStory, defaultParameters);


### PR DESCRIPTION
This story is for testing a specific interaction. The snapshot is not visually different than the default dropdown story.

This fixes a mistake I made in 510d78c2b87a4ffe4eba1b920d689d6860500401.