### PR TITLE
chore: deploy pr preview whether or not build succeeds if docs generated

### DIFF
--- a/.github/workflows/pr-comment-bot.yml
+++ b/.github/workflows/pr-comment-bot.yml
@@ -7,6 +7,19 @@ jobs:
     name: PR Comment Bot
     runs-on: ubuntu-latest
     steps:
+      - name: Check For Docs
+        id: check-for-docs
+        uses: actions/github-script@v6
+        with:
+          result-encoding: string
+          script: |
+            const actifacts = await github.rest.actions.listWorkflowRunArtifacts({
+              owner: '${{github.repository_owner}}'',
+              repo: '${{ github.event.repository.name }}',
+              run_id: '${{github.event.workflow_run.id}}',
+            });
+
+            return actifacts.find(actifact => artifact.name === 'docs')
       - name: Get PR Event
         id: get-pr-event
         uses: potiuk/get-workflow-origin@v1_5
@@ -56,8 +69,26 @@ jobs:
 
             🤖 Clarity Release Bot
           edit-mode: replace
-      - name: Build Failed PR Comment
-        if: ${{github.event.workflow_run.conclusion == 'failure'}}
+      - name: Build Failed with Docs Artifact PR Comment
+        if: ${{github.event.workflow_run.conclusion == 'failure' && steps.check-for-docs.outputs.result == 'true'}}
+        uses: peter-evans/create-or-update-comment@v2
+        with:
+          comment-id: ${{steps.find-comment.outputs.comment-id}}
+          issue-number: ${{steps.get-pr-event.outputs.pullRequestNumber}}
+          body: |
+            👋 @${{github.event.sender.login}},
+
+            * 😭 The build for this PR has failed
+            * 🗒 Please check out the [build log](${{github.event.workflow_run.html_url}})
+            * 🍿 Although the build failed, you can still view a [preview of this PR](https://${{steps.get-pr-event.outputs.pullRequestNumber}}--${{secrets.NETLIFY_SITE_NAME}}.netlify.app)
+            * 🖐 You can always follow up here. If you're a VMware employee, you can also reach us on our [internal #clarity-support Slack channel](https://vmware-clarity.slack.com/archives/C0JF8D2LB)
+
+            Thank you,
+
+            🤖 Clarity Release Bot
+          edit-mode: replace
+      - name: Build Failed without Docs Artifact PR Comment
+        if: ${{github.event.workflow_run.conclusion == 'failure' && steps.check-for-docs.outputs.result == 'false'}}
         uses: peter-evans/create-or-update-comment@v2
         with:
           comment-id: ${{steps.find-comment.outputs.comment-id}}

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -6,7 +6,6 @@ on:
       - completed
 jobs:
   pr-preview:
-    if: ${{github.event.workflow_run.conclusion == 'success'}}
     timeout-minutes: 10
     runs-on: ubuntu-latest
     steps:
@@ -24,13 +23,19 @@ jobs:
           path: dist/docs
           workflow: ${{github.event.workflow_run.workflow_id}}
           run_id: ${{github.event.workflow_run.id}}
+          if_no_artifact_found: ignore
+      - name: Check For Docs
+        id: check-for-docs
+        run: echo "docs-exist=$([[ -d dist/docs ]] && echo 'true' || echo 'false')" >> $GITHUB_OUTPUT
       - name: Get PR Event
         id: get-pr-event
+        if: ${{steps.check-for-docs.outputs.docs-exist == 'true'}}
         uses: potiuk/get-workflow-origin@v1_5
         with:
           token: ${{secrets.GITHUB_TOKEN}}
           sourceRunId: ${{github.event.workflow_run.id}}
       - name: Deploy Docs Preview
+        if: ${{steps.check-for-docs.outputs.docs-exist == 'true'}}
         timeout-minutes: 5
         env:
           NETLIFY_SITE_ID: ${{secrets.NETLIFY_SITE_ID}}

--- a/.storybook/stories/accordion/accordion.stories.ts
+++ b/.storybook/stories/accordion/accordion.stories.ts
@@ -12,6 +12,8 @@ import { setupStorybook } from '../../helpers/setup-storybook.helpers';
 
 const defaultStory: Story = args => ({
   template: `
+    I need the visual regression test to fail.
+
     <clr-accordion [clrAccordionMultiPanel]="clrAccordionMultiPanel">
       <clr-accordion-panel
         *ngFor="let _ of createArray(panelCount); let i = index"


### PR DESCRIPTION
This change is helpful in cases where only the visual regression tests fail. It may be helpful to have a preview of the PR to inspect.