### PR TITLE
chore: enable Angular's strict checks in library and demo app (backport to 13.x)

### DIFF
--- a/projects/angular/src/utils/focus-trap/focus-trap.ts
+++ b/projects/angular/src/utils/focus-trap/focus-trap.ts
@@ -5,7 +5,7 @@
  */
 
 import { DOCUMENT, isPlatformBrowser } from '@angular/common';
-import { Injectable, Injector, Renderer2 } from '@angular/core';
+import { Injector, Renderer2 } from '@angular/core';
 import { createId, FocusTrapTrackerService, isFocusable, isHTMLElement } from '@cds/core/internal';
 
 export interface FocusTrapElement extends HTMLElement {
@@ -106,7 +106,6 @@ export function castHtmlElementToFocusTrapElement(el: HTMLElement): FocusTrapEle
   return el as FocusTrapElement;
 }
 
-@Injectable()
 export class FocusTrap {
   focusTrapElement: FocusTrapElement;
   private previousFocus: HTMLElement;

--- a/projects/demo/src/app/cds-theme-select.component.ts
+++ b/projects/demo/src/app/cds-theme-select.component.ts
@@ -14,7 +14,7 @@ export const cdsThemeAttribute = 'cds-theme';
   template: `
     <clr-select-container>
       <label>Cds Theme</label>
-      <select clrSelect [value]="theme" (change)="applyTheme($event.target.value)">
+      <select #cdsThemeSelectElement clrSelect [value]="theme" (change)="applyTheme(cdsThemeSelectElement.value)">
         <option value="">None</option>
         <option value="light">Light</option>
         <option value="dark">Dark</option>

--- a/projects/demo/src/app/overlay-clipping/overlay-clipping.demo.html
+++ b/projects/demo/src/app/overlay-clipping/overlay-clipping.demo.html
@@ -188,7 +188,7 @@
       size="18"
       aria-label="blank id string"
     ></cds-icon>
-    <clr-tooltip-content [id]="blankStringId" clrPosition="top-right" clrSize="md">
+    <clr-tooltip-content clrPosition="top-right" clrSize="md">
       Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore
       magna aliqua. Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo
       consequat.

--- a/projects/demo/tsconfig.app.json
+++ b/projects/demo/tsconfig.app.json
@@ -5,10 +5,7 @@
     "types": []
   },
   "angularCompilerOptions": {
-    "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": false, // TURN BACK ON
-    "strictInputAccessModifiers": false, // TURN BACK ON
-    "strictTemplates": false // TURN BACK ON
+    "enableI18nLegacyMessageIdFormat": false
   },
   "files": ["src/main.ts", "src/polyfills.ts"],
   "include": ["src/**/*.d.ts"]

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -20,9 +20,8 @@
   },
   "angularCompilerOptions": {
     "enableI18nLegacyMessageIdFormat": false,
-    "strictInjectionParameters": false, // TURN BACK ON
-    "strictInputAccessModifiers": false, // TURN BACK ON
-    "strictTemplates": false // TURN BACK ON
+    "strictInjectionParameters": true,
+    "strictTemplates": true
   },
   "exclude": ["dist", "node_modules"]
 }


### PR DESCRIPTION
The `FocusTrap` is used as a base class. It is not injectable.

This change required minor changes to templates in the demo app.

The `strictInputAccessModifiers` option is implied by `strictTemplates`, so I removed that option.

This is a backport of #593 to 13.x.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Build related changes

## Does this PR introduce a breaking change?

No.