### PR TITLE
chore: add retries to playwright to prevent flaky tests (port of #1089)

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -18,7 +18,7 @@ export default defineConfig({
   },
   fullyParallel: true,
   forbidOnly: true,
-  retries: 0,
+  retries: 2,
   workers: 3,
   reporter: 'html',
   projects: [


### PR DESCRIPTION
Update the playwright config to allow two retries for failed tests. When a test fails, that individual test will be retried twice, and if it fails every time, the last screenshot will be retained for different comparisons. This should help overcome the flaky button issues seen on this PR and #1088 .

Port of #1089 

