### PR TITLE
fix(select): change caret color on hover

### DIFF
--- a/projects/angular/src/forms/styles/_select.clarity.scss
+++ b/projects/angular/src/forms/styles/_select.clarity.scss
@@ -73,12 +73,7 @@
     }
 
     &:hover::after {
-      @include css-var(
-        color,
-        clr-forms-select-caret-hover-color,
-        $clr-forms-select-caret-hover-color,
-        $clr-use-custom-properties
-      );
+      background-image: generateCaretIcon($clr-forms-select-caret-hover-color);
     }
   }
 


### PR DESCRIPTION
The difference on hover is that it's slightly darker:
Left: default Right: hover
![Screenshot 2023-05-30 at 19 46 50](https://github.com/vmware-clarity/ng-clarity/assets/127101685/9b095242-56ba-4656-a11e-a4a5f30b7b24)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently it was set to change 'color' on hover but we use background image for the caret and it was not working.

Issue Number: N/A

## What is the new behavior?

Using proper image with the right color on hover.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
