### PR TITLE
fix(header): position header overflow trigger button correctly

### DIFF
--- a/projects/angular/src/layout/nav/_responsive-nav.clarity.scss
+++ b/projects/angular/src/layout/nav/_responsive-nav.clarity.scss
@@ -345,7 +345,7 @@
         }
 
         .branding + .header-overflow-trigger,
-        .header-nav + .header-overflow-trigger {
+        .header-nav + .cdk-visually-hidden + .header-overflow-trigger {
           margin-left: auto;
         }
       }


### PR DESCRIPTION
The `cdkTrapFocus` directive inserts an element that break the sibling selector.

I broke this in 4828c5c8839aae6f50df358f18ba715af0fbf03d.