### PR TITLE
chore: simplify `EventEmitter` property declarations (backport of #675 to 13.x)

### DIFF
--- a/projects/angular/src/button/button-group/button.ts
+++ b/projects/angular/src/button/button-group/button.ts
@@ -143,7 +143,7 @@ export class ClrButton implements LoadingListener {
     this.loading = state === ClrLoadingState.LOADING;
   }
 
-  @Output('click') _click: EventEmitter<boolean> = new EventEmitter<boolean>(false);
+  @Output('click') _click = new EventEmitter<boolean>(false);
 
   emitClick(): void {
     this._click.emit(true);

--- a/projects/angular/src/button/button-loading/loading-button.ts
+++ b/projects/angular/src/button/button-loading/loading-button.ts
@@ -67,8 +67,7 @@ export class ClrLoadingButton implements LoadingListener {
 
   @Input('disabled') disabled: boolean;
 
-  @Output('clrLoadingChange')
-  clrLoadingChange: EventEmitter<ClrLoadingState> = new EventEmitter<ClrLoadingState>(false);
+  @Output('clrLoadingChange') clrLoadingChange = new EventEmitter<ClrLoadingState>(false);
 
   constructor(public el: ElementRef, private renderer: Renderer2) {}
 

--- a/projects/angular/src/data/datagrid/render/header-renderer.ts
+++ b/projects/angular/src/data/datagrid/render/header-renderer.ts
@@ -38,7 +38,7 @@ export class DatagridHeaderRenderer implements OnDestroy {
     this.subscriptions.push(columnState.subscribe(state => this.stateChanges(state)));
   }
 
-  @Output('clrDgColumnResize') resizeEmitter: EventEmitter<number> = new EventEmitter();
+  @Output('clrDgColumnResize') resizeEmitter = new EventEmitter<number>();
 
   /**
    * Indicates if the column has a strict width, so it doesn't shrink or expand based on the content.

--- a/projects/angular/src/data/stack-view/stack-block.ts
+++ b/projects/angular/src/data/stack-view/stack-block.ts
@@ -83,7 +83,7 @@ export class ClrStackBlock implements OnInit {
   @Input('clrSbExpanded')
   expanded = false;
 
-  @Output('clrSbExpandedChange') expandedChange: EventEmitter<boolean> = new EventEmitter<boolean>(false);
+  @Output('clrSbExpandedChange') expandedChange = new EventEmitter<boolean>(false);
   @HostBinding('class.stack-block-expandable')
   @Input('clrSbExpandable')
   expandable = false;

--- a/projects/angular/src/emphasis/alert/alert.ts
+++ b/projects/angular/src/emphasis/alert/alert.ts
@@ -56,7 +56,7 @@ export class ClrAlert implements OnInit, OnDestroy {
       this.open();
     }
   }
-  @Output('clrAlertClosedChange') _closedChanged: EventEmitter<boolean> = new EventEmitter<boolean>(false);
+  @Output('clrAlertClosedChange') _closedChanged = new EventEmitter<boolean>(false);
 
   @Input('clrAlertType')
   set alertType(val: string) {

--- a/projects/angular/src/forms/combobox/combobox.ts
+++ b/projects/angular/src/forms/combobox/combobox.ts
@@ -250,7 +250,7 @@ export class ClrCombobox<T>
     }
   }
 
-  @Output('clrInputChange') clrInputChange: EventEmitter<string> = new EventEmitter<string>(false);
+  @Output('clrInputChange') clrInputChange = new EventEmitter<string>(false);
 
   @Output('clrOpenChange') clrOpenChange: Observable<boolean> = this.toggleService.openChange;
 

--- a/projects/angular/src/forms/datepicker/date-input.ts
+++ b/projects/angular/src/forms/datepicker/date-input.ts
@@ -57,7 +57,7 @@ export class ClrDateInput extends WrappedFormControl<ClrDateContainer> implement
   static ngAcceptInputType_date: Date | null | string;
 
   @Input() placeholder: string;
-  @Output('clrDateChange') dateChange: EventEmitter<Date> = new EventEmitter<Date>(false);
+  @Output('clrDateChange') dateChange = new EventEmitter<Date>(false);
   @Input('clrDate')
   set date(date: Date | string) {
     if (this.previousDateChange !== date) {

--- a/projects/angular/src/forms/datepicker/providers/datepicker-focus.service.spec.ts
+++ b/projects/angular/src/forms/datepicker/providers/datepicker-focus.service.spec.ts
@@ -66,7 +66,7 @@ export default function () {
 }
 
 class MockNgZone extends NgZone {
-  onStable: EventEmitter<any> = new EventEmitter<any>(false);
+  onStable = new EventEmitter<any>(false);
 
   constructor() {
     super({ enableLongStackTrace: false });

--- a/projects/angular/src/layout/vertical-nav/vertical-nav-group.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav-group.ts
@@ -111,7 +111,7 @@ export class ClrVerticalNavGroup implements AfterContentInit, OnDestroy {
     }
   }
 
-  @Output('clrVerticalNavGroupExpandedChange') expandedChange: EventEmitter<boolean> = new EventEmitter<boolean>(true);
+  @Output('clrVerticalNavGroupExpandedChange') expandedChange = new EventEmitter<boolean>(true);
 
   private _subscriptions: Subscription[] = [];
 

--- a/projects/angular/src/layout/vertical-nav/vertical-nav.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav.ts
@@ -43,7 +43,7 @@ export class ClrVerticalNav implements OnDestroy {
   }
 
   @Output('clrVerticalNavCollapsedChange')
-  private _collapsedChanged: EventEmitter<boolean> = new EventEmitter<boolean>(true);
+  private _collapsedChanged = new EventEmitter<boolean>(true);
 
   get hasNavGroups(): boolean {
     return this._navGroupRegistrationService.navGroupCount > 0;

--- a/projects/angular/src/modal/modal.ts
+++ b/projects/angular/src/modal/modal.ts
@@ -56,7 +56,7 @@ export class ClrModal implements OnChanges, OnDestroy {
   @HostBinding('class.open')
   @Input('clrModalOpen')
   _open = false;
-  @Output('clrModalOpenChange') _openChanged: EventEmitter<boolean> = new EventEmitter<boolean>(false);
+  @Output('clrModalOpenChange') _openChanged = new EventEmitter<boolean>(false);
 
   @Input('clrModalClosable') closable = true;
   @Input('clrModalCloseButtonAriaLabel') closeButtonAriaLabel = this.commonStrings.keys.close;
@@ -67,7 +67,7 @@ export class ClrModal implements OnChanges, OnDestroy {
   // presently this is only used by wizards
   @Input('clrModalOverrideScrollService') bypassScrollService = false;
   @Input('clrModalPreventClose') stopClose = false;
-  @Output('clrModalAlternateClose') altClose: EventEmitter<boolean> = new EventEmitter<boolean>(false);
+  @Output('clrModalAlternateClose') altClose = new EventEmitter<boolean>(false);
 
   @Input('clrModalLabelledById') labelledBy = this.modalId;
 

--- a/projects/angular/src/utils/conditional/if-active.directive.ts
+++ b/projects/angular/src/utils/conditional/if-active.directive.ts
@@ -90,7 +90,7 @@ export class ClrIfActive implements OnDestroy {
    * used with de-structured / de-sugared syntax.
    *
    */
-  @Output('clrIfActiveChange') activeChange: EventEmitter<boolean> = new EventEmitter<boolean>(false);
+  @Output('clrIfActiveChange') activeChange = new EventEmitter<boolean>(false);
 
   /*********
    *

--- a/projects/angular/src/utils/conditional/if-expanded.directive.ts
+++ b/projects/angular/src/utils/conditional/if-expanded.directive.ts
@@ -39,7 +39,7 @@ export class ClrIfExpanded implements OnInit, OnDestroy {
     }
   }
 
-  @Output('clrIfExpandedChange') expandedChange: EventEmitter<boolean> = new EventEmitter<boolean>(true);
+  @Output('clrIfExpandedChange') expandedChange = new EventEmitter<boolean>(true);
 
   constructor(
     @Optional() private template: TemplateRef<any>,

--- a/projects/angular/src/utils/conditional/if-open.directive.ts
+++ b/projects/angular/src/utils/conditional/if-open.directive.ts
@@ -57,7 +57,7 @@ export class ClrIfOpen implements OnDestroy {
    * An event emitter that emits when the open property is set to allow for 2way binding when the directive is
    * used with de-structured / de-sugared syntax.
    */
-  @Output('clrIfOpenChange') openChange: EventEmitter<boolean> = new EventEmitter<boolean>(false);
+  @Output('clrIfOpenChange') openChange = new EventEmitter<boolean>(false);
 
   constructor(
     private toggleService: ClrPopoverToggleService,

--- a/projects/angular/src/utils/focus/key-focus/key-focus.ts
+++ b/projects/angular/src/utils/focus/key-focus/key-focus.ts
@@ -30,7 +30,7 @@ export class ClrKeyFocus {
   constructor(private elementRef: ElementRef) {}
   @Input('clrDirection') direction: ClrFocusDirection | string = ClrFocusDirection.VERTICAL;
   @Input('clrFocusOnLoad') focusOnLoad = false;
-  @Output('clrFocusChange') private focusChange: EventEmitter<number> = new EventEmitter<number>();
+  @Output('clrFocusChange') private focusChange = new EventEmitter<number>();
   @ContentChildren(ClrKeyFocusItem, { descendants: true })
   protected clrKeyFocusItems: QueryList<ClrKeyFocusItem>;
 

--- a/projects/angular/src/utils/popover/popover-close-button.ts
+++ b/projects/angular/src/utils/popover/popover-close-button.ts
@@ -32,7 +32,7 @@ export class ClrPopoverCloseButton implements OnDestroy, AfterViewInit {
     );
   }
 
-  @Output('clrPopoverOnCloseChange') closeChange: EventEmitter<void> = new EventEmitter<void>();
+  @Output('clrPopoverOnCloseChange') closeChange = new EventEmitter<void>();
 
   @HostListener('click', ['$event'])
   handleClick(event: MouseEvent) {

--- a/projects/angular/src/utils/popover/popover-content.ts
+++ b/projects/angular/src/utils/popover/popover-content.ts
@@ -151,7 +151,7 @@ export class ClrPopoverContent implements AfterContentChecked, OnDestroy {
   // As multiple check events may happen in the same rendering cycle, we need to collect all events
   // and only act after the content is really stable. Or we may get wrong intermediate positioning values.
   // We will channel subsequent content check events through this observable.
-  private checkCollector: EventEmitter<void> = new EventEmitter();
+  private checkCollector = new EventEmitter<void>();
 
   ngAfterContentChecked(): void {
     if (this.smartOpenService.open && this.view && this.shouldRealign) {

--- a/projects/angular/src/utils/popover/popover-open-close-button.ts
+++ b/projects/angular/src/utils/popover/popover-open-close-button.ts
@@ -26,7 +26,7 @@ export class ClrPopoverOpenCloseButton implements OnDestroy {
     );
   }
 
-  @Output('clrPopoverOpenCloseChange') openCloseChange: EventEmitter<boolean> = new EventEmitter<boolean>();
+  @Output('clrPopoverOpenCloseChange') openCloseChange = new EventEmitter<boolean>();
 
   @HostListener('click', ['$event'])
   handleClick(event: MouseEvent) {

--- a/projects/angular/src/wizard/wizard-button.ts
+++ b/projects/angular/src/wizard/wizard-button.ts
@@ -56,7 +56,7 @@ export class ClrWizardButton {
   @Input('clrWizardButtonHidden') hidden = false;
 
   // EventEmitter which is emitted when a button is clicked.
-  @Output('clrWizardButtonClicked') wasClicked: EventEmitter<string> = new EventEmitter<string>(false);
+  @Output('clrWizardButtonClicked') wasClicked = new EventEmitter<string>(false);
 
   constructor(public navService: WizardNavigationService, public buttonService: ButtonHubService) {}
 

--- a/projects/angular/src/wizard/wizard-header-action.ts
+++ b/projects/angular/src/wizard/wizard-header-action.ts
@@ -37,7 +37,7 @@ export class ClrWizardHeaderAction {
 
   @Input('clrWizardHeaderActionDisabled') disabled = false;
 
-  @Output('actionClicked') headerActionClicked: EventEmitter<string> = new EventEmitter(false);
+  @Output('actionClicked') headerActionClicked = new EventEmitter<string>(false);
 
   click(): void {
     if (this.disabled) {

--- a/projects/angular/src/wizard/wizard-page.ts
+++ b/projects/angular/src/wizard/wizard-page.ts
@@ -141,7 +141,7 @@ export class ClrWizardPage implements OnInit {
    * @memberof WizardPage
    *
    */
-  @Output('clrWizardPageNextDisabledChange') nextStepDisabledChange: EventEmitter<boolean> = new EventEmitter();
+  @Output('clrWizardPageNextDisabledChange') nextStepDisabledChange = new EventEmitter<boolean>();
 
   /**
    *
@@ -190,8 +190,7 @@ export class ClrWizardPage implements OnInit {
    * @memberof WizardPage
    *
    */
-  @Output('clrWizardPagePreviousDisabledChange')
-  previousStepDisabledChange: EventEmitter<boolean> = new EventEmitter();
+  @Output('clrWizardPagePreviousDisabledChange') previousStepDisabledChange = new EventEmitter<boolean>();
 
   /**
    *
@@ -279,7 +278,7 @@ export class ClrWizardPage implements OnInit {
    * @memberof WizardPage
    *
    */
-  @Output('clrWizardPagePreventDefaultCancelChange') stopCancelChange: EventEmitter<boolean> = new EventEmitter();
+  @Output('clrWizardPagePreventDefaultCancelChange') stopCancelChange = new EventEmitter<boolean>();
 
   /**
    *
@@ -330,7 +329,7 @@ export class ClrWizardPage implements OnInit {
    * @memberof WizardPage
    *
    */
-  @Output('clrWizardPageOnCommit') onCommit: EventEmitter<string> = new EventEmitter<string>(false);
+  @Output('clrWizardPageOnCommit') onCommit = new EventEmitter<string>(false);
 
   /**
    * Emits an event when ClrWizardPage becomes the current page of the
@@ -339,7 +338,7 @@ export class ClrWizardPage implements OnInit {
    * @memberof WizardPage
    *
    */
-  @Output('clrWizardPageOnLoad') onLoad: EventEmitter<string> = new EventEmitter();
+  @Output('clrWizardPageOnLoad') onLoad = new EventEmitter<string>();
 
   /**
    * Emits an event when the ClrWizardPage invokes the cancel routine for the wizard.
@@ -356,7 +355,7 @@ export class ClrWizardPage implements OnInit {
    * @memberof WizardPage
    *
    */
-  @Output('clrWizardPageOnCancel') pageOnCancel: EventEmitter<ClrWizardPage> = new EventEmitter();
+  @Output('clrWizardPageOnCancel') pageOnCancel = new EventEmitter<ClrWizardPage>();
 
   /**
    * Emits an event when the finish button is clicked and the ClrWizardPage is
@@ -375,7 +374,7 @@ export class ClrWizardPage implements OnInit {
    * @memberof WizardPage
    *
    */
-  @Output('clrWizardPageFinish') finishButtonClicked: EventEmitter<ClrWizardPage> = new EventEmitter();
+  @Output('clrWizardPageFinish') finishButtonClicked = new EventEmitter<ClrWizardPage>();
 
   /**
    * Emits an event when the previous button is clicked and the ClrWizardPage is
@@ -394,7 +393,7 @@ export class ClrWizardPage implements OnInit {
    * @memberof WizardPage
    *
    */
-  @Output('clrWizardPagePrevious') previousButtonClicked: EventEmitter<ClrWizardPage> = new EventEmitter();
+  @Output('clrWizardPagePrevious') previousButtonClicked = new EventEmitter<ClrWizardPage>();
 
   /**
    * Emits an event when the next button is clicked and the ClrWizardPage is
@@ -413,7 +412,7 @@ export class ClrWizardPage implements OnInit {
    * @memberof WizardPage
    *
    */
-  @Output('clrWizardPageNext') nextButtonClicked: EventEmitter<ClrWizardPage> = new EventEmitter();
+  @Output('clrWizardPageNext') nextButtonClicked = new EventEmitter<ClrWizardPage>();
 
   /**
    * Emits an event when a danger button is clicked and the ClrWizardPage is
@@ -436,7 +435,7 @@ export class ClrWizardPage implements OnInit {
    * @memberof WizardPage
    *
    */
-  @Output('clrWizardPageDanger') dangerButtonClicked: EventEmitter<ClrWizardPage> = new EventEmitter();
+  @Output('clrWizardPageDanger') dangerButtonClicked = new EventEmitter<ClrWizardPage>();
 
   /**
    * Emits an event when a next, finish, or danger button is clicked and the
@@ -459,9 +458,9 @@ export class ClrWizardPage implements OnInit {
    * @memberof WizardPage
    *
    */
-  @Output('clrWizardPagePrimary') primaryButtonClicked: EventEmitter<string> = new EventEmitter();
+  @Output('clrWizardPagePrimary') primaryButtonClicked = new EventEmitter<string>();
 
-  @Output('clrWizardPageCustomButton') customButtonClicked: EventEmitter<string> = new EventEmitter();
+  @Output('clrWizardPageCustomButton') customButtonClicked = new EventEmitter<string>();
 
   /**
    * An input value that is used internally to generate the ClrWizardPage ID as

--- a/projects/angular/src/wizard/wizard.ts
+++ b/projects/angular/src/wizard/wizard.ts
@@ -167,46 +167,46 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
    * Emits when the wizard is opened or closed.
    * Listen via `(clrWizardOpenChange)` event.
    */
-  @Output('clrWizardOpenChange') _openChanged: EventEmitter<boolean> = new EventEmitter<boolean>(false);
+  @Output('clrWizardOpenChange') _openChanged = new EventEmitter<boolean>(false);
 
   /**
    * Emits when the wizard is canceled. Listen via `(clrWizardOnCancel)` event.
    * Can be combined with the `[clrWizardPreventDefaultCancel]` input to create
    * wizard-level custom cancel routines.
    */
-  @Output('clrWizardOnCancel') onCancel: EventEmitter<any> = new EventEmitter<any>(false);
+  @Output('clrWizardOnCancel') onCancel = new EventEmitter<any>(false);
 
   /**
    * Emits when the wizard is completed. Listen via `(clrWizardOnFinish)` event.
    * Can be combined with the `[clrWizardPreventDefaultNext]` input to create
    * wizard-level custom completion routines.
    */
-  @Output('clrWizardOnFinish') wizardFinished: EventEmitter<any> = new EventEmitter<any>(false);
+  @Output('clrWizardOnFinish') wizardFinished = new EventEmitter<any>(false);
 
   /**
    * Emits when the wizard is reset. Listen via `(clrWizardOnReset)` event.
    */
-  @Output('clrWizardOnReset') onReset: EventEmitter<any> = new EventEmitter<any>(false);
+  @Output('clrWizardOnReset') onReset = new EventEmitter<any>(false);
 
   /**
    * Emits when the current page has changed. Listen via `(clrWizardCurrentPageChanged)` event.
    * output. Useful for non-blocking validation.
    */
-  @Output('clrWizardCurrentPageChanged') currentPageChanged: EventEmitter<any> = new EventEmitter<any>(false);
+  @Output('clrWizardCurrentPageChanged') currentPageChanged = new EventEmitter<any>(false);
 
   /**
    * Emits when the wizard moves to the next page. Listen via `(clrWizardOnNext)` event.
    * Can be combined with the `[clrWizardPreventDefaultNext]` input to create
    * wizard-level custom navigation routines, which are useful for validation.
    */
-  @Output('clrWizardOnNext') onMoveNext: EventEmitter<any> = new EventEmitter<any>(false);
+  @Output('clrWizardOnNext') onMoveNext = new EventEmitter<any>(false);
 
   /**
    * Emits when the wizard moves to the previous page. Can be useful for validation.
    * Listen via `(clrWizardOnPrevious)` event.
    */
 
-  @Output('clrWizardOnPrevious') onMovePrevious: EventEmitter<any> = new EventEmitter<any>(false);
+  @Output('clrWizardOnPrevious') onMovePrevious = new EventEmitter<any>(false);
 
   @ContentChildren(ClrWizardPage, { descendants: true })
   pages: QueryList<ClrWizardPage>;


### PR DESCRIPTION
This is a backport of 05deac5a9b36634fa0f927e9917f3d9c291d1760 (#675) to 13.x.