### PR TITLE
fix(popover): export stop propagation directive

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -3660,6 +3660,21 @@ export class ClrStepperPanel extends ClrAccordionPanel implements OnInit {
 }
 
 // @public (undocumented)
+export class ClrStopEscapePropagationDirective implements OnInit, OnDestroy {
+    constructor(toggleService: ClrPopoverToggleService);
+    // (undocumented)
+    ngOnDestroy(): void;
+    // (undocumented)
+    ngOnInit(): void;
+    // (undocumented)
+    onEscapeKey(event: KeyboardEvent): void;
+    // (undocumented)
+    static ɵdir: i0.ɵɵDirectiveDeclaration<ClrStopEscapePropagationDirective, never, never, {}, {}, never, never, true, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<ClrStopEscapePropagationDirective, never>;
+}
+
+// @public (undocumented)
 export class ClrTab {
     // Warning: (ae-forgotten-export) The symbol "TabsService" needs to be exported by the entry point index.d.ts
     constructor(ifActiveService: IfActiveService, id: number, tabsService: TabsService);

--- a/projects/angular/src/utils/popover/all.spec.ts
+++ b/projects/angular/src/utils/popover/all.spec.ts
@@ -12,7 +12,7 @@ import { ClrAlignmentSpec, ClrPositionTransformSpec, ClrViewportValidationSpec }
 import EventServiceSpec from './providers/popover-events.service.spec';
 import PositionServiceSpec from './providers/popover-position.service.spec';
 import ToggleServiceSpec from './providers/popover-toggle.service.spec';
-import StopEscapePropagationDirectiveSpec from './stop-escape-propagation.directive.spec';
+import ClrStopEscapePropagationDirectiveSpec from './stop-escape-propagation.directive.spec';
 
 describe('ClrPopover', () => {
   describe('ClrPositionOperator functions', () => {
@@ -32,6 +32,6 @@ describe('ClrPopover', () => {
     ClrPopoverOpenCloseButtonSpec();
     ClrPopoverCloseButtonSpec();
     ClrPopoverContentSpec();
-    StopEscapePropagationDirectiveSpec();
+    ClrStopEscapePropagationDirectiveSpec();
   });
 });

--- a/projects/angular/src/utils/popover/index.ts
+++ b/projects/angular/src/utils/popover/index.ts
@@ -13,6 +13,7 @@ export * from './providers/popover-position.service';
 export * from './providers/popover-toggle.service';
 export * from './popover-anchor';
 export * from './popover-content';
+export * from './stop-escape-propagation.directive';
 
 export { ClrPopoverModuleNext as ÇlrClrPopoverModuleNext } from './popover.module';
 export { ClrPopoverCloseButton as ÇlrClrPopoverCloseButton } from './popover-close-button';

--- a/projects/angular/src/utils/popover/popover-host.directive.ts
+++ b/projects/angular/src/utils/popover/popover-host.directive.ts
@@ -10,7 +10,7 @@ import { POPOVER_HOST_ANCHOR } from '../../popover/common/popover-host-anchor.to
 import { ClrPopoverEventsService } from './providers/popover-events.service';
 import { ClrPopoverPositionService } from './providers/popover-position.service';
 import { ClrPopoverToggleService } from './providers/popover-toggle.service';
-import { StopEscapePropagationDirective } from './stop-escape-propagation.directive';
+import { ClrStopEscapePropagationDirective } from './stop-escape-propagation.directive';
 
 @Directive({
   standalone: true,
@@ -20,6 +20,6 @@ import { StopEscapePropagationDirective } from './stop-escape-propagation.direct
     ClrPopoverPositionService,
     { provide: POPOVER_HOST_ANCHOR, useExisting: ElementRef },
   ],
-  hostDirectives: [StopEscapePropagationDirective],
+  hostDirectives: [ClrStopEscapePropagationDirective],
 })
 export class PopoverHostDirective {}

--- a/projects/angular/src/utils/popover/stop-escape-propagation.directive.spec.ts
+++ b/projects/angular/src/utils/popover/stop-escape-propagation.directive.spec.ts
@@ -12,10 +12,10 @@ import { ClrModal } from '../../modal/modal';
 import { ClrModalModule } from '../../modal/modal.module';
 import { Keys } from '../enums/keys.enum';
 import { ClrPopoverToggleService } from './providers/popover-toggle.service';
-import { StopEscapePropagationDirective } from './stop-escape-propagation.directive';
+import { ClrStopEscapePropagationDirective } from './stop-escape-propagation.directive';
 
 export default function (): void {
-  describe('StopEscapePropagationDirective', function () {
+  describe('ClrStopEscapePropagationDirective', function () {
     let fixture: ComponentFixture<TestComponent>;
 
     beforeEach(() => {
@@ -71,7 +71,7 @@ async function pressEscapeKey(fixture: ComponentFixture<TestComponent>, element:
   selector: 'app-test-popover-host',
   template: '',
   providers: [ClrPopoverToggleService],
-  hostDirectives: [StopEscapePropagationDirective],
+  hostDirectives: [ClrStopEscapePropagationDirective],
 })
 class TestPopoverHostComponent {
   constructor(readonly elementRef: ElementRef<HTMLElement>, readonly toggleService: ClrPopoverToggleService) {}

--- a/projects/angular/src/utils/popover/stop-escape-propagation.directive.ts
+++ b/projects/angular/src/utils/popover/stop-escape-propagation.directive.ts
@@ -12,7 +12,7 @@ import { ClrPopoverToggleService } from './providers/popover-toggle.service';
 @Directive({
   standalone: true,
 })
-export class StopEscapePropagationDirective implements OnInit, OnDestroy {
+export class ClrStopEscapePropagationDirective implements OnInit, OnDestroy {
   private subscription: Subscription;
   private lastOpenChange: boolean | null = null;
 


### PR DESCRIPTION
This allows the Angular compiler to properly type check templates that have components that use the stop propagation directive.

closes #569

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The Angular Language Service crashes or is otherwise unable to type-check components that use the stop propagation directive due to it not being exported.

Issue Number: #569

## What is the new behavior?

The stop propagation directive is now exported, so the Angular Language Service should be able to import it for type checking.

## Does this PR introduce a breaking change?

No.