### PR TITLE
fix(stack-view): ignore input events in stack block

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -3496,6 +3496,8 @@ export class ClrStackBlock implements OnInit {
     // (undocumented)
     get onStackLabelFocus(): boolean;
     // (undocumented)
+    protected preventDefaultIfNotInputEvent(event: Event): void;
+    // (undocumented)
     get role(): string;
     // (undocumented)
     set setChangedValue(value: boolean);
@@ -3504,7 +3506,7 @@ export class ClrStackBlock implements OnInit {
     // (undocumented)
     get tabIndex(): string;
     // (undocumented)
-    toggleExpand(): void;
+    toggleExpand(event?: Event): void;
     // (undocumented)
     uniqueId: string;
     // (undocumented)

--- a/projects/angular/src/data/stack-view/stack-block.ts
+++ b/projects/angular/src/data/stack-view/stack-block.ts
@@ -27,10 +27,10 @@ import { ClrStackViewLabel } from './stack-view-custom-tags';
          from scrolling when a stack block is toggled via the space key. -->
     <div
       class="stack-block-label"
-      (click)="toggleExpand()"
-      (keyup.enter)="toggleExpand()"
-      (keyup.space)="toggleExpand()"
-      (keydown.space)="$event.preventDefault()"
+      (click)="toggleExpand($event)"
+      (keyup.enter)="toggleExpand($event)"
+      (keyup.space)="toggleExpand($event)"
+      (keydown.space)="preventDefaultIfNotInputEvent($event)"
       (focus)="focused = true"
       (blur)="focused = false"
       [id]="uniqueId"
@@ -179,7 +179,11 @@ export class ClrStackBlock implements OnInit {
     this.expandable = true;
   }
 
-  toggleExpand(): void {
+  toggleExpand(event?: Event): void {
+    if (eventIsInputEvent(event)) {
+      return;
+    }
+
     if (this.expandable) {
       this.expanded = !this.expanded;
       this.expandedChange.emit(this.expanded);
@@ -189,4 +193,18 @@ export class ClrStackBlock implements OnInit {
   getStackChildrenId() {
     return this.expanded ? `clr-stack-children-${this.uniqueId}` : null;
   }
+
+  protected preventDefaultIfNotInputEvent(event: Event) {
+    if (eventIsInputEvent(event)) {
+      return;
+    }
+
+    event.preventDefault();
+  }
+}
+
+function eventIsInputEvent(event?: Event) {
+  const targetElement = event?.target as HTMLElement;
+
+  return targetElement?.tagName === 'INPUT';
 }


### PR DESCRIPTION
The stack block handles the space and enter keys to toggle expansion. We don't want the stack block to expand or collapse on click, space, or enter inside of an input.

The stack block prevents default on `keydown.space` which prevents the space from being "typed" into the input. This change fixes that as well.

closes #710