### PR TITLE
chore: clean up eslint ignore comments (backport of #676 to 13.x)

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -38,7 +38,12 @@ module.exports = {
         ],
         '@typescript-eslint/no-explicit-any': 'off', // Would LOVE to turn this on
         '@typescript-eslint/no-non-null-assertion': 'error',
-        '@typescript-eslint/no-unused-vars': 'error',
+        '@typescript-eslint/no-unused-vars': [
+          'error',
+          {
+            argsIgnorePattern: '^_',
+          },
+        ],
         '@typescript-eslint/no-var-requires': 'error',
         curly: 'error',
         eqeqeq: 'error',

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter-impl.spec.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-numeric-filter-impl.spec.ts
@@ -113,7 +113,6 @@ class TestFilter implements ClrDatagridNumericFilterInterface<number> {
 }
 
 class IncompatibleFilter implements ClrDatagridFilterInterface<number> {
-  // eslint-disable-next-line
   accepts(_item: number): boolean {
     return true;
   }

--- a/projects/angular/src/data/datagrid/built-in/filters/datagrid-string-filter-impl.spec.ts
+++ b/projects/angular/src/data/datagrid/built-in/filters/datagrid-string-filter-impl.spec.ts
@@ -100,7 +100,6 @@ class TestFilter implements ClrDatagridStringFilterInterface<string> {
 }
 
 class IncompatibleFilter implements ClrDatagridFilterInterface<string> {
-  // eslint-disable-next-line
   accepts(_item: string): boolean {
     return true;
   }

--- a/projects/angular/src/data/datagrid/datagrid-action-overflow.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-action-overflow.spec.ts
@@ -113,7 +113,6 @@ export default function (): void {
   `,
 })
 class SimpleTest {
-  // eslint-disable-next-line
   clrDgActionOverflowOpenChangeFn = (_$event: boolean) => {
     // Do nothing
   };

--- a/projects/angular/src/data/datagrid/datagrid-column.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-column.spec.ts
@@ -487,7 +487,6 @@ export default function (): void {
 }
 
 class TestComparator implements ClrDatagridComparatorInterface<number> {
-  // eslint-disable-next-line
   compare(_a: number, _b: number): number {
     return 0;
   }
@@ -498,7 +497,6 @@ class TestFilter implements ClrDatagridFilterInterface<number> {
     return true;
   }
 
-  // eslint-disable-next-line
   accepts(_n: number): boolean {
     return true;
   }
@@ -507,7 +505,6 @@ class TestFilter implements ClrDatagridFilterInterface<number> {
 }
 
 class TestStringFilter implements ClrDatagridStringFilterInterface<number> {
-  // eslint-disable-next-line
   accepts(_n: number, _search: string): boolean {
     return true;
   }

--- a/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.spec.ts
@@ -191,7 +191,6 @@ class TestFilter implements ClrDatagridFilterInterface<number> {
     return this.active;
   }
 
-  // eslint-disable-next-line
   accepts(_n: number): boolean {
     return true;
   }
@@ -220,7 +219,6 @@ class FullTest {
   filter: ClrDatagridFilterInterface<number>;
   open = false;
 
-  // eslint-disable-next-line
   clrDgFilterOpenChangeFn = (_$event: boolean) => {
     // Do nothing
   };

--- a/projects/angular/src/data/datagrid/datagrid.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid.spec.ts
@@ -314,7 +314,6 @@ class MixedExpandableRowTest {
   }
 }
 class TestComparator implements ClrDatagridComparatorInterface<number> {
-  // eslint-disable-next-line
   compare(_a: number, _b: number): number {
     return 0;
   }
@@ -325,7 +324,6 @@ class TestFilter implements ClrDatagridFilterInterface<number> {
     return true;
   }
 
-  // eslint-disable-next-line
   accepts(_n: number): boolean {
     return true;
   }
@@ -346,7 +344,6 @@ class TestCustomStateFilter extends TestFilter {
 }
 
 class TestStringFilter implements ClrDatagridStringFilterInterface<number> {
-  // eslint-disable-next-line
   accepts(_item: number, _search: string) {
     return true;
   }

--- a/projects/angular/src/data/datagrid/render/noop-dom-adapter.ts
+++ b/projects/angular/src/data/datagrid/render/noop-dom-adapter.ts
@@ -15,28 +15,23 @@ import { DomAdapter } from '../../../utils/dom-adapter/dom-adapter';
 
 @Injectable()
 export class NoopDomAdapter implements DomAdapter {
-  // eslint-disable-next-line
-  userDefinedWidth(element: any): number {
+  userDefinedWidth(_element: any): number {
     return 0;
   }
 
-  // eslint-disable-next-line
-  scrollBarWidth(element: any) {
+  scrollBarWidth(_element: any) {
     return 0;
   }
 
-  // eslint-disable-next-line
-  scrollWidth(element: any) {
+  scrollWidth(_element: any) {
     return 0;
   }
 
-  // eslint-disable-next-line
-  computedHeight(element: any): number {
+  computedHeight(_element: any): number {
     return 0;
   }
 
-  // eslint-disable-next-line
-  clientRect(element: any): DOMRect {
+  clientRect(_element: any): DOMRect {
     return {
       top: 0,
       bottom: 0,
@@ -47,13 +42,11 @@ export class NoopDomAdapter implements DomAdapter {
     } as DOMRect;
   }
 
-  // eslint-disable-next-line
-  minWidth(element: any): number {
+  minWidth(_element: any): number {
     return 0;
   }
 
-  // eslint-disable-next-line
-  focus(element: any): void {
+  focus(_element: any): void {
     // Do nothing
   }
 }

--- a/projects/angular/src/forms/common/if-control-state/abstract-if-state.ts
+++ b/projects/angular/src/forms/common/if-control-state/abstract-if-state.ts
@@ -42,8 +42,7 @@ export abstract class AbstractIfState {
     this.subscriptions.forEach(sub => sub.unsubscribe());
   }
 
-  // eslint-disable-next-line @typescript-eslint/no-unused-vars
-  protected handleState(state: CONTROL_STATE): void {
+  protected handleState(_state: CONTROL_STATE): void {
     /* overwrite in implementation to handle status change */
   }
 }

--- a/projects/angular/src/forms/datepicker/date-input.spec.ts
+++ b/projects/angular/src/forms/datepicker/date-input.spec.ts
@@ -47,7 +47,6 @@ export default function () {
 
     @Injectable()
     class MockNgControlService extends NgControlService {
-      // eslint-disable-next-line
       setControl = setControlSpy;
     }
 

--- a/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.spec.ts
+++ b/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.spec.ts
@@ -17,9 +17,6 @@ import { Linkers } from '../../../utils/focus/focusable-item/linkers';
 import { ClrPopoverToggleService } from '../../../utils/popover/providers/popover-toggle.service';
 import { DROPDOWN_FOCUS_HANDLER_PROVIDER, DropdownFocusHandler } from './dropdown-focus-handler.service';
 
-// eslint-disable-next-line id-blacklist
-import any = jasmine.any;
-
 @Component({
   selector: 'simple-host',
   template: '',
@@ -301,7 +298,7 @@ export default function (): void {
       it('links received children back to the trigger', function (this: TestContext) {
         const spy = spyOn(Linkers, 'linkParent');
         this.focusHandler.addChildren(this.children);
-        expect(spy).toHaveBeenCalledWith(this.children, any(Observable), ArrowKeyDirection.LEFT);
+        expect(spy).toHaveBeenCalledWith(this.children, jasmine.any(Observable), ArrowKeyDirection.LEFT);
       });
 
       it('closes the dropdown when trying to go back to the trigger', function (this: TestContext) {

--- a/projects/angular/src/utils/dom-adapter/dom-adapter.mock.ts
+++ b/projects/angular/src/utils/dom-adapter/dom-adapter.mock.ts
@@ -11,25 +11,21 @@ import { DomAdapter } from './dom-adapter';
 @Injectable()
 export class MockDomAdapter extends DomAdapter {
   _userDefinedWidth = 0;
-  // eslint-disable-next-line
   userDefinedWidth(_element: any): number {
     return this._userDefinedWidth;
   }
 
   _scrollBarWidth = 0;
-  // eslint-disable-next-line
   scrollBarWidth(_element: any) {
     return this._scrollBarWidth;
   }
 
   _scrollWidth = 0;
-  // eslint-disable-next-line
   scrollWidth(_element: any) {
     return this._scrollWidth;
   }
 
   _computedHeight = 0;
-  // eslint-disable-next-line
   computedHeight(_element: any) {
     return this._computedHeight;
   }

--- a/projects/angular/src/wizard/providers/page-collection.service.mock.ts
+++ b/projects/angular/src/wizard/providers/page-collection.service.mock.ts
@@ -25,8 +25,7 @@ export class PageCollectionMock {
 
   _previousPageIsCompleted = true;
 
-  // eslint-disable-next-line
-  public previousPageIsCompleted(_page: any = null): boolean {
+  previousPageIsCompleted(_page: any = null): boolean {
     return this._previousPageIsCompleted;
   }
 }


### PR DESCRIPTION
This is a backport of 5f8b534769e55958575fad8bdd9ebd5103c43f41 (#676) to 13.x.