### PR TITLE
fix(stepper): fix stepper rendering in some safari versions

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -269,7 +269,7 @@ export class ClrAccordionModule {
 // @public (undocumented)
 export class ClrAccordionPanel implements OnInit, OnChanges {
     // Warning: (ae-forgotten-export) The symbol "IfExpandService" needs to be exported by the entry point index.d.ts
-    constructor(commonStrings: ClrCommonStringsService, accordionService: AccordionService, ifExpandService: IfExpandService);
+    constructor(commonStrings: ClrCommonStringsService, accordionService: AccordionService, ifExpandService: IfExpandService, cdr: ChangeDetectorRef);
     // (undocumented)
     accordionDescription: QueryList<ClrAccordionDescription>;
     // Warning: (ae-forgotten-export) The symbol "AccordionStatus" needs to be exported by the entry point index.d.ts
@@ -301,6 +301,8 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
     //
     // (undocumented)
     panel: Observable<AccordionPanelModel>;
+    // (undocumented)
+    get panelNumber(): number;
     // (undocumented)
     panelOpen: boolean;
     // (undocumented)
@@ -3635,7 +3637,7 @@ export class ClrStepperModule {
 
 // @public (undocumented)
 export class ClrStepperPanel extends ClrAccordionPanel implements OnInit {
-    constructor(platformId: any, commonStrings: ClrCommonStringsService, formGroupName: FormGroupName, ngModelGroup: NgModelGroup, stepperService: StepperService, ifExpandService: IfExpandService);
+    constructor(platformId: any, commonStrings: ClrCommonStringsService, formGroupName: FormGroupName, ngModelGroup: NgModelGroup, stepperService: StepperService, ifExpandService: IfExpandService, cdr: ChangeDetectorRef);
     // (undocumented)
     commonStrings: ClrCommonStringsService;
     // (undocumented)
@@ -3654,7 +3656,7 @@ export class ClrStepperPanel extends ClrAccordionPanel implements OnInit {
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<ClrStepperPanel, "clr-stepper-panel", never, {}, {}, never, ["clr-accordion-title, clr-step-title", "clr-accordion-description, clr-step-description", "*"], false, never>;
     // (undocumented)
-    static ɵfac: i0.ɵɵFactoryDeclaration<ClrStepperPanel, [null, null, { optional: true; }, { optional: true; }, null, null]>;
+    static ɵfac: i0.ɵɵFactoryDeclaration<ClrStepperPanel, [null, null, { optional: true; }, { optional: true; }, null, null, null]>;
 }
 
 // @public (undocumented)

--- a/projects/angular/src/accordion/_accordion.clarity.scss
+++ b/projects/angular/src/accordion/_accordion.clarity.scss
@@ -9,7 +9,6 @@
 @include exports('accordion.clarity') {
   .clr-accordion {
     display: block;
-    counter-reset: accordion;
     margin-bottom: $clr_baselineRem_1;
   }
 
@@ -67,11 +66,6 @@
   .clr-accordion-number {
     padding: 0 $clr-accordion-padding;
     display: none;
-
-    &::before {
-      content: counter(accordion) '.';
-      counter-increment: accordion;
-    }
   }
 
   .clr-accordion-header-button {

--- a/projects/angular/src/accordion/accordion-panel.html
+++ b/projects/angular/src/accordion/accordion-panel.html
@@ -19,7 +19,7 @@
         </span>
         <span class="clr-accordion-status">
           <cds-icon shape="angle" direction="right" class="clr-accordion-angle"></cds-icon>
-          <span class="clr-accordion-number"></span>
+          <span class="clr-accordion-number">{{panelNumber}}.</span>
           <cds-icon status="danger" shape="exclamation-circle" class="clr-accordion-error-icon"></cds-icon>
           <cds-icon status="success" shape="check-circle" class="clr-accordion-complete-icon"></cds-icon>
         </span>

--- a/projects/angular/src/accordion/stepper/stepper-panel.ts
+++ b/projects/angular/src/accordion/stepper/stepper-panel.ts
@@ -7,6 +7,7 @@
 import { isPlatformBrowser } from '@angular/common';
 import {
   ChangeDetectionStrategy,
+  ChangeDetectorRef,
   Component,
   ElementRef,
   Inject,
@@ -60,9 +61,10 @@ export class ClrStepperPanel extends ClrAccordionPanel implements OnInit {
     @Optional() private formGroupName: FormGroupName,
     @Optional() private ngModelGroup: NgModelGroup,
     private stepperService: StepperService,
-    ifExpandService: IfExpandService
+    ifExpandService: IfExpandService,
+    cdr: ChangeDetectorRef
   ) {
-    super(commonStrings, stepperService, ifExpandService);
+    super(commonStrings, stepperService, ifExpandService, cdr);
   }
 
   override ngOnInit(): void {


### PR DESCRIPTION
closes #152
Signed-off-by: Ivan Donchev <idonchev@vmware.com>

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

In certain new safari versions the stepper numbering and layout will break.

Issue Number: #152 

## What is the new behavior?

The numbering is moved to the TS layer, which makes it independent of the safari issues with the "counter" CSS.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
