### PR TITLE
fix(datagrid): apply min/max filter placeholder values from column (backport to 13.x)

### DIFF
--- a/projects/angular/src/data/datagrid/datagrid-column.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column.ts
@@ -67,8 +67,8 @@ import { WrappedColumn } from './wrapped-column';
 
       <clr-dg-numeric-filter
         *ngIf="field && !customFilter && colType == 'number'"
-        [clrFilterMaxPlaceholder]="filterMaxPlaceholderValue"
-        [clrFilterMinPlaceholder]="filterMinPlaceholderValue"
+        [clrFilterMaxPlaceholder]="filterNumberMaxPlaceholderValue"
+        [clrFilterMinPlaceholder]="filterNumberMinPlaceholderValue"
         [clrDgNumericFilter]="registered"
         [(clrFilterValue)]="filterValue"
       ></clr-dg-numeric-filter>


### PR DESCRIPTION
The `clr-dg-column` inputs for the min/max filter placeholder values didn't work.

This is a backport of #590 to 13.x.