### PR TITLE
feat(combobox): scroll to selected value on open

### DIFF
--- a/projects/angular/src/forms/combobox/combobox.ts
+++ b/projects/angular/src/forms/combobox/combobox.ts
@@ -171,9 +171,7 @@ export class ClrCombobox<T>
     this.optionSelectionService.loading = state === ClrLoadingState.LOADING;
     this.positionService.realign();
     if (state !== ClrLoadingState.LOADING && isPlatformBrowser(this.platformId)) {
-      setTimeout(() => {
-        this.focusFirstActive();
-      });
+      this.focusFirstActive();
     }
   }
 
@@ -314,7 +312,9 @@ export class ClrCombobox<T>
   }
 
   focusFirstActive() {
-    this.focusHandler.focusFirstActive();
+    setTimeout(() => {
+      this.focusHandler.focusFirstActive();
+    });
   }
 
   private updateInputValue(model: ComboboxModel<T>) {

--- a/projects/angular/src/forms/combobox/providers/combobox-focus-handler.service.ts
+++ b/projects/angular/src/forms/combobox/providers/combobox-focus-handler.service.ts
@@ -89,9 +89,7 @@ export class ComboboxFocusHandler<T> {
       }
     }
     this.pseudoFocus.select(this.optionData[index]);
-    if (this.pseudoFocus.model && this.pseudoFocus.model.el) {
-      this.pseudoFocus.model.el.scrollIntoView({ behavior: 'smooth', block: 'center', inline: 'nearest' });
-    }
+    this.scrollIntoSelectedModel();
   }
 
   private openAndMoveTo(direction: ArrowKeyDirection) {
@@ -155,6 +153,12 @@ export class ComboboxFocusHandler<T> {
     return preventDefault;
   }
 
+  private scrollIntoSelectedModel(behavior: ScrollBehavior = 'smooth') {
+    if (this.pseudoFocus.model && this.pseudoFocus.model.el) {
+      this.pseudoFocus.model.el.scrollIntoView({ behavior, block: 'center', inline: 'nearest' });
+    }
+  }
+
   private preventViewportScrolling(event: KeyboardEvent) {
     event.preventDefault();
     event.stopImmediatePropagation();
@@ -206,6 +210,7 @@ export class ComboboxFocusHandler<T> {
           // we have active element, but it's filtered out
           this.pseudoFocus.select(this.optionData[0]);
         }
+        this.scrollIntoSelectedModel('auto');
       }
     }
   }


### PR DESCRIPTION
Original issue: https://github.com/vmware-clarity/ng-clarity/issues/612

## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [X] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

After opening the combobox you have to scroll to find the selected item.

Issue Number: CDE-137

## What is the new behavior?

After opening the selected item will be in the view and focused.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
