### PR TITLE
fix(signpost): provide default `aria-label` only on default trigger

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -3410,13 +3410,11 @@ export class ClrSignpostModule {
 
 // @public (undocumented)
 export class ClrSignpostTrigger implements OnDestroy {
-    constructor(toggleService: ClrPopoverToggleService, el: ElementRef, commonStrings: ClrCommonStringsService, signpostIdService: SignpostIdService, signpostFocusManager: SignpostFocusManager, document: any, platformId: any);
+    constructor(toggleService: ClrPopoverToggleService, el: ElementRef, signpostIdService: SignpostIdService, signpostFocusManager: SignpostFocusManager, document: any, platformId: any);
     // (undocumented)
     ariaControl: string;
     // (undocumented)
     ariaExpanded: boolean;
-    // (undocumented)
-    commonStrings: ClrCommonStringsService;
     // (undocumented)
     isOpen: boolean;
     // (undocumented)

--- a/projects/angular/src/popover/signpost/signpost-trigger.spec.ts
+++ b/projects/angular/src/popover/signpost/signpost-trigger.spec.ts
@@ -62,10 +62,6 @@ export default function (): void {
       expect(trigger.classList.contains('active')).toBeFalsy();
     });
 
-    it('has a default label from common strings', () => {
-      expect(trigger.getAttribute('aria-label')).toEqual('Signpost Toggle');
-    });
-
     it('preserves explicitly set label', () => {
       const testLabel = 'Test label';
       fixture.debugElement.componentInstance.label = testLabel;

--- a/projects/angular/src/popover/signpost/signpost-trigger.ts
+++ b/projects/angular/src/popover/signpost/signpost-trigger.ts
@@ -8,7 +8,6 @@ import { DOCUMENT, isPlatformBrowser } from '@angular/common';
 import { Directive, ElementRef, HostListener, Inject, OnDestroy, PLATFORM_ID } from '@angular/core';
 import { Subscription } from 'rxjs';
 
-import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { ClrPopoverToggleService } from '../../utils/popover/providers/popover-toggle.service';
 import { SignpostFocusManager } from './providers/signpost-focus-manager.service';
 import { SignpostIdService } from './providers/signpost-id.service';
@@ -41,7 +40,6 @@ export class ClrSignpostTrigger implements OnDestroy {
   constructor(
     private toggleService: ClrPopoverToggleService,
     private el: ElementRef,
-    public commonStrings: ClrCommonStringsService,
     private signpostIdService: SignpostIdService,
     private signpostFocusManager: SignpostFocusManager,
     @Inject(DOCUMENT) document: any,
@@ -68,7 +66,6 @@ export class ClrSignpostTrigger implements OnDestroy {
       }),
       this.signpostIdService.id.subscribe(idChange => (this.ariaControl = idChange))
     );
-    this.addDefaultAriaLabel(this.el.nativeElement);
   }
 
   ngOnDestroy() {
@@ -83,12 +80,6 @@ export class ClrSignpostTrigger implements OnDestroy {
   @HostListener('click', ['$event'])
   onSignpostTriggerClick(event: Event): void {
     this.toggleService.toggleWithEvent(event);
-  }
-
-  private addDefaultAriaLabel(el: HTMLElement) {
-    if (!el.hasAttribute('aria-label')) {
-      el.setAttribute('aria-label', this.commonStrings.keys.signpostToggle);
-    }
   }
 
   private focusOnClose() {

--- a/projects/angular/src/popover/signpost/signpost.spec.ts
+++ b/projects/angular/src/popover/signpost/signpost.spec.ts
@@ -56,6 +56,12 @@ export default function (): void {
         expect(signpostContent).toBeNull();
         expect(this.toggleService.open).toBe(false);
       });
+
+      it('has a default aria-label on the default trigger', function (this: Context) {
+        const signpostToggle: HTMLElement = this.hostElement.querySelector('.signpost-action');
+
+        expect(signpostToggle.getAttribute('aria-label')).toEqual('Signpost Toggle');
+      });
     });
 
     describe('focus management', function () {

--- a/projects/angular/src/popover/signpost/signpost.ts
+++ b/projects/angular/src/popover/signpost/signpost.ts
@@ -16,7 +16,12 @@ import { ClrSignpostTrigger } from './signpost-trigger';
   selector: 'clr-signpost',
   template: `
     <ng-container *ngIf="!useCustomTrigger">
-      <button type="button" class="signpost-action btn btn-sm btn-icon btn-link" clrSignpostTrigger>
+      <button
+        type="button"
+        class="signpost-action btn btn-sm btn-icon btn-link"
+        clrSignpostTrigger
+        [attr.aria-label]="commonStrings.keys.signpostToggle"
+      >
         <cds-icon shape="info-circle" [attr.title]="commonStrings.keys.info"></cds-icon>
       </button>
     </ng-container>


### PR DESCRIPTION
This is a backport of dd1504aac25af2e959f15583a144c28c2b8c6f59 (#1052) to 16.x.

This prevents overriding the visible text of a custom signpost trigger.

VPAT-774