### PR TITLE
fix(textarea): set focus ring to solid to prevent dual lines

### DIFF
--- a/projects/angular/src/utils/_mixins.scss
+++ b/projects/angular/src/utils/_mixins.scss
@@ -35,8 +35,8 @@ $clr-outline-spread: variables.$clr_baselineRem_2px;
 }
 
 @mixin include-slim-outline-style-form-fields() {
-  outline: Highlight auto variables.$clr_baselineRem_2px;
-  outline: -webkit-focus-ring-color auto variables.$clr_baselineRem_2px;
+  outline: Highlight solid variables.$clr_baselineRem_2px;
+  outline: -webkit-focus-ring-color solid variables.$clr_baselineRem_2px;
 }
 
 @mixin include-outline-style-links() {


### PR DESCRIPTION
Sets the focus ring to explicitly use "solid" as "auto" was using the "double" or "groove" type in dark mode. 