### PR TITLE
fix(header): remove `aria-expanded` attribute from open menu buttons

### DIFF
--- a/projects/angular/src/layout/nav/header.ts
+++ b/projects/angular/src/layout/nav/header.ts
@@ -20,7 +20,6 @@ import { ResponsiveNavCodes } from './responsive-nav-codes';
       *ngIf="isNavLevel1OnPage"
       class="header-hamburger-trigger"
       [attr.aria-label]="responsiveNavCommonString"
-      [attr.aria-expanded]="openNavLevel === 1 ? 'true' : 'false'"
       (click)="openNav(responsiveNavCodes.NAV_LEVEL_1)"
     >
       <span></span>
@@ -31,7 +30,6 @@ import { ResponsiveNavCodes } from './responsive-nav-codes';
       *ngIf="isNavLevel2OnPage"
       class="header-overflow-trigger"
       [attr.aria-label]="responsiveOverflowCommonString"
-      [attr.aria-expanded]="openNavLevel === 2 ? 'true' : 'false'"
       (click)="openNav(responsiveNavCodes.NAV_LEVEL_2)"
     >
       <span></span>


### PR DESCRIPTION
The `aria-expanded` attribute is incorrect because these button just open the menus. The buttons do not toggle the expanded state.