### PR TITLE
fix(popover): use scroll position in position calculation

### DIFF
--- a/projects/angular/src/utils/popover/popover-content.ts
+++ b/projects/angular/src/utils/popover/popover-content.ts
@@ -100,7 +100,7 @@ export class ClrPopoverContent implements AfterContentChecked, OnDestroy {
         this.alignContent();
         this.shouldRealign = false;
         if (this.view) {
-          this.renderer.setStyle(this.view.rootNodes[0], 'opacity', '1');
+          this.renderer.setStyle(this.view.rootNodes[0], 'visibility', 'visible');
         }
       })
     );
@@ -129,8 +129,8 @@ export class ClrPopoverContent implements AfterContentChecked, OnDestroy {
     // coordinates values.
     this.renderer.setStyle(rootNode, 'top', '0px');
     this.renderer.setStyle(rootNode, 'left', '0px');
-    // We need to hide it during the calculation phase, while it's not yet finally positioned.
-    this.renderer.setStyle(rootNode, 'opacity', '0');
+    // // We need to hide it during the calculation phase, while it's not yet finally positioned.
+    this.renderer.setStyle(rootNode, 'visibility', 'hidden');
     this.removeClickListenerFn = this.renderer.listen(rootNode, 'click', event => {
       this.smartOpenService.openEvent = event;
     });
@@ -158,7 +158,13 @@ export class ClrPopoverContent implements AfterContentChecked, OnDestroy {
     if (!this.view) {
       return;
     }
-    const positionCoords = this.smartPositionService.alignContent(this.view.rootNodes[0]);
+
+    const { yOffset, xOffset } = this.smartPositionService.alignContent(this.view.rootNodes[0]);
+    const positionCoords = {
+      yOffset: yOffset + this.document.documentElement.scrollTop,
+      xOffset: xOffset + this.document.documentElement.scrollLeft,
+    };
+
     this.renderer.setStyle(this.view.rootNodes[0], 'top', `${positionCoords.yOffset}px`);
     this.renderer.setStyle(this.view.rootNodes[0], 'left', `${positionCoords.xOffset}px`);
     this.smartOpenService.popoverAlignedEmit(this.view.rootNodes[0]);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Currently when opening a popover it was being hidden trough opacity change but that was causing issues with pages being scrolled to the top due to the initial focus in these popovers and it's initial position at the top of the page. Also the root scroll position was not being counted in calculations and that was giving troubles with positioning.

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-150

## What is the new behavior?

The popover is now being hidden trough 'visibility' change which would to the same as opacity but won't be available for focusing and that's fixing the issue with scrolling to the top and also to calculate the position right the root scroll is now used in calculations.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
