### PR TITLE
chore(analytics): update storybook config to use gtag/ga4

### DIFF
--- a/.storybook/manager-head.html
+++ b/.storybook/manager-head.html
@@ -3,32 +3,26 @@
   href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' height='36' viewBox='0 0 36 36' width='36'%3E%3Cg fill='none' fill-rule='evenodd' transform='translate(0 4.544118)'%3E%3Cpath d='m24.7018129.03888403 11.2778281 6.67879663-.0181821 13.56348904-11.259646 6.6606051-6.6844666-3.9709902 11.6514714-6.541272v-5.8973849l-4.7471673-2.60470586-6.8895427-3.93711399' fill='%230095d3'/%3E%3Cpath d='m11.3313965.03888403-11.277828 6.67879663.01818205 13.56348904 11.25964595 6.6606051 6.6852924-3.9717138-10.66220196-6.5405484v-5.8973849l10.67797726-6.54221107' fill='%23f38b00'/%3E%3Cpath d='m18.017374 22.9708988-6.5183252-3.998915 6.5222007-3.8447451 6.9298332 3.951391' fill='%23004b70'/%3E%3Cpath d='m18.0314053 3.98921729-6.5046536 3.98442963 6.5172421 3.88418548 6.8619013-3.93951296' fill='%2398441e'/%3E%3C/g%3E%3C/svg%3E"
   type="image/svg+xml"
 />
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-JKD0PD2LJF"></script>
 <script type="text/javascript">
+  window.dataLayer = window.dataLayer || [];
+  function gtag() {
+    dataLayer.push(arguments);
+  }
+  function sendPageView() {
+    gtag('set', 'page', new URLSearchParams(window.location.search).get('path'));
+    gtag('send', 'pageview');
+  }
+
   if (/clarity.design/.test(window.location.href)) {
-    (function (i, s, o, g, r, a, m) {
-      i['GoogleAnalyticsObject'] = r;
-      (i[r] =
-        i[r] ||
-        function () {
-          (i[r].q = i[r].q || []).push(arguments);
-        }),
-        (i[r].l = 1 * new Date());
-      (a = s.createElement(o)), (m = s.getElementsByTagName(o)[0]);
-      a.async = 1;
-      a.src = g;
-      m.parentNode.insertBefore(a, m);
-    })(window, document, 'script', 'https://www.google-analytics.com/analytics.js', 'ga');
-    ga('create', 'UA-86120402-1', 'auto');
+    gtag('js', new Date());
+    gtag('config', 'G-JKD0PD2LJF');
     sendPageView();
+
     const pushState = window.history.pushState;
     window.history.pushState = function () {
       pushState.apply(window.history, arguments);
       sendPageView();
     };
-
-    function sendPageView() {
-      ga('set', 'page', new URLSearchParams(window.location.search).get('path'));
-      ga('send', 'pageview');
-    }
   }
 </script>


### PR DESCRIPTION
Update storybook google analytics to use GA4 and gtag. GA3 (current implementation) will be disabled on July 1. 