### PR TITLE
fix(links): exclude btn and nav-link from styling

### DIFF
--- a/projects/angular/src/layout/nav/_links.clarity.scss
+++ b/projects/angular/src/layout/nav/_links.clarity.scss
@@ -10,10 +10,16 @@
 @include mixins.exports('links.clarity') {
   // only imported for demos. gives a static view of links in various states.
   a:link {
-    @include mixins.css-var(font-weight, clr-link-font-weight, inherit, variables.$clr-use-custom-properties);
-    @include mixins.css-var(font-size, clr-link-font-size, inherit, variables.$clr-use-custom-properties);
-    @include mixins.css-var(line-height, clr-link-line-height, inherit, variables.$clr-use-custom-properties);
-    @include mixins.css-var(letter-spacing, clr-link-letter-spacing, inherit, variables.$clr-use-custom-properties);
+    /* 
+    * Due to the higher specificity of `a:link` over `.btn` and `.nav-link` it overrides the styles of both 
+    * which is not required. Also `.btn, .nav-link` doesn't need these styles, so we don't add them in these cases.
+    */
+    &:not(.btn, .nav-link) {
+      @include mixins.css-var(font-weight, clr-link-font-weight, inherit, variables.$clr-use-custom-properties);
+      @include mixins.css-var(font-size, clr-link-font-size, inherit, variables.$clr-use-custom-properties);
+      @include mixins.css-var(line-height, clr-link-line-height, inherit, variables.$clr-use-custom-properties);
+      @include mixins.css-var(letter-spacing, clr-link-letter-spacing, inherit, variables.$clr-use-custom-properties);
+    }
   }
   a.link-normal:link {
     @include mixins.css-var(color, clr-link-color, nav-variables.$clr-link-color, variables.$clr-use-custom-properties);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The styles of the links override the button ones and this creates visual issues due to the selectors of `:link` being with higher specificity than the `.btn` one. 

Issue Number: N/A

## What is the new behavior?

Not setting the new styles on elements with `.btn` and `.nav-links` because they don't need it.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
