### PR TITLE
chore: revert cds-text on body of storybook core theme pages

### DIFF
--- a/.storybook/pages/cds-core-shim.stories.mdx
+++ b/.storybook/pages/cds-core-shim.stories.mdx
@@ -11,9 +11,8 @@ themes. The shim maps colors, spacing and typography values to the `@cds/core` d
 If your application does not use `@clr/ui`, this shim is not needed.
 
 Follow the [Getting Started](https://storybook.core.clarity.design/?path=/story/documentation-getting-started--page)
-directions for Clarity Core, including loading the relevant CSS files, setting the `cds-theme` and `cds-text="body"`
-attributes on the body tag. The shim will not be applied to `@clr/ui` or `@clr/angular` components properly
-without these attributes.
+directions for Clarity Core, including loading the relevant CSS files and setting the `cds-theme` attribute on the body
+tag. The shim will not be applied to `@clr/ui` or `@clr/angular` components properly without this attribute.
 
 Import and load the CSS shim file last after `@clr/ui` global CSS. This will ensure that the shim can
 override the `@clr/ui` values appropriately.

--- a/.storybook/preview.js
+++ b/.storybook/preview.js
@@ -28,7 +28,6 @@ import { THEMES } from './helpers/constants';
 
 const privateModifier = 121;
 const cdsThemeAttribute = 'cds-theme';
-const cdsTextAttribute = 'cds-text';
 const styleElement = addStyleElement();
 
 const cdsCoreAndShimStyles = [
@@ -84,19 +83,16 @@ const themeDecorator = (story, { globals, parameters }) => {
   switch (currentTheme) {
     case THEMES.NG_LIGHT:
       styleElement.textContent = clrUiStyles;
-      document.body.removeAttribute(cdsTextAttribute);
       document.body.removeAttribute(cdsThemeAttribute);
       document.body.style.backgroundColor = getClrUiAppBackgroundColor(currentTheme);
       break;
     case THEMES.NG_DARK:
       styleElement.textContent = clrUiDarkStyles;
-      document.body.removeAttribute(cdsTextAttribute);
       document.body.removeAttribute(cdsThemeAttribute);
       document.body.style.backgroundColor = getClrUiAppBackgroundColor(currentTheme);
       break;
     default:
       styleElement.textContent = `${clrUiStyles}${cdsCoreAndShimStyles.join('')}`;
-      document.body.setAttribute(cdsTextAttribute, 'body');
       document.body.setAttribute(cdsThemeAttribute, currentTheme);
       document.body.style.backgroundColor = null;
       break;


### PR DESCRIPTION
Reverts the changes to the storybook pages when using the shim (adding cds-text="body" to the body tag). This change introduced a lot of undesired visual changes and should be introduced in a more granular way as we iterate. 