### PR TITLE
chore: fetch just head commit in release workflows

### DIFF
--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,8 +9,6 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
-        with:
-          fetch-depth: 0
       - name: Setup Node.js
         uses: actions/setup-node@v3
         with:


### PR DESCRIPTION
I missed this in c3b0ab50d46196b6f2129c17fa37a9f95f549d05.

That commit did not fully revert ddebc67c694681045ef2a55879454d0fed5399a4.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

CI related changes

## Does this PR introduce a breaking change?

No.