### PR TITLE
fix(stepper): don't open first panel if clrInitialStep is set

### DIFF
--- a/projects/angular/src/accordion/stepper/models/stepper.model.ts
+++ b/projects/angular/src/accordion/stepper/models/stepper.model.ts
@@ -9,9 +9,14 @@ import { AccordionModel } from '../../models/accordion.model';
 
 export class StepperModel extends AccordionModel {
   private stepperModelInitialize = false;
+  private initialPanel: string;
 
   get allPanelsCompleted(): boolean {
     return this.panels.length && this.getNumberOfIncompletePanels() === 0 && this.getNumberOfOpenPanels() === 0;
+  }
+
+  get shouldOpenFirstPanel() {
+    return !this.initialPanel || (this._panels && Object.keys(this._panels).length && !this._panels[this.initialPanel]);
   }
 
   override addPanel(id: string, open = false) {
@@ -42,6 +47,7 @@ export class StepperModel extends AccordionModel {
   }
 
   overrideInitialPanel(panelId: string) {
+    this.initialPanel = panelId;
     this.panels
       .filter(() => this._panels[panelId] !== undefined)
       .forEach(panel => {
@@ -81,6 +87,9 @@ export class StepperModel extends AccordionModel {
   }
 
   private openFirstPanel() {
+    if (!this.shouldOpenFirstPanel) {
+      return;
+    }
     const firstPanel = this.getFirstPanel();
     /**
      * You need to call updatePanelOrder first to get the correct order,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently the stepper is always opening the first panel no matter what. However if the initialStep is different from the first panel it still emits change events for the first panel.

Issue Number: N/A

## What is the new behavior?

No longer opens the first panel if the initial panel is different.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
