### PR TITLE
chore(vrt): expand parallel workers for tests

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -19,7 +19,7 @@ export default defineConfig({
   fullyParallel: true,
   forbidOnly: true,
   retries: 0,
-  workers: 1,
+  workers: 3,
   reporter: 'html',
   projects: [
     {

--- a/tests/visual-snapshots.spec.ts
+++ b/tests/visual-snapshots.spec.ts
@@ -39,6 +39,10 @@ for (const { storyId, component } of stories) {
 
       await page.goto(`http://localhost:8080/iframe.html?${storyParams}`);
 
+      console.log(
+        `Executing ${screenshotPath}:${storyId}:${theme} story. Worker index: ${process.env.TEST_WORKER_INDEX}. Parallel Index: ${process.env.TEST_PARALLEL_INDEX}`
+      );
+
       await expect(page).toHaveScreenshot(screenshotPath.split(path.sep), {
         animations: 'disabled',
         caret: 'hide',

--- a/tests/visual-snapshots.spec.ts
+++ b/tests/visual-snapshots.spec.ts
@@ -49,4 +49,6 @@ for (const { storyId, component } of stories) {
   }
 }
 
-handleUnusedScreenshots(usedScreenshotPaths);
+test.afterAll(() => {
+  handleUnusedScreenshots(usedScreenshotPaths);
+});

--- a/tests/visual-snapshots.spec.ts
+++ b/tests/visual-snapshots.spec.ts
@@ -49,6 +49,4 @@ for (const { storyId, component } of stories) {
   }
 }
 
-test.afterAll(() => {
-  handleUnusedScreenshots(usedScreenshotPaths);
-});
+handleUnusedScreenshots(usedScreenshotPaths);

--- a/tests/visual-snapshots.spec.ts
+++ b/tests/visual-snapshots.spec.ts
@@ -39,10 +39,6 @@ for (const { storyId, component } of stories) {
 
       await page.goto(`http://localhost:8080/iframe.html?${storyParams}`);
 
-      console.log(
-        `Executing ${screenshotPath}:${storyId}:${theme} story. Worker index: ${process.env.TEST_WORKER_INDEX}. Parallel Index: ${process.env.TEST_PARALLEL_INDEX}`
-      );
-
       await expect(page).toHaveScreenshot(screenshotPath.split(path.sep), {
         animations: 'disabled',
         caret: 'hide',


### PR DESCRIPTION
Reduces VRT duration from ~11m to ~6-7m. Further improvements can be made using a matrix and sharding across different jobs but the current structure of handling the unused screenshots would cause problems. We can investigate those later. 