### PR TITLE
chore: prevent "element not focusable" warning in tests

### DIFF
--- a/projects/angular/src/utils/popover/stop-escape-propagation.directive.spec.ts
+++ b/projects/angular/src/utils/popover/stop-escape-propagation.directive.spec.ts
@@ -63,8 +63,8 @@ async function pressEscapeKey(fixture: ComponentFixture<TestComponent>, element:
   element.dispatchEvent(new KeyboardEvent('keydown', { key: Keys.Escape, bubbles: true }));
   element.dispatchEvent(new KeyboardEvent('keyup', { key: Keys.Escape, bubbles: true }));
 
-  fixture.detectChanges();
   await fixture.whenStable();
+  fixture.detectChanges();
 }
 
 @Component({


### PR DESCRIPTION
This is the warning that was being logged:

```
Element matching '[cdkFocusInitial]' is not focusable.
```

I think the `.modal-title-wrapper` element was failing the visibility check while the modal was being closed. Detecting changes after the component is stable fixes it.