### PR TITLE
fix(combobox): add touched condition to invalid validation

### DIFF
--- a/projects/angular/src/forms/combobox/combobox.ts
+++ b/projects/angular/src/forms/combobox/combobox.ts
@@ -356,7 +356,7 @@ export class ClrCombobox<T>
     if (this.controlStateService) {
       this.subscriptions.push(
         this.controlStateService.statusChanges.subscribe(invalid => {
-          this.invalid = invalid === CONTROL_STATE.INVALID;
+          this.invalid = this.control.control.touched && invalid === CONTROL_STATE.INVALID;
         })
       );
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The `invalid` class on the combobox wrapper is set even if the control is not touched.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-1122

## What is the new behavior?

The class is now being set if the control is touched and invalid.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
