### PR TITLE
fix(header): add `role="banner"` by default

### DIFF
--- a/.storybook/stories/header/header.stories.ts
+++ b/.storybook/stories/header/header.stories.ts
@@ -13,7 +13,7 @@ import { setupStorybook } from '../../helpers/setup-storybook.helpers';
 const defaultStory: Story = args => ({
   template: `
     <clr-main-container>
-      <clr-header>
+      <clr-header [role]="role">
         <div class="branding">
           <a href="javascript://" class="nav-link">
             <cds-icon shape="vm-bug"></cds-icon>

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -2330,10 +2330,12 @@ export class ClrHeader implements OnDestroy {
     get responsiveNavCommonString(): string;
     // (undocumented)
     get responsiveOverflowCommonString(): string;
+    // (undocumented)
+    role: string;
     // @deprecated (undocumented)
     toggleNav(navLevel: number): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrHeader, "clr-header", never, {}, {}, never, ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrHeader, "clr-header", never, { "role": "role"; }, {}, never, ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrHeader, never>;
 }

--- a/projects/angular/src/layout/nav/header.spec.ts
+++ b/projects/angular/src/layout/nav/header.spec.ts
@@ -56,6 +56,10 @@ describe('Header', () => {
     expect(compiled.textContent).toMatch(/Components/);
   });
 
+  it('has role="banner" by default', () => {
+    expect(compiled.querySelector('clr-header').getAttribute('role')).toBe('banner');
+  });
+
   it('shows the hamburger trigger when the level1 directive is registered', () => {
     expect(compiled.querySelector('.header-hamburger-trigger')).not.toBeNull();
   });
@@ -69,5 +73,53 @@ describe('Header', () => {
     expect(compiled.querySelector('.header-overflow-trigger').getAttribute('aria-label')).toBe(
       'Navigation overflow menu'
     );
+  });
+});
+
+describe('Header with custom role', () => {
+  let fixture: ComponentFixture<any>;
+  let nativeElement: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: '<clr-header role="generic"></clr-header>',
+      },
+    });
+
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    nativeElement = fixture.nativeElement;
+  });
+
+  it('uses provided custom role', () => {
+    expect(nativeElement.querySelector('clr-header').getAttribute('role')).toBe('generic');
+  });
+});
+
+describe('Header without role', () => {
+  let fixture: ComponentFixture<any>;
+  let nativeElement: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.overrideComponent(TestComponent, {
+      set: {
+        template: '<clr-header [role]="undefined"></clr-header>',
+      },
+    });
+
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    nativeElement = fixture.nativeElement;
+  });
+
+  it('does not have a role attribute', () => {
+    expect(nativeElement.querySelector('clr-header').hasAttribute('role')).toBe(false);
   });
 });

--- a/projects/angular/src/layout/nav/header.ts
+++ b/projects/angular/src/layout/nav/header.ts
@@ -4,7 +4,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, OnDestroy } from '@angular/core';
+import { Component, HostBinding, Input, OnDestroy } from '@angular/core';
 import { Subscription } from 'rxjs';
 import { filter } from 'rxjs/operators';
 
@@ -41,6 +41,8 @@ import { ResponsiveNavCodes } from './responsive-nav-codes';
   host: { '[class.header]': 'true' },
 })
 export class ClrHeader implements OnDestroy {
+  @Input() @HostBinding('attr.role') role = 'banner';
+
   isNavLevel1OnPage = false;
   isNavLevel2OnPage = false;
   openNavLevel: number = null;


### PR DESCRIPTION
The `clr-header` element will now have `role="banner"` by default. This can be overridden in applications by setting the attribute to a different value, e.g. `role="generic"`. Alternatively, the `role` attribute can be removed entirely by binding `[role]="undefined"`.

CDE-452