### PR TITLE
fix(datagrid): change label around clickable row

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1747,6 +1747,8 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     selection: Selection_2<T>;
     // (undocumented)
     SELECTION_TYPE: typeof SelectionType;
+    // @deprecated (undocumented)
+    protected selectRow(selected?: boolean): void;
     // (undocumented)
     _stickyCells: ViewContainerRef;
     // (undocumented)

--- a/projects/angular/src/data/datagrid/datagrid-row.html
+++ b/projects/angular/src/data/datagrid/datagrid-row.html
@@ -3,7 +3,7 @@
   Clicking of that wrapper label will equate to clicking on the whole row, which triggers the checkbox to toggle.
 -->
 <div
-  class="datagrid-row-clickable clr-col-null"
+  class="datagrid-row-clickable"
   *ngIf="selection.rowSelectionMode"
   (mousedown)="clearRanges($event)"
   (click)="selectRow(!selected)"

--- a/projects/angular/src/data/datagrid/datagrid-row.html
+++ b/projects/angular/src/data/datagrid/datagrid-row.html
@@ -6,7 +6,7 @@
   class="datagrid-row-clickable clr-col-null"
   *ngIf="selection.rowSelectionMode"
   (mousedown)="clearRanges($event)"
-  (click)="rowSelected(!selected)"
+  (click)="selectRow(!selected)"
 >
   <clr-expandable-animation [clrExpandTrigger]="expandAnimationTrigger" *ngIf="expand.expandable">
     <ng-template [ngTemplateOutlet]="rowContent"></ng-template>

--- a/projects/angular/src/data/datagrid/datagrid-row.html
+++ b/projects/angular/src/data/datagrid/datagrid-row.html
@@ -2,12 +2,17 @@
   We need to wrap the #rowContent in label element if we are in rowSelectionMode.
   Clicking of that wrapper label will equate to clicking on the whole row, which triggers the checkbox to toggle.
 -->
-<label class="datagrid-row-clickable clr-col-null" *ngIf="selection.rowSelectionMode" (mousedown)="clearRanges($event)">
+<div
+  class="datagrid-row-clickable clr-col-null"
+  *ngIf="selection.rowSelectionMode"
+  (mousedown)="clearRanges($event)"
+  (click)="rowSelected(!selected)"
+>
   <clr-expandable-animation [clrExpandTrigger]="expandAnimationTrigger" *ngIf="expand.expandable">
     <ng-template [ngTemplateOutlet]="rowContent"></ng-template>
   </clr-expandable-animation>
   <ng-template [ngTemplateOutlet]="rowContent" *ngIf="!expand.expandable"></ng-template>
-</label>
+</div>
 
 <clr-expandable-animation
   *ngIf="!selection.rowSelectionMode && expand.expandable"

--- a/projects/angular/src/data/datagrid/datagrid-row.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.spec.ts
@@ -394,7 +394,7 @@ export default function (): void {
         context.detectChanges();
         const row = context.clarityElement;
         selectionProvider.rowSelectionMode = true;
-        expect(row.querySelectorAll('label label').length).toBe(0);
+        expect(row.querySelector('label label')).toBeNull();
       });
 
       it('verifies a label is not nested within a label when `rowSelectionMode` is enabled (multi-select)', function () {
@@ -403,8 +403,9 @@ export default function (): void {
         context.detectChanges();
         const row = context.clarityElement;
         selectionProvider.rowSelectionMode = true;
-        expect(row.querySelectorAll('label label').length).toBe(0);
+        expect(row.querySelector('label label')).toBeNull();
       });
+
       function flushAndAssertSelected(selected: boolean) {
         context.detectChanges();
         // ngModel is asynchronous, we need an extra change detection

--- a/projects/angular/src/data/datagrid/datagrid-row.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.spec.ts
@@ -359,7 +359,6 @@ export default function (): void {
         // Enabling the rowSelectionMode
         selectionProvider.rowSelectionMode = true;
         context.detectChanges();
-        expect(row.children[0] instanceof HTMLLabelElement).toBeTruthy();
         row.children[0].click();
         context.detectChanges();
         expect(selectionProvider.currentSingle).toEqual(context.testComponent.item);
@@ -380,7 +379,6 @@ export default function (): void {
         // Enabling the rowSelectionMode
         selectionProvider.rowSelectionMode = true;
         context.detectChanges();
-        expect(row.children[0] instanceof HTMLLabelElement).toBeTruthy();
         row.children[0].click();
         context.detectChanges();
         expect(selectionProvider.current).toEqual([context.testComponent.item]);
@@ -390,6 +388,23 @@ export default function (): void {
         expect(selectionProvider.current).toEqual([]);
       });
 
+      it('verifies a label is not nested within a label when `rowSelectionMode` is enabled', function () {
+        selectionProvider.selectionType = SelectionType.Single;
+        context.testComponent.item = { id: 1 };
+        context.detectChanges();
+        const row = context.clarityElement;
+        selectionProvider.rowSelectionMode = true;
+        expect(row.querySelectorAll('label label').length).toBe(0);
+      });
+
+      it('verifies a label is not nested within a label when `rowSelectionMode` is enabled (multi-select)', function () {
+        selectionProvider.selectionType = SelectionType.Multi;
+        context.testComponent.item = { id: 1 };
+        context.detectChanges();
+        const row = context.clarityElement;
+        selectionProvider.rowSelectionMode = true;
+        expect(row.querySelectorAll('label label').length).toBe(0);
+      });
       function flushAndAssertSelected(selected: boolean) {
         context.detectChanges();
         // ngModel is asynchronous, we need an extra change detection

--- a/projects/angular/src/data/datagrid/datagrid-row.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.ts
@@ -193,6 +193,17 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     }
   }
 
+  /**
+   * @deprecated related to clrDgRowSelection, which is deprecated
+   */
+  rowSelected(selected = !this.selected) {
+    if (this.selection.selectionType === this.SELECTION_TYPE.Single) {
+      this.selection.currentSingle = this.item;
+    } else {
+      this.toggle(selected);
+    }
+  }
+
   get expanded() {
     return this.expand.expanded;
   }

--- a/projects/angular/src/data/datagrid/datagrid-row.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.ts
@@ -196,7 +196,7 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
   /**
    * @deprecated related to clrDgRowSelection, which is deprecated
    */
-  rowSelected(selected = !this.selected) {
+  protected selectRow(selected = !this.selected) {
     if (this.selection.selectionType === this.SELECTION_TYPE.Single) {
       this.selection.currentSingle = this.item;
     } else {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The row selection mode (`clrDgRowSelection`) feature uses a top-level label to wrap around the entire row in order to proxy clicks to the appropriate checkbox. This feature is deprecated, but cannot be removed for legacy reasons. 

Issue Number: Resolves #378 . CDE-5

## What is the new behavior?

The label wrapping the row has been replaced with a div that proxies click events to trigger the appropriate row selection (single vs multi). 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information