### PR TITLE
fix(datagrid): re-map selection if row item references are changed (backport of #672 to 13.x)

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -40,6 +40,7 @@ import { OnInit } from '@angular/core';
 import { QueryList } from '@angular/core';
 import { Renderer2 } from '@angular/core';
 import { RendererFactory2 } from '@angular/core';
+import { ReplaySubject } from 'rxjs';
 import { RouterLinkActive } from '@angular/router';
 import { SelectMultipleControlValueAccessor } from '@angular/forms';
 import { SimpleChange } from '@angular/core';
@@ -1781,6 +1782,8 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     set item(item: T);
     // (undocumented)
     get item(): T;
+    // @internal (undocumented)
+    itemChanges: ReplaySubject<T>;
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)

--- a/projects/angular/src/data/datagrid/datagrid-row.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.ts
@@ -21,7 +21,7 @@ import {
   ViewChild,
   ViewContainerRef,
 } from '@angular/core';
-import { combineLatest, Subscription } from 'rxjs';
+import { combineLatest, ReplaySubject, Subscription } from 'rxjs';
 
 import { ClrExpandableAnimation } from '../../utils/animations/expandable-animation/expandable-animation';
 import { IfExpandService } from '../../utils/conditional/if-expanded.service';
@@ -75,12 +75,18 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
   @Input('clrDgItem')
   set item(item: T) {
     this._item = item;
+    this.itemChanges.next(item);
     this.clrDgSelectable = this._selectable;
   }
 
   get item(): T {
     return this._item;
   }
+
+  /**
+   * @internal
+   */
+  itemChanges = new ReplaySubject<T>(1);
 
   replaced: boolean;
 


### PR DESCRIPTION
Previous behavior:

If the row item references are changed but the row component instances are not changed, the selection was not re-mapped to the new item instances.

This was because the selection was only re-mapped if the rows `QueryList` emitted a change. If `[ngForTrackBy]` is used and the items collection is updated to new instances of the same items, the selection was not mapped to the new item instances. This caused the datagrid to display an inconsistent/incorrect view (e.g. a non-zero selection count but no rows actually checked).

New behavior:

If the row item references are changed, the selection is re-mapped to the new object references even if the rows `QueryList` does not emit a change.

closes #671

This is a backport of 701bc436c48a9c0c3f8305076a339642be91f42f (#672) to 13.x.