### PR TITLE
chore(vrt): change filter to exclude default stories

### DIFF
--- a/tests/visual-snapshots.spec.ts
+++ b/tests/visual-snapshots.spec.ts
@@ -18,7 +18,7 @@ const usedScreenshotPaths: string[] = [];
 const stories: Story[] = JSON.parse(fs.readFileSync('./dist/docs/stories.json').toString());
 
 for (const { storyId, component } of stories) {
-  if (!storyId.includes('--variants')) {
+  if (storyId.endsWith('--default') || !component) {
     continue;
   }
 


### PR DESCRIPTION
Updates the VRT screenshot tests from only taking screenshots of stories ending with `--variants` to taking screenshots of every story except those ending in `--default`. As stories are converted to use the standard CSFv3 syntax, we'll end up with more individual stories but for those that are converted, we won't have the --variants version of the page. 