### PR TITLE
chore(wizard): remove unused `clr-wizard-pagetitle` selector (backport #661 to 13.x)

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -4809,7 +4809,7 @@ export class ClrWizardButton {
 // @public (undocumented)
 export class ClrWizardCustomTags {
     // (undocumented)
-    static ɵdir: i0.ɵɵDirectiveDeclaration<ClrWizardCustomTags, "clr-wizard-title, clr-wizard-pagetitle", never, {}, {}, never>;
+    static ɵdir: i0.ɵɵDirectiveDeclaration<ClrWizardCustomTags, "clr-wizard-title", never, {}, {}, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrWizardCustomTags, never>;
 }

--- a/projects/angular/src/wizard/wizard-custom-tags.ts
+++ b/projects/angular/src/wizard/wizard-custom-tags.ts
@@ -7,7 +7,7 @@
 import { Directive } from '@angular/core';
 
 @Directive({
-  selector: 'clr-wizard-title, clr-wizard-pagetitle',
+  selector: 'clr-wizard-title',
 })
 export class ClrWizardCustomTags {
   // No behavior


### PR DESCRIPTION
This is a backport of 56e8868e3425a6389c5c4453007ef33d72ed80b5 (#661) to 13.x.