### PR TITLE
chore: assert actual string values instead of common string values (backport to 13.x)

### DIFF
--- a/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
+++ b/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
@@ -11,7 +11,6 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { BehaviorSubject, Subject } from 'rxjs';
 
-import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { AccordionStatus } from '../enums/accordion-status.enum';
 import { AccordionPanelModel } from '../models/accordion.model';
 import { StepperService } from './providers/stepper.service';
@@ -98,21 +97,18 @@ describe('ClrStep Reactive Forms', () => {
     it('should show appropriate screen reader only status in button based on form state', () => {
       const mockStep = new AccordionPanelModel('groupName', 0);
       const stepperService = fixture.debugElement.query(By.directive(ClrStepperPanel)).injector.get(StepperService);
-      const commonStringsService = fixture.debugElement
-        .query(By.directive(ClrStepper))
-        .injector.get(ClrCommonStringsService);
       mockStep.status = AccordionStatus.Error;
       (stepperService as MockStepperService).step.next(mockStep);
       fixture.detectChanges();
 
       const statusMessage = fixture.nativeElement.querySelector('button .clr-sr-only');
-      expect(statusMessage.innerText.trim()).toBe(commonStringsService.keys.danger);
+      expect(statusMessage.innerText.trim()).toBe('Error');
 
       mockStep.status = AccordionStatus.Complete;
       (stepperService as MockStepperService).step.next(mockStep);
       fixture.detectChanges();
 
-      expect(statusMessage.innerText.trim()).toBe(commonStringsService.keys.success);
+      expect(statusMessage.innerText.trim()).toBe('Success');
     });
 
     it('should add aria-disabled attribute to the header button based on the appropriate step state', () => {

--- a/projects/angular/src/data/datagrid/datagrid-column-toggle.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column-toggle.spec.ts
@@ -7,7 +7,6 @@
 import { Component, TemplateRef, ViewChild } from '@angular/core';
 import { fakeAsync, tick } from '@angular/core/testing';
 
-import { commonStringsDefault } from '../../utils/i18n/common-strings.default';
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
 import { ClrDatagridColumnToggle } from './datagrid-column-toggle';
 import { TestContext } from './helpers.spec';
@@ -158,7 +157,7 @@ export default function (): void {
         context.detectChanges();
         tick();
         expect(document.querySelector('button.toggle-switch-close-button').attributes['aria-label'].value).toBe(
-          commonStringsDefault.close
+          'Close'
         );
       }));
 

--- a/projects/angular/src/data/datagrid/datagrid-detail.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-detail.spec.ts
@@ -7,7 +7,6 @@
 import { Component } from '@angular/core';
 import { async } from '@angular/core/testing';
 
-import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { ClrDatagridDetail } from './datagrid-detail';
 import { TestContext } from './helpers.spec';
 import { DetailService } from './providers/detail.service';
@@ -75,12 +74,11 @@ export default function (): void {
       });
 
       it('should have text based boundaries for screen readers', () => {
-        const commonStrings = context.getClarityProvider(ClrCommonStringsService);
         detailService.open({});
         context.detectChanges();
         const messages = context.testElement.querySelectorAll('.clr-sr-only');
-        expect(messages[0].innerText).toBe(commonStrings.keys.detailPaneStart);
-        expect(messages[1].innerText).toBe(commonStrings.keys.detailPaneEnd);
+        expect(messages[0].innerText).toBe('Start of row details');
+        expect(messages[1].innerText).toBe('End of row details');
       });
     });
   });

--- a/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
@@ -143,14 +143,12 @@ export default function (): void {
       });
 
       it('has role and label on the filter dialog', function () {
-        const commonStrings: ClrCommonStringsService =
-          context.fixture.debugElement.injector.get(ClrCommonStringsService);
         const openBtn: HTMLButtonElement = context.clarityElement.querySelector('.clr-smart-open-close');
         openBtn.click();
         context.detectChanges();
         const popoverContent = document.querySelector('.clr-popover-content');
         expect(popoverContent.getAttribute('role')).toBe('dialog');
-        expect(popoverContent.getAttribute('aria-label')).toBe(commonStrings.keys.datagridFilterDialogAriaLabel);
+        expect(popoverContent.getAttribute('aria-label')).toBe('Filter dialog');
       });
 
       it('projects content into the dropdown', function () {

--- a/projects/angular/src/data/datagrid/datagrid-pagination.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-pagination.spec.ts
@@ -6,7 +6,6 @@
 
 import { Component } from '@angular/core';
 
-import { commonStringsDefault } from '../../utils/i18n/common-strings.default';
 import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { ClrDatagridPagination } from './datagrid-pagination';
 import { TestContext } from './helpers.spec';
@@ -362,25 +361,25 @@ export default function (): void {
         context.detectChanges();
       });
 
-      it('expect buttons to have the correct aria-label from ClrCommonStringsService', function () {
+      it('expect buttons to have the correct aria-label', function () {
         expect(context.clarityElement.querySelector('.pagination-first').attributes['aria-label'].value).toBe(
-          commonStringsDefault.firstPage
+          'First Page'
         );
         expect(context.clarityElement.querySelector('.pagination-last').attributes['aria-label'].value).toBe(
-          commonStringsDefault.lastPage
+          'Last Page'
         );
         expect(context.clarityElement.querySelector('.pagination-previous').attributes['aria-label'].value).toBe(
-          commonStringsDefault.previousPage
+          'Previous Page'
         );
         expect(context.clarityElement.querySelector('.pagination-next').attributes['aria-label'].value).toBe(
-          commonStringsDefault.nextPage
+          'Next Page'
         );
         expect(context.clarityElement.querySelector('.pagination-current').attributes['aria-label'].value).toBe(
-          commonStringsDefault.currentPage
+          'Current Page'
         );
         expect(
           context.clarityElement.querySelector('.pagination-list span:not(.clr-sr-only)').attributes['aria-label'].value
-        ).toBe(commonStringsDefault.totalPages);
+        ).toBe('Total Pages');
       });
     });
   });

--- a/projects/angular/src/data/datagrid/datagrid-row-detail.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row-detail.spec.ts
@@ -6,7 +6,6 @@
 
 import { Component } from '@angular/core';
 
-import { commonStringsDefault } from '../../utils/i18n/common-strings.default';
 import { DatagridIfExpandService } from './datagrid-if-expanded.service';
 import { ClrDatagridRowDetail } from './datagrid-row-detail';
 import { DATAGRID_SPEC_PROVIDERS, TestContext } from './helpers.spec';
@@ -53,22 +52,10 @@ export default function (): void {
     it('should add helper text', function () {
       const rows: HTMLElement[] = context.clarityElement.querySelectorAll('.clr-sr-only');
 
-      // TODO: @deprecated - dategrid* keys are deprecated. Remove in v14.
-      const first = [
-        commonStringsDefault.dategridExpandableBeginningOf,
-        commonStringsDefault.dategridExpandableRowContent,
-        commonStringsDefault.dategridExpandableRowsHelperText,
-        commonStringsDefault.dategridExpandableBeginningOf || commonStringsDefault.datagridExpandableBeginningOf,
-        commonStringsDefault.dategridExpandableRowContent || commonStringsDefault.datagridExpandableRowContent,
-        commonStringsDefault.dategridExpandableRowsHelperText || commonStringsDefault.datagridExpandableRowsHelperText,
-      ];
-      const last = [
-        commonStringsDefault.dategridExpandableEndOf || commonStringsDefault.datagridExpandableEndOf,
-        commonStringsDefault.dategridExpandableRowContent || commonStringsDefault.datagridExpandableRowContent,
-      ];
-
-      expect(rows[0].innerText.trim()).toBe(first.join(' ').trim());
-      expect(rows[1].innerText.trim()).toBe(last.join(' ').trim());
+      expect(rows[0].innerText.trim()).toBe(
+        "Beginning of Expandable row content Screen reader table commands may not work for viewing expanded content, please use your screen reader's browse mode to read the content exposed by this button"
+      );
+      expect(rows[1].innerText.trim()).toBe('End of Expandable row content');
     });
 
     it('should add id to the root element', function () {

--- a/projects/angular/src/data/datagrid/datagrid.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid.spec.ts
@@ -9,7 +9,6 @@ import { async, fakeAsync, tick } from '@angular/core/testing';
 import { Subject } from 'rxjs';
 
 import { Keys } from '../../utils/enums/keys.enum';
-import { commonStringsDefault } from '../../utils/i18n/common-strings.default';
 import { DatagridPropertyStringFilter } from './built-in/filters/datagrid-property-string-filter';
 import { DatagridStringFilterImpl } from './built-in/filters/datagrid-string-filter-impl';
 import { ClrDatagrid } from './datagrid';
@@ -530,15 +529,9 @@ export default function (): void {
       });
 
       it('should cretae default values for clrDgSingleSelectionAriaLabel, clrDgSingleActionableAriaLabel, clrDetailExpandableAriaLabel', function () {
-        expect(context.clarityDirective.clrDgSingleSelectionAriaLabel).toBe(
-          commonStringsDefault.singleSelectionAriaLabel
-        );
-        expect(context.clarityDirective.clrDgSingleActionableAriaLabel).toBe(
-          commonStringsDefault.singleActionableAriaLabel
-        );
-        expect(context.clarityDirective.clrDetailExpandableAriaLabel).toBe(
-          commonStringsDefault.detailExpandableAriaLabel
-        );
+        expect(context.clarityDirective.clrDgSingleSelectionAriaLabel).toBe('Single selection header');
+        expect(context.clarityDirective.clrDgSingleActionableAriaLabel).toBe('Single actionable header');
+        expect(context.clarityDirective.clrDetailExpandableAriaLabel).toBe('Toggle more row content');
       });
 
       it('receives an input for the loading state', function () {

--- a/projects/angular/src/emphasis/alert/providers/icon-and-types.service.spec.ts
+++ b/projects/angular/src/emphasis/alert/providers/icon-and-types.service.spec.ts
@@ -4,7 +4,6 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { commonStringsDefault } from '../../../utils/i18n/common-strings.default';
 import { ClrCommonStringsService } from '../../../utils/i18n/common-strings.service';
 import { AlertIconAndTypesService } from './icon-and-types.service';
 
@@ -74,7 +73,7 @@ export default function (): void {
       it('returns title based on alertType', function () {
         testMe.alertType = 'warning';
         expect(testMe.alertType).toBe('warning');
-        expect(testMe.alertIconTitle).toBe(commonStringsDefault.warning);
+        expect(testMe.alertIconTitle).toBe('Warning');
       });
     });
 
@@ -90,8 +89,8 @@ export default function (): void {
       });
 
       it('returns info title as fallthrough', function () {
-        expect(testTitle(null)).toBe(commonStringsDefault.info);
-        expect(testTitle('ohai')).toBe(commonStringsDefault.info);
+        expect(testTitle(null)).toBe('Info');
+        expect(testTitle('ohai')).toBe('Info');
       });
 
       it('returns warning icon', function () {
@@ -103,7 +102,7 @@ export default function (): void {
       });
 
       it('returns warning title', function () {
-        expect(testTitle('warning')).toBe(commonStringsDefault.warning);
+        expect(testTitle('warning')).toBe('Warning');
       });
 
       it('returns danger icon', function () {
@@ -115,7 +114,7 @@ export default function (): void {
       });
 
       it('returns danger title', function () {
-        expect(testTitle('danger')).toBe(commonStringsDefault.danger);
+        expect(testTitle('danger')).toBe('Error');
       });
 
       it('returns success icon', function () {
@@ -127,7 +126,7 @@ export default function (): void {
       });
 
       it('returns success title', function () {
-        expect(testTitle('success')).toBe(commonStringsDefault.success);
+        expect(testTitle('success')).toBe('Success');
       });
 
       it('returns info icon', function () {
@@ -139,7 +138,7 @@ export default function (): void {
       });
 
       it('returns info title', function () {
-        expect(testTitle('info')).toBe(commonStringsDefault.info);
+        expect(testTitle('info')).toBe('Info');
       });
     });
   });

--- a/projects/angular/src/layout/nav/header.spec.ts
+++ b/projects/angular/src/layout/nav/header.spec.ts
@@ -8,7 +8,6 @@ import { Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 
 import { ClrIconModule } from '../../icon/icon.module';
-import { commonStringsDefault } from '../../utils/i18n/common-strings.default';
 import { MainContainerWillyWonka } from './chocolate/main-container-willy-wonka';
 import { ClrNavigationModule } from './navigation.module';
 
@@ -66,11 +65,9 @@ describe('Header', () => {
   });
 
   it('should have aria labels for menu buttons', () => {
-    expect(compiled.querySelector('.header-hamburger-trigger').getAttribute('aria-label')).toBe(
-      commonStringsDefault.responsiveNavToggleOpen
-    );
+    expect(compiled.querySelector('.header-hamburger-trigger').getAttribute('aria-label')).toBe('Navigation menu');
     expect(compiled.querySelector('.header-overflow-trigger').getAttribute('aria-label')).toBe(
-      commonStringsDefault.responsiveNavOverflowOpen
+      'Navigation overflow menu'
     );
   });
 });

--- a/projects/angular/src/layout/vertical-nav/vertical-nav-group.spec.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav-group.spec.ts
@@ -168,7 +168,7 @@ export default function (): void {
 
       it('defaults aria-label of nav group toggle button to common strings', () => {
         expect(toggleBtn.hasAttribute('aria-label')).toBe(true);
-        expect(toggleBtn.getAttribute('aria-label')).toBe(navGroup.commonStrings.keys.verticalNavGroupToggle);
+        expect(toggleBtn.getAttribute('aria-label')).toBe('Toggle vertical navigation group');
       });
 
       it('overrides default aria-label if clrVerticalNavGroup is set', fakeAsync(function () {

--- a/projects/angular/src/layout/vertical-nav/vertical-nav.spec.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav.spec.ts
@@ -10,7 +10,6 @@ import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { ClrIconModule } from '../../icon/icon.module';
-import { commonStringsDefault } from '../../utils/i18n/common-strings.default';
 import { VerticalNavService } from './providers/vertical-nav.service';
 import { ClrVerticalNav } from './vertical-nav';
 import { ClrVerticalNavModule } from './vertical-nav.module';
@@ -548,19 +547,17 @@ export default function (): void {
         fixture.destroy();
       });
 
-      it('expect buttons to have correct aria-label from ClrCommonStringsService', () => {
+      it('expect buttons to have correct aria-label', () => {
         vertNavService.collapsible = true;
         vertNavService.collapsed = true;
 
         fixture.detectChanges();
 
-        const verticalNavToggleString = commonStringsDefault.verticalNavToggle;
-
         const toggleVertNavBtn: HTMLElement = compiled.querySelector('.nav-trigger');
         const navBtn: HTMLElement = compiled.querySelector('.nav-btn');
 
-        expect(toggleVertNavBtn.getAttribute('aria-label')).toBe(verticalNavToggleString);
-        expect(navBtn.getAttribute('aria-label')).toBe(verticalNavToggleString);
+        expect(toggleVertNavBtn.getAttribute('aria-label')).toBe('Toggle vertical navigation');
+        expect(navBtn.getAttribute('aria-label')).toBe('Toggle vertical navigation');
       });
     });
   });

--- a/projects/angular/src/modal/modal.spec.ts
+++ b/projects/angular/src/modal/modal.spec.ts
@@ -12,7 +12,6 @@ import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 
 import { FocusTrapDirective } from '../utils/focus-trap/focus-trap.directive';
 import { ClrFocusTrapModule } from '../utils/focus-trap/focus-trap.module';
-import { commonStringsDefault } from '../utils/i18n/common-strings.default';
 import { ClrModal } from './modal';
 import { ClrModalModule } from './modal.module';
 
@@ -259,7 +258,7 @@ describe('Modal', () => {
   });
 
   it('close button should have default aria-label', () => {
-    expect(compiled.querySelector('.close').getAttribute('aria-label')).toBe(commonStringsDefault.close);
+    expect(compiled.querySelector('.close').getAttribute('aria-label')).toBe('Close');
   });
 
   it('close button should have customizable aria-label', () => {

--- a/projects/angular/src/wizard/wizard-stepnav-item.spec.ts
+++ b/projects/angular/src/wizard/wizard-stepnav-item.spec.ts
@@ -8,7 +8,6 @@ import { AfterContentInit, Component, DebugElement, ViewChild } from '@angular/c
 import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { By } from '@angular/platform-browser';
 
-import { commonStringsDefault } from '../utils/i18n/common-strings.default';
 import { ButtonHubService } from './providers/button-hub.service';
 import { PageCollectionService } from './providers/page-collection.service';
 import { PageCollectionMock } from './providers/page-collection.service.mock';
@@ -485,7 +484,7 @@ export default function (): void {
           fixture.detectChanges();
           const spans: NodeList = myStepnavItem.querySelectorAll('span.clr-sr-only');
           expect(spans.length).toEqual(1);
-          expect(spans[0].textContent).toEqual(commonStringsDefault.wizardStepError);
+          expect(spans[0].textContent).toEqual('Error');
         });
 
         it('should have a span with text "Completed" when page is completed', () => {
@@ -494,7 +493,7 @@ export default function (): void {
           fixture.detectChanges();
           const spans: NodeList = myStepnavItem.querySelectorAll('span.clr-sr-only');
           expect(spans.length).toEqual(1);
-          expect(spans[0].textContent).toEqual(commonStringsDefault.wizardStepSuccess);
+          expect(spans[0].textContent).toEqual('Completed');
         });
       });
 


### PR DESCRIPTION
This makes the tests directly assert the actual result.

This is a backport of e0d9810c38e6006b59777a1bb19a8c656cc26af9 (#630) to 13.x.