### PR TITLE
feat(popover): use scroll position in position calculation and visible event added

### DIFF
--- a/projects/angular/src/button/button-group/button-group.ts
+++ b/projects/angular/src/button/button-group/button-group.ts
@@ -14,7 +14,7 @@ import {
   QueryList,
   ViewChild,
 } from '@angular/core';
-import { delay, takeUntil } from 'rxjs/operators';
+import { takeUntil } from 'rxjs/operators';
 
 import { ClrDestroyService } from '../../utils/destroy/destroy.service';
 import { FOCUS_SERVICE_PROVIDER } from '../../utils/focus/focus.service';
@@ -162,8 +162,8 @@ export class ClrButtonGroup implements AfterContentInit, AfterViewInit {
 
   private handleFocusOnMenuOpen() {
     if (this.menuButtons.length) {
-      this.toggleService.openChange.pipe(delay(0), takeUntil(this.destroy$)).subscribe(isOpened => {
-        if (isOpened) {
+      this.toggleService.popoverVisible.pipe(takeUntil(this.destroy$)).subscribe(visible => {
+        if (visible) {
           this.focusHandler.initialize({
             menu: this.menu.nativeElement,
             menuToggle: this.menuToggle.nativeElement,

--- a/projects/angular/src/data/datagrid/datagrid-action-overflow.ts
+++ b/projects/angular/src/data/datagrid/datagrid-action-overflow.ts
@@ -94,7 +94,9 @@ export class ClrDatagridActionOverflow implements OnDestroy {
     this.subscriptions.push(
       this.smartToggleService.openChange.subscribe(openState => {
         this.open = openState;
-        if (openState) {
+      }),
+      this.smartToggleService.popoverVisible.subscribe(visible => {
+        if (visible) {
           this.initializeFocus();
         }
       })
@@ -128,16 +130,14 @@ export class ClrDatagridActionOverflow implements OnDestroy {
   private initializeFocus(): void {
     if (isPlatformBrowser(this.platformId)) {
       this.zone.runOutsideAngular(() => {
-        setTimeout(() => {
-          const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>('button.action-item'));
+        const buttons = Array.from(document.querySelectorAll<HTMLButtonElement>('button.action-item'));
 
-          if (buttons.length) {
-            this.keyFocus.current = 0;
-            this.keyFocus.focusableItems = buttons;
+        if (buttons.length) {
+          this.keyFocus.current = 0;
+          this.keyFocus.focusableItems = buttons;
 
-            this.keyFocus.focusCurrent();
-          }
-        });
+          this.keyFocus.focusCurrent();
+        }
       });
     }
   }

--- a/projects/angular/src/utils/popover/popover-content.ts
+++ b/projects/angular/src/utils/popover/popover-content.ts
@@ -101,6 +101,7 @@ export class ClrPopoverContent implements AfterContentChecked, OnDestroy {
         this.shouldRealign = false;
         if (this.view) {
           this.renderer.setStyle(this.view.rootNodes[0], 'opacity', '1');
+          this.smartOpenService.popoverVisibleEmit(true);
         }
       })
     );
@@ -129,7 +130,7 @@ export class ClrPopoverContent implements AfterContentChecked, OnDestroy {
     // coordinates values.
     this.renderer.setStyle(rootNode, 'top', '0px');
     this.renderer.setStyle(rootNode, 'left', '0px');
-    // We need to hide it during the calculation phase, while it's not yet finally positioned.
+    // // We need to hide it during the calculation phase, while it's not yet finally positioned.
     this.renderer.setStyle(rootNode, 'opacity', '0');
     this.removeClickListenerFn = this.renderer.listen(rootNode, 'click', event => {
       this.smartOpenService.openEvent = event;
@@ -152,12 +153,14 @@ export class ClrPopoverContent implements AfterContentChecked, OnDestroy {
     this.view.rootNodes.forEach(node => this.renderer.removeChild(this.document.body, node));
     this.container.clear();
     delete this.view;
+    this.smartOpenService.popoverVisibleEmit(false);
   }
 
   private alignContent() {
     if (!this.view) {
       return;
     }
+
     const positionCoords = this.smartPositionService.alignContent(this.view.rootNodes[0]);
     this.renderer.setStyle(this.view.rootNodes[0], 'top', `${positionCoords.yOffset}px`);
     this.renderer.setStyle(this.view.rootNodes[0], 'left', `${positionCoords.xOffset}px`);

--- a/projects/angular/src/utils/popover/providers/popover-position.service.ts
+++ b/projects/angular/src/utils/popover/providers/popover-position.service.ts
@@ -95,6 +95,14 @@ export class ClrPopoverPositionService {
       this.handleHorizontalAxisTwoViolations(errorSum);
     }
 
+    /**
+     * Adjusts popover position based on scroll value by adding the negative 'top' value of currentContentCoords to yOffset for proper alignment.
+     * - The negative value means that the 'top' of the content is scrolled out of view at the top of the viewport.
+     */
+    if (this.currentContentCoords.top < 0) {
+      this.contentOffsets.yOffset += Math.abs(this.currentContentCoords.top);
+    }
+
     return this.contentOffsets;
   }
 

--- a/projects/angular/src/utils/popover/providers/popover-toggle.service.ts
+++ b/projects/angular/src/utils/popover/providers/popover-toggle.service.ts
@@ -19,9 +19,14 @@ export class ClrPopoverToggleService {
   private _openEvent: Event;
   private _openEventChange = new Subject<Event>();
   private _popoverAligned = new Subject<HTMLElement>();
+  private _popoverVisible = new Subject<boolean>();
 
   get openChange(): Observable<boolean> {
     return this._openChange.asObservable();
+  }
+
+  get popoverVisible(): Observable<boolean> {
+    return this._popoverVisible.asObservable();
   }
 
   get openEvent(): Event {
@@ -65,6 +70,10 @@ export class ClrPopoverToggleService {
 
     this.openEvent = event;
     this.open = !this.open;
+  }
+
+  popoverVisibleEmit(visible: boolean) {
+    this._popoverVisible.next(visible);
   }
 
   popoverAlignedEmit(popoverNode: HTMLElement) {


### PR DESCRIPTION

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [] Bugfix
- [X] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently if you open a popover it's being rendered at the top left corner with opacity 0 which just makes it invisible but it's available for interactions. So when you click the action button in datagrid and you have available scroll the page gets scrolled to the top due to focusing of the first item in that popover which is positioned in the top corner.

Issue Number: CDE-150

## What is the new behavior?

We are using the scrolled value in the calculations because while the content was scrolled to the top the wrong positioned popover was not noticed. Using an event which emits once the popover is visible fixes a lot of possible and current issues because of most components are awaiting popover open event which is not when the popover is really ready for interactions.  
Initially I fixed the issue with using 'visibility: hidden' instead of opacity to hide the popover but that creates a lot of other issues both in tests and other places which in perfect scenario should be fixed but in the current moment the task gets out of scope a lot. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
