### PR TITLE
chore: use `commonStringsDefault` instead of creating service instance (backport to 13.x)

### DIFF
--- a/.storybook/stories/alert/alert.stories.ts
+++ b/.storybook/stories/alert/alert.stories.ts
@@ -4,15 +4,13 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { ClrAlert, ClrAlertModule, ClrCommonStringsService } from '@clr/angular';
+import { ClrAlert, ClrAlertModule, commonStringsDefault } from '@clr/angular';
 import { action } from '@storybook/addon-actions';
 import { Parameters } from '@storybook/addons';
 import { Story } from '@storybook/angular';
 
 import { ALERT_TYPES } from '../../../projects/angular/src/emphasis/alert/utils/alert-types';
 import { setupStorybook } from '../../helpers/setup-storybook.helpers';
-
-const commonStringsService = new ClrCommonStringsService();
 
 const defaultStory: Story = args => ({
   template: ` 
@@ -42,7 +40,7 @@ const defaultParameters: Parameters = {
     clrAlertClosed: { defaultValue: false },
     clrAlertIcon: { defaultValue: '' },
     clrAlertType: { defaultValue: 'info', control: { type: 'radio', options: ALERT_TYPES } },
-    clrCloseButtonAriaLabel: { defaultValue: commonStringsService.keys.alertCloseButtonAriaLabel },
+    clrCloseButtonAriaLabel: { defaultValue: commonStringsDefault.alertCloseButtonAriaLabel },
     // outputs
     clrAlertClosedChange: { control: { disable: true } },
     // methods

--- a/.storybook/stories/button/button-group.stories.ts
+++ b/.storybook/stories/button/button-group.stories.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { CLR_MENU_POSITIONS, ClrButtonGroup, ClrButtonGroupModule, ClrCommonStringsService } from '@clr/angular';
+import { CLR_MENU_POSITIONS, ClrButtonGroup, ClrButtonGroupModule, commonStringsDefault } from '@clr/angular';
 import { Parameters } from '@storybook/addons';
 import { Story } from '@storybook/angular';
 
@@ -32,15 +32,13 @@ const defaultStory: Story = args => ({
   props: { ...args },
 });
 
-const commonStringsService = new ClrCommonStringsService();
-
 const defaultParameters: Parameters = {
   title: 'Button/Button Group',
   component: ClrButtonGroup,
   argTypes: {
     // inputs
     clrMenuPosition: { defaultValue: 'bottom-left', control: { type: 'radio', options: CLR_MENU_POSITIONS } },
-    clrToggleButtonAriaLabel: { defaultValue: commonStringsService.keys.rowActions },
+    clrToggleButtonAriaLabel: { defaultValue: commonStringsDefault.rowActions },
     // methods
     getMoveIndex: { control: { disable: true }, table: { disable: true } },
     initializeButtons: { control: { disable: true }, table: { disable: true } },

--- a/.storybook/stories/datagrid/datagrid-column.stories.ts
+++ b/.storybook/stories/datagrid/datagrid-column.stories.ts
@@ -5,11 +5,11 @@
  */
 
 import {
-  ClrCommonStringsService,
   ClrConditionalModule,
   ClrDatagridColumn,
   ClrDatagridModule,
   ClrDatagridSortOrder,
+  commonStringsDefault,
 } from '@clr/angular';
 import { action } from '@storybook/addon-actions';
 import { Parameters } from '@storybook/addons';
@@ -84,8 +84,6 @@ const defaultStory: Story = args => ({
   props: { ...args },
 });
 
-const commonStringsService = new ClrCommonStringsService();
-
 const defaultParameters: Parameters = {
   title: 'Datagrid/Column',
   component: ClrDatagridColumn,
@@ -102,9 +100,9 @@ const defaultParameters: Parameters = {
         options: Object.values(ClrDatagridSortOrder).filter(value => typeof value === 'string'),
       },
     },
-    clrFilterNumberMaxPlaceholder: { defaultValue: commonStringsService.keys.maxValue },
-    clrFilterNumberMinPlaceholder: { defaultValue: commonStringsService.keys.minValue },
-    clrFilterStringPlaceholder: { defaultValue: commonStringsService.keys.filterItems },
+    clrFilterNumberMaxPlaceholder: { defaultValue: commonStringsDefault.maxValue },
+    clrFilterNumberMinPlaceholder: { defaultValue: commonStringsDefault.minValue },
+    clrFilterStringPlaceholder: { defaultValue: commonStringsDefault.filterItems },
     clrFilterValue: { defaultValue: '', type: 'string' },
     // outputs
     clrDgColumnResize: { control: { disable: true } },

--- a/.storybook/stories/datagrid/datagrid.stories.ts
+++ b/.storybook/stories/datagrid/datagrid.stories.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { ClrCommonStringsService, ClrConditionalModule, ClrDatagrid, ClrDatagridModule } from '@clr/angular';
+import { ClrConditionalModule, ClrDatagrid, ClrDatagridModule, commonStringsDefault } from '@clr/angular';
 import { action } from '@storybook/addon-actions';
 import { Parameters } from '@storybook/addons';
 import { Story } from '@storybook/angular';
@@ -71,21 +71,19 @@ const defaultStory: Story = args => ({
   props: { ...args },
 });
 
-const commonStringsService = new ClrCommonStringsService();
-
 const defaultParameters: Parameters = {
   title: 'Datagrid/Datagrid',
   component: ClrDatagrid,
   argTypes: {
     // inputs
-    clrDetailExpandableAriaLabel: { defaultValue: commonStringsService.keys.detailExpandableAriaLabel },
+    clrDetailExpandableAriaLabel: { defaultValue: commonStringsDefault.detailExpandableAriaLabel },
     clrDgLoading: { defaultValue: false },
     clrDgPreserveSelection: { defaultValue: false },
     clrDgRowSelection: { defaultValue: false },
     clrDgSelected: { control: { disable: true } },
-    clrDgSingleActionableAriaLabel: { defaultValue: commonStringsService.keys.singleActionableAriaLabel },
+    clrDgSingleActionableAriaLabel: { defaultValue: commonStringsDefault.singleActionableAriaLabel },
     clrDgSingleSelected: { control: { disable: true } },
-    clrDgSingleSelectionAriaLabel: { defaultValue: commonStringsService.keys.singleSelectionAriaLabel },
+    clrDgSingleSelectionAriaLabel: { defaultValue: commonStringsDefault.singleSelectionAriaLabel },
     // outputs
     clrDgRefresh: { control: { disable: true } },
     clrDgSelectedChange: { control: { disable: true } },

--- a/.storybook/stories/modal/modal.stories.ts
+++ b/.storybook/stories/modal/modal.stories.ts
@@ -4,14 +4,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { ClrCommonStringsService, ClrModal, ClrModalModule } from '@clr/angular';
+import { ClrModal, ClrModalModule, commonStringsDefault } from '@clr/angular';
 import { action } from '@storybook/addon-actions';
 import { Parameters } from '@storybook/addons';
 import { Story } from '@storybook/angular';
 
 import { setupStorybook } from '../../helpers/setup-storybook.helpers';
-
-const commonStringsService = new ClrCommonStringsService();
 
 const defaultStory: Story = args => ({
   template: `
@@ -53,7 +51,7 @@ const defaultParameters: Parameters = {
   component: ClrModal,
   argTypes: {
     // inputs
-    clrModalCloseButtonAriaLabel: { type: 'string', defaultValue: commonStringsService.keys.close },
+    clrModalCloseButtonAriaLabel: { type: 'string', defaultValue: commonStringsDefault.close },
     clrModalLabelledById: { defaultValue: '' },
     clrModalSize: { defaultValue: 'md', control: { type: 'radio', options: ['sm', 'md', 'lg', 'xl'] } },
     clrModalSkipAnimation: { defaultValue: false, control: { type: 'boolean' } },

--- a/projects/angular/src/data/datagrid/datagrid-pagination.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-pagination.spec.ts
@@ -6,6 +6,7 @@
 
 import { Component } from '@angular/core';
 
+import { commonStringsDefault } from '../../utils/i18n/common-strings.default';
 import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { ClrDatagridPagination } from './datagrid-pagination';
 import { TestContext } from './helpers.spec';
@@ -18,12 +19,10 @@ export default function (): void {
     describe('Typescript API', function () {
       let pageService: Page;
       let component: ClrDatagridPagination;
-      let commonStrings: ClrCommonStringsService;
 
       beforeEach(function () {
         pageService = new Page(new StateDebouncer());
-        commonStrings = new ClrCommonStringsService();
-        component = new ClrDatagridPagination(pageService, commonStrings, null);
+        component = new ClrDatagridPagination(pageService, new ClrCommonStringsService(), null);
         component.ngOnInit(); // For the subscription that will get destroyed.
       });
 
@@ -353,11 +352,9 @@ export default function (): void {
     describe('Accessibility', function () {
       // Until we can properly type "this"
       let context: TestContext<ClrDatagridPagination, FullTest>;
-      let commonStrings: ClrCommonStringsService;
 
       beforeEach(function (this: any) {
         context = this.create(ClrDatagridPagination, FullTest, [Page, DetailService, StateDebouncer]);
-        commonStrings = new ClrCommonStringsService();
 
         context.testComponent.size = 10;
         context.testComponent.total = 100;
@@ -367,23 +364,23 @@ export default function (): void {
 
       it('expect buttons to have the correct aria-label from ClrCommonStringsService', function () {
         expect(context.clarityElement.querySelector('.pagination-first').attributes['aria-label'].value).toBe(
-          commonStrings.keys.firstPage
+          commonStringsDefault.firstPage
         );
         expect(context.clarityElement.querySelector('.pagination-last').attributes['aria-label'].value).toBe(
-          commonStrings.keys.lastPage
+          commonStringsDefault.lastPage
         );
         expect(context.clarityElement.querySelector('.pagination-previous').attributes['aria-label'].value).toBe(
-          commonStrings.keys.previousPage
+          commonStringsDefault.previousPage
         );
         expect(context.clarityElement.querySelector('.pagination-next').attributes['aria-label'].value).toBe(
-          commonStrings.keys.nextPage
+          commonStringsDefault.nextPage
         );
         expect(context.clarityElement.querySelector('.pagination-current').attributes['aria-label'].value).toBe(
-          commonStrings.keys.currentPage
+          commonStringsDefault.currentPage
         );
         expect(
           context.clarityElement.querySelector('.pagination-list span:not(.clr-sr-only)').attributes['aria-label'].value
-        ).toBe(commonStrings.keys.totalPages);
+        ).toBe(commonStringsDefault.totalPages);
       });
     });
   });

--- a/projects/angular/src/data/datagrid/datagrid-row-detail.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row-detail.spec.ts
@@ -6,7 +6,7 @@
 
 import { Component } from '@angular/core';
 
-import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
+import { commonStringsDefault } from '../../utils/i18n/common-strings.default';
 import { DatagridIfExpandService } from './datagrid-if-expanded.service';
 import { ClrDatagridRowDetail } from './datagrid-row-detail';
 import { DATAGRID_SPEC_PROVIDERS, TestContext } from './helpers.spec';
@@ -51,21 +51,20 @@ export default function (): void {
     });
 
     it('should add helper text', function () {
-      const commonStrings = new ClrCommonStringsService();
       const rows: HTMLElement[] = context.clarityElement.querySelectorAll('.clr-sr-only');
 
       // TODO: @deprecated - dategrid* keys are deprecated. Remove in v14.
       const first = [
-        commonStrings.keys.dategridExpandableBeginningOf,
-        commonStrings.keys.dategridExpandableRowContent,
-        commonStrings.keys.dategridExpandableRowsHelperText,
-        commonStrings.keys.dategridExpandableBeginningOf || commonStrings.keys.datagridExpandableBeginningOf,
-        commonStrings.keys.dategridExpandableRowContent || commonStrings.keys.datagridExpandableRowContent,
-        commonStrings.keys.dategridExpandableRowsHelperText || commonStrings.keys.datagridExpandableRowsHelperText,
+        commonStringsDefault.dategridExpandableBeginningOf,
+        commonStringsDefault.dategridExpandableRowContent,
+        commonStringsDefault.dategridExpandableRowsHelperText,
+        commonStringsDefault.dategridExpandableBeginningOf || commonStringsDefault.datagridExpandableBeginningOf,
+        commonStringsDefault.dategridExpandableRowContent || commonStringsDefault.datagridExpandableRowContent,
+        commonStringsDefault.dategridExpandableRowsHelperText || commonStringsDefault.datagridExpandableRowsHelperText,
       ];
       const last = [
-        commonStrings.keys.dategridExpandableEndOf || commonStrings.keys.datagridExpandableEndOf,
-        commonStrings.keys.dategridExpandableRowContent || commonStrings.keys.datagridExpandableRowContent,
+        commonStringsDefault.dategridExpandableEndOf || commonStringsDefault.datagridExpandableEndOf,
+        commonStringsDefault.dategridExpandableRowContent || commonStringsDefault.datagridExpandableRowContent,
       ];
 
       expect(rows[0].innerText.trim()).toBe(first.join(' ').trim());

--- a/projects/angular/src/emphasis/alert/providers/icon-and-types.service.spec.ts
+++ b/projects/angular/src/emphasis/alert/providers/icon-and-types.service.spec.ts
@@ -4,13 +4,13 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { commonStringsDefault } from '../../../utils/i18n/common-strings.default';
 import { ClrCommonStringsService } from '../../../utils/i18n/common-strings.service';
 import { AlertIconAndTypesService } from './icon-and-types.service';
 
 export default function (): void {
   describe('Alert Icon and Types Service', function () {
     let testMe: AlertIconAndTypesService;
-    let commonStrings: ClrCommonStringsService;
 
     function testShape(alertType: string): string {
       return testMe.iconInfoFromType(alertType).shape;
@@ -25,8 +25,7 @@ export default function (): void {
     }
 
     beforeEach(() => {
-      commonStrings = new ClrCommonStringsService();
-      testMe = new AlertIconAndTypesService(commonStrings);
+      testMe = new AlertIconAndTypesService(new ClrCommonStringsService());
     });
 
     afterEach(() => {
@@ -75,7 +74,7 @@ export default function (): void {
       it('returns title based on alertType', function () {
         testMe.alertType = 'warning';
         expect(testMe.alertType).toBe('warning');
-        expect(testMe.alertIconTitle).toBe(commonStrings.keys.warning);
+        expect(testMe.alertIconTitle).toBe(commonStringsDefault.warning);
       });
     });
 
@@ -91,8 +90,8 @@ export default function (): void {
       });
 
       it('returns info title as fallthrough', function () {
-        expect(testTitle(null)).toBe(commonStrings.keys.info);
-        expect(testTitle('ohai')).toBe(commonStrings.keys.info);
+        expect(testTitle(null)).toBe(commonStringsDefault.info);
+        expect(testTitle('ohai')).toBe(commonStringsDefault.info);
       });
 
       it('returns warning icon', function () {
@@ -104,7 +103,7 @@ export default function (): void {
       });
 
       it('returns warning title', function () {
-        expect(testTitle('warning')).toBe(commonStrings.keys.warning);
+        expect(testTitle('warning')).toBe(commonStringsDefault.warning);
       });
 
       it('returns danger icon', function () {
@@ -116,7 +115,7 @@ export default function (): void {
       });
 
       it('returns danger title', function () {
-        expect(testTitle('danger')).toBe(commonStrings.keys.danger);
+        expect(testTitle('danger')).toBe(commonStringsDefault.danger);
       });
 
       it('returns success icon', function () {
@@ -128,7 +127,7 @@ export default function (): void {
       });
 
       it('returns success title', function () {
-        expect(testTitle('success')).toBe(commonStrings.keys.success);
+        expect(testTitle('success')).toBe(commonStringsDefault.success);
       });
 
       it('returns info icon', function () {
@@ -140,7 +139,7 @@ export default function (): void {
       });
 
       it('returns info title', function () {
-        expect(testTitle('info')).toBe(commonStrings.keys.info);
+        expect(testTitle('info')).toBe(commonStringsDefault.info);
       });
     });
   });

--- a/projects/angular/src/layout/vertical-nav/vertical-nav.spec.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav.spec.ts
@@ -10,7 +10,7 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ClrIconModule } from '../../icon/icon.module';
-import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
+import { commonStringsDefault } from '../../utils/i18n/common-strings.default';
 import { VerticalNavService } from './providers/vertical-nav.service';
 import { ClrVerticalNav } from './vertical-nav';
 import { ClrVerticalNavModule } from './vertical-nav.module';
@@ -535,7 +535,6 @@ export default function (): void {
 
     describe('Accessibility', () => {
       let vertNavService: VerticalNavService;
-      let commonStrings: ClrCommonStringsService;
 
       beforeEach(() => {
         fixture = TestBed.createComponent(NoIconsNoNavGroupTestComponent);
@@ -543,7 +542,6 @@ export default function (): void {
 
         compiled = fixture.nativeElement;
         vertNavService = fixture.debugElement.query(By.directive(ClrVerticalNav)).injector.get(VerticalNavService);
-        commonStrings = new ClrCommonStringsService();
       });
 
       afterEach(() => {
@@ -556,7 +554,7 @@ export default function (): void {
 
         fixture.detectChanges();
 
-        const verticalNavToggleString = commonStrings.keys.verticalNavToggle;
+        const verticalNavToggleString = commonStringsDefault.verticalNavToggle;
 
         const toggleVertNavBtn: HTMLElement = compiled.querySelector('.nav-trigger');
         const navBtn: HTMLElement = compiled.querySelector('.nav-btn');

--- a/projects/angular/src/modal/modal.spec.ts
+++ b/projects/angular/src/modal/modal.spec.ts
@@ -12,7 +12,7 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { FocusTrapDirective } from '../utils/focus-trap/focus-trap.directive';
 import { ClrFocusTrapModule } from '../utils/focus-trap/focus-trap.module';
-import { ClrCommonStringsService } from '../utils/i18n/common-strings.service';
+import { commonStringsDefault } from '../utils/i18n/common-strings.default';
 import { ClrModal } from './modal';
 import { ClrModalModule } from './modal.module';
 
@@ -66,7 +66,6 @@ describe('Modal', () => {
   let fixture: ComponentFixture<TestComponent>;
   let compiled: HTMLElement;
   let modal: ClrModal;
-  const commonStrings = new ClrCommonStringsService();
 
   beforeEach(() => {
     TestBed.configureTestingModule({
@@ -260,7 +259,7 @@ describe('Modal', () => {
   });
 
   it('close button should have default aria-label', () => {
-    expect(compiled.querySelector('.close').getAttribute('aria-label')).toBe(commonStrings.keys.close);
+    expect(compiled.querySelector('.close').getAttribute('aria-label')).toBe(commonStringsDefault.close);
   });
 
   it('close button should have customizable aria-label', () => {

--- a/projects/angular/src/wizard/wizard-stepnav-item.spec.ts
+++ b/projects/angular/src/wizard/wizard-stepnav-item.spec.ts
@@ -8,7 +8,7 @@ import { AfterContentInit, Component, DebugElement, ViewChild } from '@angular/c
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { ClrCommonStringsService } from '../utils';
+import { commonStringsDefault } from '../utils/i18n/common-strings.default';
 import { ButtonHubService } from './providers/button-hub.service';
 import { PageCollectionService } from './providers/page-collection.service';
 import { PageCollectionMock } from './providers/page-collection.service.mock';
@@ -483,20 +483,18 @@ export default function (): void {
           fakeOutPage.completed = true;
           fakeOutPage.hasError = true;
           fixture.detectChanges();
-          const commonStrings = new ClrCommonStringsService();
           const spans: NodeList = myStepnavItem.querySelectorAll('span.clr-sr-only');
           expect(spans.length).toEqual(1);
-          expect(spans[0].textContent).toEqual(commonStrings.keys.wizardStepError);
+          expect(spans[0].textContent).toEqual(commonStringsDefault.wizardStepError);
         });
 
         it('should have a span with text "Completed" when page is completed', () => {
           fakeOutPage.completed = true;
           fakeOutPage.hasError = false;
           fixture.detectChanges();
-          const commonStrings = new ClrCommonStringsService();
           const spans: NodeList = myStepnavItem.querySelectorAll('span.clr-sr-only');
           expect(spans.length).toEqual(1);
-          expect(spans[0].textContent).toEqual(commonStrings.keys.wizardStepSuccess);
+          expect(spans[0].textContent).toEqual(commonStringsDefault.wizardStepSuccess);
         });
       });
 


### PR DESCRIPTION
This is a backport of 6d90a51ca659e59e2ec8cbc6dab45157c4ed9302 (#622) to 13.x.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Refactoring (no functional changes, no api changes)