### PR TITLE
feat(wizard): add custom aria-label for stepnav section

### DIFF
--- a/.storybook/stories/wizard/wizard.stories.ts
+++ b/.storybook/stories/wizard/wizard.stories.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { ClrWizard, ClrWizardModule } from '@clr/angular';
+import { ClrWizard, ClrWizardModule, commonStringsDefault } from '@clr/angular';
 import { action } from '@storybook/addon-actions';
 import { Parameters } from '@storybook/addons';
 import { Story } from '@storybook/angular';
@@ -62,7 +62,7 @@ const defaultParameters: Parameters = {
     clrWizardPreventDefaultNext: { defaultValue: false },
     clrWizardPreventDefaultCancel: { defaultValue: false },
     clrWizardPreventModalAnimation: { defaultValue: false },
-    clrWizardStepnavAriaLabel: { defaultValue: 'Step navigation', control: { type: 'text' } },
+    clrWizardStepnavAriaLabel: { defaultValue: commonStringsDefault.wizardStepnavAriaLabel },
     clrWizardSize: { defaultValue: 'xl', control: { type: 'inline-radio', options: ['sm', 'md', 'lg', 'xl'] } },
     // outputs
     clrWizardOpenChange: { control: { disable: true } },

--- a/.storybook/stories/wizard/wizard.stories.ts
+++ b/.storybook/stories/wizard/wizard.stories.ts
@@ -23,6 +23,7 @@ const defaultStory: Story = args => ({
       [clrWizardPreventDefaultCancel]="clrWizardPreventDefaultCancel"
       [clrWizardPreventModalAnimation]="clrWizardPreventModalAnimation"
       [clrWizardSize]="clrWizardSize"
+      [clrWizardStepnavAriaLabel]="clrWizardStepnavAriaLabel"
       (clrWizardOpenChange)="clrWizardOpenChange($event)"
       (clrWizardCurrentPageChanged)="clrWizardCurrentPageChanged($event)"
       (clrWizardOnNext)="clrWizardOnNext($event)"
@@ -61,6 +62,7 @@ const defaultParameters: Parameters = {
     clrWizardPreventDefaultNext: { defaultValue: false },
     clrWizardPreventDefaultCancel: { defaultValue: false },
     clrWizardPreventModalAnimation: { defaultValue: false },
+    clrWizardStepnavAriaLabel: { defaultValue: 'Step navigation', control: { type: 'text' } },
     clrWizardSize: { defaultValue: 'xl', control: { type: 'inline-radio', options: ['sm', 'md', 'lg', 'xl'] } },
     // outputs
     clrWizardOpenChange: { control: { disable: true } },

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1005,6 +1005,7 @@ export interface ClrCommonStrings {
     verticalNavToggle: string;
     warning: string;
     wizardStepError: string;
+    wizardStepnavAriaLabel: string;
     wizardStepSuccess: string;
 }
 
@@ -4349,6 +4350,7 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
     previous(): void;
     reset(): void;
     size: string;
+    stepnavAriaLabel: string;
     set stopCancel(value: boolean);
     // (undocumented)
     get stopCancel(): boolean;
@@ -4365,7 +4367,7 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
     // (undocumented)
     protected wizardTitle: ClrWizardTitle;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrWizard, "clr-wizard", never, { "size": "clrWizardSize"; "closable": "clrWizardClosable"; "forceForward": "clrWizardForceForwardNavigation"; "clrWizardOpen": "clrWizardOpen"; "stopNext": "clrWizardPreventDefaultNext"; "stopCancel": "clrWizardPreventDefaultCancel"; "stopNavigation": "clrWizardPreventNavigation"; "disableStepnav": "clrWizardDisableStepnav"; }, { "_openChanged": "clrWizardOpenChange"; "onCancel": "clrWizardOnCancel"; "wizardFinished": "clrWizardOnFinish"; "onReset": "clrWizardOnReset"; "currentPageChanged": "clrWizardCurrentPageChanged"; "onMoveNext": "clrWizardOnNext"; "onMovePrevious": "clrWizardOnPrevious"; }, ["wizardTitle", "pages", "headerActions"], ["clr-wizard-title", "clr-wizard-header-action", "*", "clr-wizard-button"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrWizard, "clr-wizard", never, { "stepnavAriaLabel": "clrWizardStepnavAriaLabel"; "size": "clrWizardSize"; "closable": "clrWizardClosable"; "forceForward": "clrWizardForceForwardNavigation"; "clrWizardOpen": "clrWizardOpen"; "stopNext": "clrWizardPreventDefaultNext"; "stopCancel": "clrWizardPreventDefaultCancel"; "stopNavigation": "clrWizardPreventNavigation"; "disableStepnav": "clrWizardDisableStepnav"; }, { "_openChanged": "clrWizardOpenChange"; "onCancel": "clrWizardOnCancel"; "wizardFinished": "clrWizardOnFinish"; "onReset": "clrWizardOnReset"; "currentPageChanged": "clrWizardCurrentPageChanged"; "onMoveNext": "clrWizardOnNext"; "onMovePrevious": "clrWizardOnPrevious"; }, ["wizardTitle", "pages", "headerActions"], ["clr-wizard-title", "clr-wizard-header-action", "*", "clr-wizard-button"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrWizard, never>;
 }

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -4285,7 +4285,7 @@ export class ClrVerticalNavModule {
 
 // @public (undocumented)
 export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
-    constructor(platformId: any, navService: WizardNavigationService, pageCollection: PageCollectionService, buttonService: ButtonHubService, headerActionService: HeaderActionService, differs: IterableDiffers);
+    constructor(platformId: any, commonStrings: ClrCommonStringsService, navService: WizardNavigationService, pageCollection: PageCollectionService, buttonService: ButtonHubService, headerActionService: HeaderActionService, differs: IterableDiffers);
     // Warning: (ae-forgotten-export) The symbol "ButtonHubService" needs to be exported by the entry point index.d.ts
     //
     // (undocumented)

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -100,6 +100,7 @@ export const commonStringsDefault: ClrCommonStrings = {
   // Wizard
   wizardStepSuccess: 'Completed',
   wizardStepError: 'Error',
+  wizardStepnavAriaLabel: 'Step navigation',
 
   /**
    * Password Input

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -275,6 +275,11 @@ export interface ClrCommonStrings {
   wizardStepError: string;
 
   /**
+   * Wizard: Aria-label for the stepnav section.
+   */
+  wizardStepnavAriaLabel: string;
+
+  /**
    * Password Input
    * Screen-reader text for the hide/show password field button.
    */

--- a/projects/angular/src/wizard/test-components/api-wizard.mock.ts
+++ b/projects/angular/src/wizard/test-components/api-wizard.mock.ts
@@ -22,6 +22,7 @@ import { ClrWizard } from '../wizard';
       (clrWizardOnCancel)="handleOnCancel()"
       (clrWizardOnFinish)="handleOnFinish()"
       [clrWizardPreventDefaultCancel]="stopCancel"
+      [clrWizardStepnavAriaLabel]="stepnavAriaLabel"
     >
       <clr-wizard-title [clrHeadingLevel]="titleHeadingLevel">{{ projectedTitle }}</clr-wizard-title>
 
@@ -56,6 +57,7 @@ export class TemplateApiWizardTestComponent {
   @ViewChild('wizard', { static: true })
   wizard: ClrWizard;
   mySize: string;
+  stepnavAriaLabel = 'Label for stepnav';
   projectedTitle = 'My Great Title';
   projectedPageTitle = 'Title for Page 2';
   titleHeadingLevel: HeadingLevel;

--- a/projects/angular/src/wizard/wizard.html
+++ b/projects/angular/src/wizard/wizard.html
@@ -13,12 +13,12 @@
   (clrModalAlternateClose)="modalCancel()"
   [clrModalLabelledById]="wizardId"
 >
-  <nav class="modal-nav clr-wizard-stepnav-wrapper">
+  <div class="modal-nav clr-wizard-stepnav-wrapper" role="region" [attr.aria-label]="stepnavAriaLabel">
     <div class="clr-wizard-title" id="{{wizardId}}" role="heading" [attr.aria-level]="wizardTitle.headingLevel || 1">
       <ng-content select="clr-wizard-title"></ng-content>
     </div>
     <clr-wizard-stepnav></clr-wizard-stepnav>
-  </nav>
+  </div>
 
   <div class="modal-title" role="heading" [attr.aria-level]="navService.currentPage.pageTitle.headingLevel || 2">
     <span tabindex="-1" #pageTitle class="modal-title-text">

--- a/projects/angular/src/wizard/wizard.spec.ts
+++ b/projects/angular/src/wizard/wizard.spec.ts
@@ -646,6 +646,16 @@ export default function (): void {
           expect(wizard.stopCancel).toBe(true);
         });
       });
+
+      describe('Aria-label', () => {
+        it('clrWizardStepnavAriaLabel input sets and updates aria-label for the stepnav section', () => {
+          const stepnavWrapper = context.hostElement.querySelector('.clr-wizard-stepnav-wrapper');
+          expect(stepnavWrapper.getAttribute('aria-label')).toBe('Label for stepnav');
+          context.hostComponent.stepnavAriaLabel = 'Updated step navigation label';
+          context.detectChanges();
+          expect(stepnavWrapper.getAttribute('aria-label')).toBe('Updated step navigation label');
+        });
+      });
     });
 
     describe('Dynamic Content', () => {

--- a/projects/angular/src/wizard/wizard.ts
+++ b/projects/angular/src/wizard/wizard.ts
@@ -25,7 +25,7 @@ import {
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
-import { commonStringsDefault } from '../utils';
+import { ClrCommonStringsService } from '../utils';
 import { uniqueIdFactory } from '../utils/id-generator/id-generator.service';
 import { ButtonHubService } from './providers/button-hub.service';
 import { HeaderActionService } from './providers/header-actions.service';
@@ -51,7 +51,7 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
   /**
    * Set the aria-label for the stepnav section of the wizard. Set using `[clrWizardStepnavAriaLabel]` input.
    */
-  @Input('clrWizardStepnavAriaLabel') stepnavAriaLabel = commonStringsDefault.wizardStepnavAriaLabel;
+  @Input('clrWizardStepnavAriaLabel') stepnavAriaLabel = this.commonStrings.keys.wizardStepnavAriaLabel;
 
   /**
    * Set the modal size of the wizard. Set using `[clrWizardSize]` input.
@@ -236,6 +236,7 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
 
   constructor(
     @Inject(PLATFORM_ID) private platformId: any,
+    private commonStrings: ClrCommonStringsService,
     public navService: WizardNavigationService,
     public pageCollection: PageCollectionService,
     public buttonService: ButtonHubService,

--- a/projects/angular/src/wizard/wizard.ts
+++ b/projects/angular/src/wizard/wizard.ts
@@ -25,6 +25,7 @@ import {
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
+import { commonStringsDefault } from '../utils';
 import { uniqueIdFactory } from '../utils/id-generator/id-generator.service';
 import { ButtonHubService } from './providers/button-hub.service';
 import { HeaderActionService } from './providers/header-actions.service';
@@ -47,6 +48,11 @@ import { ClrWizardTitle } from './wizard-title';
   },
 })
 export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
+  /**
+   * Set the aria-label for the stepnav section of the wizard. Set using `[clrWizardStepnavAriaLabel]` input.
+   */
+  @Input('clrWizardStepnavAriaLabel') stepnavAriaLabel = commonStringsDefault.wizardStepnavAriaLabel;
+
   /**
    * Set the modal size of the wizard. Set using `[clrWizardSize]` input.
    */


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently the stepnav wrapper is using <nav> element and there is no aria-label or possibility to set one for it.

Issue Number: CDE-153

## What is the new behavior?

The stepnav wrapper is now using a <div> element with role="region" and an aria-label. Which can also be set trough the clrWizardStepnavAriaLabel input.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
