### PR TITLE
fix(stack-view): remove static height in modals

### DIFF
--- a/projects/angular/src/data/stack-view/_stack-view.clarity.scss
+++ b/projects/angular/src/data/stack-view/_stack-view.clarity.scss
@@ -302,7 +302,6 @@
       Styles specific to stack views used in a modal
     */
     .modal & {
-      height: 55vh;
       margin-bottom: 0;
     }
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Currently, there is static height 55vh set to the stack-view when in modal.

Issue Number: CDE-10

## What is the new behavior?
Now there is no static height set to the stack-view when in modal.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

If some application relies on the 55vh height set to the stack-view in modal, it can be set directly on the modal.

## Other information
