### PR TITLE
fix(tooltip): allow user to interact with tooltip content using mouse

### DIFF
--- a/projects/angular/src/popover/tooltip/_tooltips.clarity.scss
+++ b/projects/angular/src/popover/tooltip/_tooltips.clarity.scss
@@ -136,6 +136,7 @@
       white-space: normal;
       z-index: map.get(variables.$clr-layers, tooltips);
 
+      // This allows a user to hover their mouse over the tooltip to stop it from hiding
       &::after {
         position: absolute;
         top: -20px;
@@ -143,6 +144,8 @@
         right: -20px;
         bottom: -20px;
         content: '';
+        // make sure this is underneath the tooltip so that user can use their mouse to select text
+        z-index: -1;
       }
     }
 


### PR DESCRIPTION
The previous change to introduce a fix for VPAT-617 meant the user was unable to copy text out of a tooltip because the ::after content overlays the tooltip content.

This change adds a -1 z-index to the ::after so that it is underneath which exposes the tooltip content div to allow text to be selected and copied.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

User hovers over tooltip trigger, tooltip displays, user then mouses over the tooltip content, but cannot select any text due to the overlaid ::after content.

Issue Number: N/A

## What is the new behavior?

User can now select text from tooltip and copy it to their clipboard.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

before:

![before](https://github.com/vmware-clarity/ng-clarity/assets/8139865/a1ce30f0-eb14-4ee5-b3b0-b52e70630ef2)

after:

![after](https://github.com/vmware-clarity/ng-clarity/assets/8139865/c10465d7-becc-42ae-8552-aff4cb1922dd)


