### PR TITLE
chore(datagrid): remove redundant default values for filter placeholders

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1226,14 +1226,12 @@ export class ClrDatagridCell implements OnInit {
 export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements OnDestroy, OnInit, OnChanges {
     // Warning: (ae-forgotten-export) The symbol "Sort" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "FiltersProvider" needs to be exported by the entry point index.d.ts
-    constructor(_sort: Sort<T>, filters: FiltersProvider<T>, vcr: ViewContainerRef, detailService: DetailService, changeDetectorRef: ChangeDetectorRef, commonStrings: ClrCommonStringsService);
+    constructor(_sort: Sort<T>, filters: FiltersProvider<T>, vcr: ViewContainerRef, detailService: DetailService, changeDetectorRef: ChangeDetectorRef);
     // (undocumented)
     get ariaSort(): "none" | "ascending" | "descending";
     // (undocumented)
     get colType(): 'string' | 'number';
     set colType(value: 'string' | 'number');
-    // (undocumented)
-    commonStrings: ClrCommonStringsService;
     customFilter: boolean;
     // (undocumented)
     get field(): string;
@@ -1241,14 +1239,8 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDa
     // (undocumented)
     filterNumberMaxPlaceholder: string;
     // (undocumented)
-    get filterNumberMaxPlaceholderValue(): string;
-    // (undocumented)
     filterNumberMinPlaceholder: string;
-    // (undocumented)
-    get filterNumberMinPlaceholderValue(): string;
     filterStringPlaceholder: string;
-    // (undocumented)
-    get filterStringPlaceholderValue(): string;
     // (undocumented)
     get filterValue(): any;
     set filterValue(newValue: any);

--- a/projects/angular/src/data/datagrid/datagrid-column.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column.ts
@@ -22,7 +22,6 @@ import {
 import { Subscription } from 'rxjs';
 
 import { HostWrapper } from '../../utils/host-wrapping/host-wrapper';
-import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { PopoverHostDirective } from '../../utils/popover/popover-host.directive';
 import { DatagridPropertyComparator } from './built-in/comparators/datagrid-property-comparator';
 import { DatagridNumericFilterImpl } from './built-in/filters/datagrid-numeric-filter-impl';
@@ -58,15 +57,15 @@ import { WrappedColumn } from './wrapped-column';
 
       <clr-dg-string-filter
         *ngIf="field && !customFilter && colType == 'string'"
-        [clrFilterPlaceholder]="filterStringPlaceholderValue"
+        [clrFilterPlaceholder]="filterStringPlaceholder"
         [clrDgStringFilter]="registered"
         [(clrFilterValue)]="filterValue"
       ></clr-dg-string-filter>
 
       <clr-dg-numeric-filter
         *ngIf="field && !customFilter && colType == 'number'"
-        [clrFilterMaxPlaceholder]="filterNumberMaxPlaceholderValue"
-        [clrFilterMinPlaceholder]="filterNumberMinPlaceholderValue"
+        [clrFilterMaxPlaceholder]="filterNumberMaxPlaceholder"
+        [clrFilterMinPlaceholder]="filterNumberMinPlaceholder"
         [clrDgNumericFilter]="registered"
         [(clrFilterValue)]="filterValue"
       ></clr-dg-numeric-filter>
@@ -99,8 +98,7 @@ export class ClrDatagridColumn<T = any>
     filters: FiltersProvider<T>,
     private vcr: ViewContainerRef,
     private detailService: DetailService,
-    private changeDetectorRef: ChangeDetectorRef,
-    public commonStrings: ClrCommonStringsService
+    private changeDetectorRef: ChangeDetectorRef
   ) {
     super(filters);
     this.subscriptions.push(this.listenForSortingChanges());
@@ -335,19 +333,8 @@ export class ClrDatagridColumn<T = any>
    * Help with accessibility for screen readers by providing custom placeholder text inside internal filters
    */
   @Input('clrFilterStringPlaceholder') filterStringPlaceholder: string;
-  get filterStringPlaceholderValue() {
-    return this.filterStringPlaceholder || this.commonStrings.keys.filterItems;
-  }
-
   @Input('clrFilterNumberMaxPlaceholder') filterNumberMaxPlaceholder: string;
-  get filterNumberMaxPlaceholderValue() {
-    return this.filterNumberMaxPlaceholder || this.commonStrings.keys.maxValue;
-  }
-
   @Input('clrFilterNumberMinPlaceholder') filterNumberMinPlaceholder: string;
-  get filterNumberMinPlaceholderValue() {
-    return this.filterNumberMinPlaceholder || this.commonStrings.keys.minValue;
-  }
 
   @Input('clrFilterValue')
   set updateFilterValue(newValue: string | [number, number]) {


### PR DESCRIPTION
The string and number filter components provide the default values.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

No.