### PR TITLE
feat(checkbox,radio,tree): refactor checbox/radio label styles to classes (backport to 13.x)

### DIFF
--- a/projects/angular/src/data/tree-view/_tree-view.clarity.scss
+++ b/projects/angular/src/data/tree-view/_tree-view.clarity.scss
@@ -160,10 +160,14 @@
     @include equilateral($clr-tree-node-touch-target);
     padding-top: $clr-tree-checkbox-padding-top;
     padding-left: $clr-tree-checkbox-padding-left;
-  }
 
-  .clr-tree-node-content-container > .clr-checkbox-wrapper:first-child {
-    margin-left: $clr-tree-node-touch-target;
+    &:first-child {
+      margin-left: $clr-tree-node-touch-target;
+    }
+
+    .clr-control-label {
+      font-size: $clr-tree-node-checkbox-label-font-size;
+    }
   }
 
   .clr-treenode-content .label {

--- a/projects/angular/src/data/tree-view/_variables.tree-view.scss
+++ b/projects/angular/src/data/tree-view/_variables.tree-view.scss
@@ -21,3 +21,4 @@ $clr-tree-link-text-color: $clr-color-neutral-700 !default;
 $clr-tree-checkbox-padding-top: ($clr-tree-node-touch-target - $clr_baselineRem_1) * 0.5 !default;
 $clr-tree-checkbox-padding-left: ($clr-tree-node-touch-target - $clr-icon-dimension-sm) * 0.5 !default;
 $clr-tree-node-caret-color: $clr-color-neutral-500 !default;
+$clr-tree-node-checkbox-label-font-size: $clr-p1-font-size !default;

--- a/projects/angular/src/forms/styles/_checkbox.clarity.scss
+++ b/projects/angular/src/forms/styles/_checkbox.clarity.scss
@@ -12,13 +12,7 @@
     @include form-flatten-validate-text();
     position: relative;
 
-    //Hide the default checkbox behind the pseudo elements
-    //Opacity is set to 0 so that the input remains accessible
-    input[type='checkbox'] {
-      @include checkbox-radio-input-styles($clr-forms-checkbox-size);
-    }
-
-    label {
+    .clr-control-label {
       @include checkbox-radio-label-styles(
         $clr-forms-checkbox-label-height,
         $clr-forms-checkbox-padding-left,
@@ -27,8 +21,14 @@
       );
     }
 
+    //Hide the default checkbox behind the pseudo elements
+    //Opacity is set to 0 so that the input remains accessible
+    input[type='checkbox'] {
+      @include checkbox-radio-input-styles($clr-forms-checkbox-size);
+    }
+
     //Checkbox base
-    input[type='checkbox'] + label::before {
+    input[type='checkbox'] + .clr-control-label::before {
       @include checkbox-radio-shared-inactive(
         $clr-forms-checkbox-height,
         $clr-forms-checkbox-top,
@@ -44,12 +44,12 @@
       );
     }
 
-    input[type='checkbox']:focus + label::before {
+    input[type='checkbox']:focus + .clr-control-label::before {
       @include include-outline-style-form-fields();
     }
 
     //Checkmark
-    input[type='checkbox'] + label::after {
+    input[type='checkbox'] + .clr-control-label::after {
       position: absolute;
       content: '';
       display: none;
@@ -68,7 +68,7 @@
       transform: translate(0, $mark-half-size) rotate(-45deg);
     }
 
-    input[type='checkbox']:checked + label::before {
+    input[type='checkbox']:checked + .clr-control-label::before {
       @include css-var(
         background,
         clr-forms-checkbox-background-color,
@@ -78,20 +78,20 @@
       border: none;
     }
 
-    input[type='checkbox']:checked + label::after {
+    input[type='checkbox']:checked + .clr-control-label::after {
       display: inline-block;
     }
 
     $indetermSassBrdrColorVar: $clr-forms-checkbox-indeterminate-border-color;
     $indetermCssBrdrColorVar: clr-forms-checkbox-indeterminate-border-color;
-    input[type='checkbox'].clr-indeterminate + label::before,
-    input[type='checkbox']:indeterminate + label::before {
+    input[type='checkbox'].clr-indeterminate + .clr-control-label::before,
+    input[type='checkbox']:indeterminate + .clr-control-label::before {
       border: $clr-global-borderwidth solid;
       @include css-var(border-color, $indetermCssBrdrColorVar, $indetermSassBrdrColorVar, $clr-use-custom-properties);
     }
 
-    input[type='checkbox'].clr-indeterminate + label::after,
-    input[type='checkbox']:indeterminate + label::after {
+    input[type='checkbox'].clr-indeterminate + .clr-control-label::after,
+    input[type='checkbox']:indeterminate + .clr-control-label::after {
       border-left: none;
       @include css-var(
         border-bottom-color,
@@ -108,17 +108,24 @@
     }
   }
 
-  .clr-error .clr-checkbox-wrapper input[type='checkbox'] + label::before {
+  .clr-error .clr-checkbox-wrapper input[type='checkbox'] + .clr-control-label::before {
     @include css-var(border-color, clr-forms-invalid-color, $clr-forms-invalid-color, $clr-use-custom-properties);
   }
 
   .clr-form-control-disabled .clr-checkbox-wrapper {
-    label {
+    .clr-control-label {
       cursor: not-allowed;
+
+      @include css-var(
+        color,
+        clr-forms-label-disabled-color,
+        $clr-forms-label-disabled-color,
+        $clr-use-custom-properties
+      );
     }
 
-    input[type='checkbox'] + label::before,
-    input[type='checkbox']:checked + label::before {
+    input[type='checkbox'] + .clr-control-label::before,
+    input[type='checkbox']:checked + .clr-control-label::before {
       @include css-var(
         background-color,
         clr-forms-checkbox-disabled-background-color,
@@ -128,7 +135,7 @@
       border: none;
     }
 
-    input[type='checkbox']:checked + label::after {
+    input[type='checkbox']:checked + .clr-control-label::after {
       $sassVar: $clr-forms-checkbox-disabled-mark-color;
       $cssVar: clr-forms-checkbox-disabled-mark-color;
       $disabled-border-style: ($clr-forms-checkbox-height * 0.125) solid;
@@ -138,8 +145,8 @@
       @include css-var(border-bottom-color, $cssVar, $sassVar, $clr-use-custom-properties);
     }
 
-    input[type='checkbox']:checked.clr-indeterminate + label::after,
-    input[type='checkbox']:checked:indeterminate + label::after {
+    input[type='checkbox']:checked.clr-indeterminate + .clr-control-label::after,
+    input[type='checkbox']:checked:indeterminate + .clr-control-label::after {
       border-left: none;
     }
   }

--- a/projects/angular/src/forms/styles/_mixins.forms.scss
+++ b/projects/angular/src/forms/styles/_mixins.forms.scss
@@ -135,7 +135,7 @@
   position: relative;
 
   //Display
-  display: inline-block;
+  display: block;
   min-height: $min-height;
   padding-left: $padding-left;
   margin-top: 0;

--- a/projects/angular/src/forms/styles/_radio.clarity.scss
+++ b/projects/angular/src/forms/styles/_radio.clarity.scss
@@ -16,7 +16,7 @@
       @include checkbox-radio-input-styles($clr-forms-radio-size);
     }
 
-    label {
+    .clr-control-label {
       @include checkbox-radio-label-styles(
         $clr-forms-radio-label-height,
         $clr-forms-radio-padding-left,
@@ -25,12 +25,12 @@
       );
     }
 
-    label:empty {
+    .clr-control-label:empty {
       padding-left: 0;
     }
 
     //Radio button base
-    input[type='radio'] + label::before {
+    input[type='radio'] + .clr-control-label::before {
       @include checkbox-radio-shared-inactive(
         $clr-forms-radio-height,
         $clr-forms-radio-top,
@@ -42,7 +42,7 @@
     }
 
     //Checked Radio Styles
-    input[type='radio']:checked + label::before {
+    input[type='radio']:checked + .clr-control-label::before {
       @include css-var(
         box-shadow,
         clr-forms-radio-selected-shadow,
@@ -53,16 +53,16 @@
     }
 
     //Outline color for unchecked radios
-    input[type='radio']:focus + label::before {
+    input[type='radio']:focus + .clr-control-label::before {
       @include include-outline-style-form-fields();
     }
 
     //Outline color for checked radios
-    input[type='radio']:focus:checked + label::before {
+    input[type='radio']:focus:checked + .clr-control-label::before {
       @include include-outline-style-form-fields();
     }
 
-    input[type='radio']:disabled + label::before {
+    input[type='radio']:disabled + .clr-control-label::before {
       border: 0;
       //background-color around the dot
       @include css-var(
@@ -73,7 +73,7 @@
       );
     }
 
-    input[type='radio']:checked:disabled + label::before {
+    input[type='radio']:checked:disabled + .clr-control-label::before {
       @include css-var(
         background-color,
         clr-forms-radio-disabled-background-color,
@@ -91,12 +91,12 @@
   }
 
   .clr-form-control-disabled .clr-radio-wrapper {
-    label {
+    .clr-control-label {
       cursor: not-allowed;
     }
   }
 
-  .clr-error .clr-radio-wrapper input[type='radio'] + label::before {
+  .clr-error .clr-radio-wrapper input[type='radio'] + .clr-control-label::before {
     @include css-var(border-color, clr-forms-invalid-color, $clr-forms-invalid-color, $clr-use-custom-properties);
   }
 


### PR DESCRIPTION
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

The checkbox/radio label styles are designed to only work with the semantic label element.

Issue Number: N/A

This change refactors the checkbox/radio label styles to use a class, as a valid use case for the selectable rows feature in data grid causing a label to be nested within a label. In the future, we may want to expand this to be an option on the checkbox/label component, since another valid use case for a checkbox is to have it be a wrapping element around a checkbox.

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
