### PR TITLE
fix(dropdown): prevent default `click` event if item is disabled (backport to 13.x)

### DIFF
--- a/projects/angular/src/popover/dropdown/dropdown-item.ts
+++ b/projects/angular/src/popover/dropdown/dropdown-item.ts
@@ -89,6 +89,7 @@ export class ClrDropdownItem {
 
   private stopImmediatePropagationIfDisabled($event: Event) {
     if (this.disabled) {
+      $event.preventDefault(); // prevent click event
       $event.stopImmediatePropagation();
     }
   }


### PR DESCRIPTION
Either 1481ce1fa6936b116b2ee10bd4b12323fe369ba5 didn't fully work, or something else changed.

This is backport of 2a4ff8b9c8b4ab5b8f87b8bef1c03b1454d24204 (#600) to 13.x.

closes #599