### PR TITLE
chore(datagrid): remove redundant default values for filter placeholders

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1264,14 +1264,12 @@ export class ClrDatagridCell implements OnInit {
 export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements OnDestroy, OnInit, OnChanges {
     // Warning: (ae-forgotten-export) The symbol "Sort" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "FiltersProvider" needs to be exported by the entry point index.d.ts
-    constructor(_sort: Sort<T>, filters: FiltersProvider<T>, vcr: ViewContainerRef, detailService: DetailService, changeDetectorRef: ChangeDetectorRef, commonStrings: ClrCommonStringsService);
+    constructor(_sort: Sort<T>, filters: FiltersProvider<T>, vcr: ViewContainerRef, detailService: DetailService, changeDetectorRef: ChangeDetectorRef);
     // (undocumented)
     get ariaSort(): "none" | "ascending" | "descending";
     // (undocumented)
     get colType(): 'string' | 'number';
     set colType(value: 'string' | 'number');
-    // (undocumented)
-    commonStrings: ClrCommonStringsService;
     customFilter: boolean;
     // (undocumented)
     get field(): string;
@@ -1279,14 +1277,8 @@ export class ClrDatagridColumn<T = any> extends DatagridFilterRegistrar<T, ClrDa
     // (undocumented)
     filterNumberMaxPlaceholder: string;
     // (undocumented)
-    get filterNumberMaxPlaceholderValue(): string;
-    // (undocumented)
     filterNumberMinPlaceholder: string;
-    // (undocumented)
-    get filterNumberMinPlaceholderValue(): string;
     filterStringPlaceholder: string;
-    // (undocumented)
-    get filterStringPlaceholderValue(): string;
     // (undocumented)
     get filterValue(): any;
     set filterValue(newValue: any);

--- a/projects/angular/src/data/datagrid/datagrid-column.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column.ts
@@ -22,7 +22,6 @@ import {
 import { Subscription } from 'rxjs';
 
 import { HostWrapper } from '../../utils/host-wrapping/host-wrapper';
-import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { ClrPopoverEventsService } from '../../utils/popover/providers/popover-events.service';
 import { ClrPopoverPositionService } from '../../utils/popover/providers/popover-position.service';
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
@@ -60,15 +59,15 @@ import { WrappedColumn } from './wrapped-column';
 
       <clr-dg-string-filter
         *ngIf="field && !customFilter && colType == 'string'"
-        [clrFilterPlaceholder]="filterStringPlaceholderValue"
+        [clrFilterPlaceholder]="filterStringPlaceholder"
         [clrDgStringFilter]="registered"
         [(clrFilterValue)]="filterValue"
       ></clr-dg-string-filter>
 
       <clr-dg-numeric-filter
         *ngIf="field && !customFilter && colType == 'number'"
-        [clrFilterMaxPlaceholder]="filterNumberMaxPlaceholderValue"
-        [clrFilterMinPlaceholder]="filterNumberMinPlaceholderValue"
+        [clrFilterMaxPlaceholder]="filterNumberMaxPlaceholder"
+        [clrFilterMinPlaceholder]="filterNumberMinPlaceholder"
         [clrDgNumericFilter]="registered"
         [(clrFilterValue)]="filterValue"
       ></clr-dg-numeric-filter>
@@ -101,8 +100,7 @@ export class ClrDatagridColumn<T = any>
     filters: FiltersProvider<T>,
     private vcr: ViewContainerRef,
     private detailService: DetailService,
-    private changeDetectorRef: ChangeDetectorRef,
-    public commonStrings: ClrCommonStringsService
+    private changeDetectorRef: ChangeDetectorRef
   ) {
     super(filters);
     this.subscriptions.push(this.listenForSortingChanges());
@@ -389,19 +387,8 @@ export class ClrDatagridColumn<T = any>
    * Help with accessibility for screen readers by providing custom placeholder text inside internal filters
    */
   @Input('clrFilterStringPlaceholder') filterStringPlaceholder: string;
-  get filterStringPlaceholderValue() {
-    return this.filterStringPlaceholder || this.commonStrings.keys.filterItems;
-  }
-
   @Input('clrFilterNumberMaxPlaceholder') filterNumberMaxPlaceholder: string;
-  get filterNumberMaxPlaceholderValue() {
-    return this.filterNumberMaxPlaceholder || this.commonStrings.keys.maxValue;
-  }
-
   @Input('clrFilterNumberMinPlaceholder') filterNumberMinPlaceholder: string;
-  get filterNumberMinPlaceholderValue() {
-    return this.filterNumberMinPlaceholder || this.commonStrings.keys.minValue;
-  }
 
   @Input('clrFilterValue')
   set updateFilterValue(newValue: string | [number, number]) {


### PR DESCRIPTION
The string and number filter components provide the default values.

This is backport of #592 to 13.x.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Refactoring (no functional changes, no api changes)

## Does this PR introduce a breaking change?

No.