### PR TITLE
chore: checkout the correct commit in "PR Visual Snapshot Update Bot"

### DIFF
--- a/.github/workflows/pr-visual-snapshot-update-bot.yml
+++ b/.github/workflows/pr-visual-snapshot-update-bot.yml
@@ -10,6 +10,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v3
+        with:
+          repo: ${{github.event.workflow_run.head_repository.full_name}}
+          ref: ${{github.event.workflow_run.head_sha}}
       - name: Get PR Event
         id: get-pr-event
         uses: potiuk/get-workflow-origin@v1_5


### PR DESCRIPTION
This fixes a mistake I made in #589.

Without this change, the visual snapshot changes patch may not be able to be cleanly applied.