### PR TITLE
fix(combobox): prevent flashing on option selected

### DIFF
--- a/projects/angular/src/utils/popover/popover-content.ts
+++ b/projects/angular/src/utils/popover/popover-content.ts
@@ -77,11 +77,6 @@ export class ClrPopoverContent implements AfterContentChecked, OnDestroy {
       }),
       this.smartPositionService.shouldRealign.subscribe(() => {
         this.shouldRealign = true;
-        // Avoid flickering on initialization, caused by the asynchronous nature of the
-        // check-collector pattern.
-        if (this.view) {
-          this.renderer.setStyle(this.view.rootNodes[0], 'opacity', '0');
-        }
       }),
       // Here we collect subsequent synchronously received content-check events and only take action
       // at the end of the cycle. See below for details on the check-collector pattern.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The combobox popover is flashing on option selection due to opacity change of the popover content.  Opacity was set to 0 when the "realign" is called which was not needed in this case. It is needed only on initial creation of the popover when the position of it is top: 0, left:0 and then when it's in the right position it would appear.

Issue Number: CDE-11

## What is the new behavior?

No longer flashing.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
