### PR TITLE
fix(datagrid): change manage columns popover close button color on hover

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1414,20 +1414,22 @@
             min-width: $clr_baselineRem_0_75;
             margin: 0;
             padding: 0;
-            @include css-var(
-              color,
-              clr-datagrid-column-switch-header-font-color,
-              $clr-datagrid-column-switch-header-font-color,
-              $clr-use-custom-properties
-            );
 
-            &:hover {
+            cds-icon {
               @include css-var(
                 color,
-                clr-datagrid-column-switch-header-font-hover-color,
-                $clr-datagrid-column-switch-header-font-hover-color,
+                clr-datagrid-column-switch-header-font-color,
+                $clr-datagrid-column-switch-header-font-color,
                 $clr-use-custom-properties
               );
+              &:hover {
+                @include css-var(
+                  color,
+                  clr-datagrid-column-switch-header-font-hover-color,
+                  $clr-datagrid-column-switch-header-font-hover-color,
+                  $clr-use-custom-properties
+                );
+              }
             }
           }
         }
@@ -2035,20 +2037,22 @@
         min-width: $clr_baselineRem_0_75;
         margin: 0;
         padding: 0;
-        @include css-var(
-          color,
-          clr-datagrid-column-switch-header-font-color,
-          $clr-datagrid-column-switch-header-font-color,
-          $clr-use-custom-properties
-        );
 
-        &:hover {
+        cds-icon {
           @include css-var(
             color,
-            clr-datagrid-column-switch-header-font-hover-color,
-            $clr-datagrid-column-switch-header-font-hover-color,
+            clr-datagrid-column-switch-header-font-color,
+            $clr-datagrid-column-switch-header-font-color,
             $clr-use-custom-properties
           );
+          &:hover {
+            @include css-var(
+              color,
+              clr-datagrid-column-switch-header-font-hover-color,
+              $clr-datagrid-column-switch-header-font-hover-color,
+              $clr-use-custom-properties
+            );
+          }
         }
       }
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently the css was changing the `color` of the button in manage columns popover which does not affect the icon color.

Issue Number: N/A

## What is the new behavior?

Hovering is now changing the close button icon color in manage columns popover.

## Does this PR introduce a breaking change?

- [ ] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
