### PR TITLE
chore: prevent installing Angular 17 instead of Angular 16

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -25,7 +25,7 @@ jobs:
       - name: Update to Angular v16
         if: ${{matrix.angular == 'Angular v16'}}
         run: |
-          npx ng update @angular/core@16 @angular/cli@16 @angular/cdk@16 --force
+          npx ng update @angular/core@16 @angular/common@16 @angular/cli@16 @angular/cdk@16 --force
       - name: Install Alternate @cds/core Version
         if: ${{matrix.cds-core != ''}}
         run: npm install ${{matrix.cds-core}}


### PR DESCRIPTION
This is a backport of 1f35ac2da70481bc006e23eb0a7d5f8924d5a1cc (#1045) to 15.x.

The previous command updated all unlisted Angular packages to v17.