### PR TITLE
chore(modal): declare `_open` property on a single line

### DIFF
--- a/projects/angular/src/modal/modal.ts
+++ b/projects/angular/src/modal/modal.ts
@@ -53,9 +53,7 @@ export class ClrModal implements OnChanges, OnDestroy {
 
   @ViewChild(FocusTrapDirective) focusTrap: FocusTrapDirective;
 
-  @HostBinding('class.open')
-  @Input('clrModalOpen')
-  _open = false;
+  @Input('clrModalOpen') @HostBinding('class.open') _open = false;
   @Output('clrModalOpenChange') _openChanged = new EventEmitter<boolean>(false);
 
   @Input('clrModalClosable') closable = true;


### PR DESCRIPTION
This commit makes `13.x` more consistent with `main`.

I missed this change in 6dce60179546dde6e64a23e168e876ff11e9d85d.