### PR TITLE
chore(wizard): rename `wizardTitle` property/template to `pageTitle` (backport of #660 to 13.x)

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -4737,6 +4737,8 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
     pageCollection: PageCollectionService;
     // (undocumented)
     pages: QueryList<ClrWizardPage>;
+    // (undocumented)
+    pageTitle: ElementRef;
     previous(): void;
     reset(): void;
     size: string;
@@ -4757,8 +4759,6 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
     wizardFinished: EventEmitter<any>;
     // (undocumented)
     wizardId: string;
-    // (undocumented)
-    wizardTitle: ElementRef;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<ClrWizard, "clr-wizard", never, { "size": "clrWizardSize"; "closable": "clrWizardClosable"; "forceForward": "clrWizardForceForwardNavigation"; "clrWizardOpen": "clrWizardOpen"; "stopNext": "clrWizardPreventDefaultNext"; "stopCancel": "clrWizardPreventDefaultCancel"; "stopNavigation": "clrWizardPreventNavigation"; "disableStepnav": "clrWizardDisableStepnav"; "_stopModalAnimations": "clrWizardPreventModalAnimation"; }, { "_openChanged": "clrWizardOpenChange"; "onCancel": "clrWizardOnCancel"; "wizardFinished": "clrWizardOnFinish"; "onReset": "clrWizardOnReset"; "currentPageChanged": "clrWizardCurrentPageChanged"; "onMoveNext": "clrWizardOnNext"; "onMovePrevious": "clrWizardOnPrevious"; }, ["pages", "headerActions"], ["clr-wizard-title", "clr-wizard-header-action", "*", "clr-wizard-button"]>;
     // (undocumented)

--- a/projects/angular/src/wizard/wizard.html
+++ b/projects/angular/src/wizard/wizard.html
@@ -21,7 +21,7 @@
   </nav>
 
   <h2 class="modal-title">
-    <span tabindex="-1" #wizardTitle class="modal-title-text">
+    <span tabindex="-1" #pageTitle class="modal-title-text">
       <ng-template [ngTemplateOutlet]="navService.currentPageTitle"></ng-template>
     </span>
 

--- a/projects/angular/src/wizard/wizard.ts
+++ b/projects/angular/src/wizard/wizard.ts
@@ -211,7 +211,7 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
   @ContentChildren(ClrWizardPage, { descendants: true })
   pages: QueryList<ClrWizardPage>;
   @ContentChildren(ClrWizardHeaderAction) headerActions: QueryList<ClrWizardHeaderAction>;
-  @ViewChild('wizardTitle') wizardTitle: ElementRef;
+  @ViewChild('pageTitle') pageTitle: ElementRef;
 
   get currentPage(): ClrWizardPage {
     return this.navService.currentPage;
@@ -453,14 +453,14 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
   private listenForNextPageChanges(): Subscription {
     return this.navService.movedToNextPage.pipe(filter(() => isPlatformBrowser(this.platformId))).subscribe(() => {
       this.onMoveNext.emit();
-      this.wizardTitle?.nativeElement.focus();
+      this.pageTitle?.nativeElement.focus();
     });
   }
 
   private listenForPreviousPageChanges(): Subscription {
     return this.navService.movedToPreviousPage.pipe(filter(() => isPlatformBrowser(this.platformId))).subscribe(() => {
       this.onMovePrevious.emit();
-      this.wizardTitle?.nativeElement.focus();
+      this.pageTitle?.nativeElement.focus();
     });
   }
 
@@ -477,7 +477,7 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
       // Added to address VPAT-749:
       //   When clicking on a wizard tab, focus should move to that
       //   tabs content to make the wizard more accessible.
-      this.wizardTitle?.nativeElement.focus();
+      this.pageTitle?.nativeElement.focus();
       this.currentPageChanged.emit();
     });
   }


### PR DESCRIPTION
This is the wizard page title, not the main wizard title.

This is a backport of 394e2b47d3a4aeb56c01bc7784ddefd680cab4c8 (#660) to 13.x.