### PR TITLE
feat(wizard): add input for content role

### DIFF
--- a/.storybook/stories/wizard/wizard.stories.ts
+++ b/.storybook/stories/wizard/wizard.stories.ts
@@ -63,6 +63,7 @@ const defaultParameters: Parameters = {
     clrWizardPreventDefaultCancel: { defaultValue: false },
     clrWizardPreventModalAnimation: { defaultValue: false },
     clrWizardStepnavAriaLabel: { defaultValue: commonStringsDefault.wizardStepnavAriaLabel },
+    clrWizardContentRole: { defaultValue: 'main' },
     clrWizardSize: { defaultValue: 'xl', control: { type: 'inline-radio', options: ['sm', 'md', 'lg', 'xl'] } },
     // outputs
     clrWizardOpenChange: { control: { disable: true } },

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -4293,6 +4293,7 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
     closable: boolean;
     close(): void;
     set clrWizardOpen(open: boolean);
+    contentRole: string;
     // (undocumented)
     get currentPage(): ClrWizardPage;
     set currentPage(page: ClrWizardPage);
@@ -4360,7 +4361,7 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
     // (undocumented)
     protected wizardTitle: ClrWizardTitle;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrWizard, "clr-wizard", never, { "stepnavAriaLabel": "clrWizardStepnavAriaLabel"; "size": "clrWizardSize"; "closable": "clrWizardClosable"; "forceForward": "clrWizardForceForwardNavigation"; "clrWizardOpen": "clrWizardOpen"; "stopNext": "clrWizardPreventDefaultNext"; "stopCancel": "clrWizardPreventDefaultCancel"; "stopNavigation": "clrWizardPreventNavigation"; "disableStepnav": "clrWizardDisableStepnav"; }, { "_openChanged": "clrWizardOpenChange"; "onCancel": "clrWizardOnCancel"; "wizardFinished": "clrWizardOnFinish"; "onReset": "clrWizardOnReset"; "currentPageChanged": "clrWizardCurrentPageChanged"; "onMoveNext": "clrWizardOnNext"; "onMovePrevious": "clrWizardOnPrevious"; }, ["wizardTitle", "pages", "headerActions"], ["clr-wizard-title", "clr-wizard-header-action", "*", "clr-wizard-button"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrWizard, "clr-wizard", never, { "stepnavAriaLabel": "clrWizardStepnavAriaLabel"; "contentRole": "clrWizardContentRole"; "size": "clrWizardSize"; "closable": "clrWizardClosable"; "forceForward": "clrWizardForceForwardNavigation"; "clrWizardOpen": "clrWizardOpen"; "stopNext": "clrWizardPreventDefaultNext"; "stopCancel": "clrWizardPreventDefaultCancel"; "stopNavigation": "clrWizardPreventNavigation"; "disableStepnav": "clrWizardDisableStepnav"; }, { "_openChanged": "clrWizardOpenChange"; "onCancel": "clrWizardOnCancel"; "wizardFinished": "clrWizardOnFinish"; "onReset": "clrWizardOnReset"; "currentPageChanged": "clrWizardCurrentPageChanged"; "onMoveNext": "clrWizardOnNext"; "onMovePrevious": "clrWizardOnPrevious"; }, ["wizardTitle", "pages", "headerActions"], ["clr-wizard-title", "clr-wizard-header-action", "*", "clr-wizard-button"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrWizard, never>;
 }

--- a/projects/angular/src/wizard/test-components/api-wizard.mock.ts
+++ b/projects/angular/src/wizard/test-components/api-wizard.mock.ts
@@ -23,6 +23,7 @@ import { ClrWizard } from '../wizard';
       (clrWizardOnFinish)="handleOnFinish()"
       [clrWizardPreventDefaultCancel]="stopCancel"
       [clrWizardStepnavAriaLabel]="stepnavAriaLabel"
+      [clrWizardContentRole]="contentRole"
     >
       <clr-wizard-title [clrHeadingLevel]="titleHeadingLevel">{{ projectedTitle }}</clr-wizard-title>
 
@@ -58,6 +59,7 @@ export class TemplateApiWizardTestComponent {
 
   mySize: string;
   stepnavAriaLabel = 'Label for stepnav';
+  contentRole: string;
   projectedTitle = 'My Great Title';
   projectedPageTitle = 'Title for Page 2';
   titleHeadingLevel: HeadingLevel;

--- a/projects/angular/src/wizard/wizard.html
+++ b/projects/angular/src/wizard/wizard.html
@@ -36,9 +36,9 @@
   </div>
 
   <div class="modal-body">
-    <main clr-wizard-pages-wrapper class="clr-wizard-content">
+    <div clr-wizard-pages-wrapper class="clr-wizard-content" [attr.role]="contentRole || 'main'">
       <ng-content></ng-content>
-    </main>
+    </div>
   </div>
   <div class="modal-footer clr-wizard-footer">
     <div class="clr-wizard-footer-buttons">

--- a/projects/angular/src/wizard/wizard.spec.ts
+++ b/projects/angular/src/wizard/wizard.spec.ts
@@ -656,6 +656,21 @@ export default function (): void {
           expect(stepnavWrapper.getAttribute('aria-label')).toBe('Updated step navigation label');
         });
       });
+
+      describe('content role', () => {
+        it('sets the content element role to "main"', () => {
+          const contentElement = context.hostElement.querySelector('.clr-wizard-content');
+          expect(contentElement.getAttribute('role')).toBe('main');
+        });
+
+        it('clrWizardContentRole input sets role for the content element', () => {
+          context.hostComponent.contentRole = 'generic';
+          context.detectChanges();
+
+          const contentElement = context.hostElement.querySelector('.clr-wizard-content');
+          expect(contentElement.getAttribute('role')).toBe('generic');
+        });
+      });
     });
 
     describe('Dynamic Content', () => {

--- a/projects/angular/src/wizard/wizard.ts
+++ b/projects/angular/src/wizard/wizard.ts
@@ -54,6 +54,11 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
   @Input('clrWizardStepnavAriaLabel') stepnavAriaLabel = this.commonStrings.keys.wizardStepnavAriaLabel;
 
   /**
+   * Set the role for the content of the wizard. Set using `[clrWizardContentRole]` input. Defaults to "main".
+   */
+  @Input('clrWizardContentRole') contentRole: string;
+
+  /**
    * Set the modal size of the wizard. Set using `[clrWizardSize]` input.
    */
   @Input('clrWizardSize') size = 'xl';


### PR DESCRIPTION
The wizard content role is defaulted to `main`, but consumers can change it if needed.

This change will allow us to remove nested `main` landmarks in the documentation website.