### PR TITLE
feat(progress-bar): change color api

### DIFF
--- a/.storybook/stories/progress-bar/progress-bar.stories.ts
+++ b/.storybook/stories/progress-bar/progress-bar.stories.ts
@@ -20,9 +20,7 @@ const defaultStory: Story = args => ({
       [clrLabeled]="clrLabeled"
       [clrFade]="clrFade"
       [clrLoop]="clrLoop"
-      [clrSuccess]="clrSuccess"
-      [clrDanger]="clrDanger"
-      [clrWarning]="clrWarning"
+      [clrColor]="clrColor"
       [clrFlash]="clrFlash"
       [clrFlashDanger]="clrFlashDanger"
       [clrCompact]="clrCompact"
@@ -43,10 +41,8 @@ const defaultParameters: Parameters = {
     clrLabeled: { defaultValue: false, control: { type: 'boolean' } },
     clrLoop: { defaultValue: false, control: { type: 'boolean' } },
     clrMax: { defaultValue: 100, control: { type: 'number' } },
-    clrSuccess: { defaultValue: false, control: { type: 'boolean' } },
-    clrWarning: { defaultValue: false, control: { type: 'boolean' } },
-    clrDanger: { defaultValue: false, control: { type: 'boolean' } },
-    clrValue: { defaultValue: 0, control: { type: 'number' } },
+    clrColor: { defaultValue: '', control: { type: 'radio', options: ['', 'success', 'warning', 'danger'] } },
+    clrValue: { defaultValue: 33, control: { type: 'number' } },
     clrCompact: { defaultValue: false, control: { type: 'boolean' } },
     id: { defaultValue: '' },
     // methods
@@ -63,17 +59,17 @@ const variants: Parameters[] = [
   },
   {
     clrValue: 66,
-    clrDanger: true,
+    clrColor: 'danger',
     clrLabeled: true,
     clrDisplayVal: '66%',
   },
   {
     clrValue: 100,
-    clrSuccess: true,
+    clrColor: 'success',
   },
   {
     clrValue: 50,
-    clrWarning: true,
+    clrColor: 'warning',
     clrLabeled: true,
     clrDisplayVal: '50%',
   },

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -3098,8 +3098,6 @@ export class ClrPopoverToggleService {
 // @public (undocumented)
 export class ClrProgressBar {
     // (undocumented)
-    set clrColor(value: string);
-    // (undocumented)
     set clrCompact(value: boolean | string);
     // (undocumented)
     set clrFade(value: boolean | string);
@@ -3111,6 +3109,8 @@ export class ClrProgressBar {
     set clrLabeled(value: boolean | string);
     // (undocumented)
     set clrLoop(value: boolean | string);
+    // (undocumented)
+    color: string;
     // (undocumented)
     get compactClass(): boolean;
     // (undocumented)
@@ -3145,7 +3145,7 @@ export class ClrProgressBar {
     // (undocumented)
     get warningClass(): boolean;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrProgressBar, "clr-progress-bar", never, { "max": "clrMax"; "displayval": "clrDisplayval"; "value": "clrValue"; "id": "id"; "clrCompact": "clrCompact"; "clrLabeled": "clrLabeled"; "clrFade": "clrFade"; "clrLoop": "clrLoop"; "clrColor": "clrColor"; "clrFlash": "clrFlash"; "clrFlashDanger": "clrFlashDanger"; }, {}, never, never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrProgressBar, "clr-progress-bar", never, { "max": "clrMax"; "displayval": "clrDisplayval"; "color": "clrColor"; "value": "clrValue"; "id": "id"; "clrCompact": "clrCompact"; "clrLabeled": "clrLabeled"; "clrFade": "clrFade"; "clrLoop": "clrLoop"; "clrFlash": "clrFlash"; "clrFlashDanger": "clrFlashDanger"; }, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrProgressBar, never>;
 }

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -3098,9 +3098,9 @@ export class ClrPopoverToggleService {
 // @public (undocumented)
 export class ClrProgressBar {
     // (undocumented)
+    set clrColor(value: string);
+    // (undocumented)
     set clrCompact(value: boolean | string);
-    // @deprecated (undocumented)
-    set clrDanger(value: boolean | string);
     // (undocumented)
     set clrFade(value: boolean | string);
     // (undocumented)
@@ -3111,10 +3111,6 @@ export class ClrProgressBar {
     set clrLabeled(value: boolean | string);
     // (undocumented)
     set clrLoop(value: boolean | string);
-    // @deprecated (undocumented)
-    set clrSuccess(value: boolean | string);
-    // @deprecated (undocumented)
-    set clrWarning(value: boolean | string);
     // (undocumented)
     get compactClass(): boolean;
     // (undocumented)
@@ -3149,7 +3145,7 @@ export class ClrProgressBar {
     // (undocumented)
     get warningClass(): boolean;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrProgressBar, "clr-progress-bar", never, { "max": "clrMax"; "displayval": "clrDisplayval"; "value": "clrValue"; "id": "id"; "clrCompact": "clrCompact"; "clrLabeled": "clrLabeled"; "clrFade": "clrFade"; "clrLoop": "clrLoop"; "clrWarning": "clrWarning"; "clrSuccess": "clrSuccess"; "clrDanger": "clrDanger"; "clrFlash": "clrFlash"; "clrFlashDanger": "clrFlashDanger"; }, {}, never, never, false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrProgressBar, "clr-progress-bar", never, { "max": "clrMax"; "displayval": "clrDisplayval"; "value": "clrValue"; "id": "id"; "clrCompact": "clrCompact"; "clrLabeled": "clrLabeled"; "clrFade": "clrFade"; "clrLoop": "clrLoop"; "clrColor": "clrColor"; "clrFlash": "clrFlash"; "clrFlashDanger": "clrFlashDanger"; }, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrProgressBar, never>;
 }

--- a/projects/angular/src/progress/progress-bars/_variables.progress-bars.scss
+++ b/projects/angular/src/progress/progress-bars/_variables.progress-bars.scss
@@ -8,15 +8,8 @@
 // @deprecated in v17 in favor of $clr-progress-default-color
 $clr-progress-defaultBarColor: var(--clr-progress-default-color) !default;
 $clr-progress-default-color: $clr-progress-defaultBarColor !default;
-
-// @deprecated in 3.0
-//  warning, success, and danger distinctions for progress bars are deprecated in 3.0
 $clr-progress-success-color: var(--clr-progress-alt-color-1) !default;
-
-// @deprecated in 3.0
 $clr-progress-danger-color: var(--clr-progress-alt-color-2) !default;
-
-// @deprecated in 3.0
 $clr-progress-warning-color: var(--clr-progress-alt-color-3) !default;
 
 // @deprecated in v17 in favor of $clr-progress-bg-color

--- a/projects/angular/src/progress/progress-bars/progress-bar.spec.ts
+++ b/projects/angular/src/progress/progress-bars/progress-bar.spec.ts
@@ -30,16 +30,7 @@ class TestDisplayValueComponent {}
 
 @Component({
   template: `
-    <clr-progress-bar
-      clrLabeled
-      clrFade
-      clrLoop
-      clrSuccess
-      clrDanger
-      clrFlash
-      clrFlashDanger
-      class="random"
-    ></clr-progress-bar>
+    <clr-progress-bar clrLabeled clrFade clrLoop clrColor clrFlash clrFlashDanger class="random"></clr-progress-bar>
   `,
 })
 class TestStylesComponent {}

--- a/projects/angular/src/progress/progress-bars/progress-bar.spec.ts
+++ b/projects/angular/src/progress/progress-bars/progress-bar.spec.ts
@@ -30,7 +30,15 @@ class TestDisplayValueComponent {}
 
 @Component({
   template: `
-    <clr-progress-bar clrLabeled clrFade clrLoop clrColor clrFlash clrFlashDanger class="random"></clr-progress-bar>
+    <clr-progress-bar
+      clrLabeled
+      clrFade
+      clrLoop
+      clrColor="danger"
+      clrFlash
+      clrFlashDanger
+      class="random"
+    ></clr-progress-bar>
   `,
 })
 class TestStylesComponent {}
@@ -91,13 +99,13 @@ describe('ClrProgressBar component', () => {
         clrProgressBar = fixture.debugElement.query(By.directive(ClrProgressBar)).nativeElement;
       });
 
-      it('should add classes based on attributes "labeled fade loop success danger flash flash-danger"', () => {
+      it('should add classes based on attributes "labeled fade loop danger flash flash-danger"', () => {
         const klasses = clrProgressBar
           .getAttribute('class')
           .split(' ')
           .sort((a, b) => (a > b ? 1 : -1))
           .join(' ');
-        expect(klasses).toContain('danger flash flash-danger labeled loop progress progress-fade random success');
+        expect(klasses).toContain('danger flash flash-danger labeled loop progress progress-fade random');
       });
 
       it('should be able to add custom class if needed', () => {

--- a/projects/angular/src/progress/progress-bars/progress-bar.ts
+++ b/projects/angular/src/progress/progress-bars/progress-bar.ts
@@ -18,6 +18,7 @@ import { isBooleanAttributeSet } from '../../utils/component/is-boolean-attribut
 export class ClrProgressBar {
   @Input('clrMax') max: number | string = 100;
   @Input('clrDisplayval') displayval: string;
+  @Input('clrColor') color: string;
 
   /*
    * No need to convert to `number` cause we could have
@@ -34,9 +35,6 @@ export class ClrProgressBar {
   private _labeled: boolean;
   private _fade: boolean;
   private _loop: boolean;
-  private _success: boolean;
-  private _danger: boolean;
-  private _warning: boolean;
   private _flash: boolean;
   private _flashDanger: boolean;
   private _compact: boolean;
@@ -95,44 +93,19 @@ export class ClrProgressBar {
     return this._loop;
   }
 
-  @Input('clrColor')
-  set clrColor(value: string) {
-    switch (value) {
-      case 'success':
-        this._success = true;
-        this._warning = false;
-        this._danger = false;
-        break;
-      case 'warning':
-        this._success = false;
-        this._warning = true;
-        this._danger = false;
-        break;
-      case 'danger':
-        this._success = false;
-        this._warning = false;
-        this._danger = true;
-        break;
-      default:
-        this._success = false;
-        this._warning = false;
-        this._danger = false;
-    }
-  }
-
   @HostBinding('class.warning')
   get warningClass() {
-    return this._warning;
+    return this.color === 'warning';
   }
 
   @HostBinding('class.success')
   get successClass() {
-    return this._success;
+    return this.color === 'success';
   }
 
   @HostBinding('class.danger')
   get dangerClass() {
-    return this._danger;
+    return this.color === 'danger';
   }
 
   @Input('clrFlash')

--- a/projects/angular/src/progress/progress-bars/progress-bar.ts
+++ b/projects/angular/src/progress/progress-bars/progress-bar.ts
@@ -95,10 +95,29 @@ export class ClrProgressBar {
     return this._loop;
   }
 
-  /** @deprecated since 2.0, remove in 4.0 */
-  @Input('clrWarning')
-  set clrWarning(value: boolean | string) {
-    this._warning = isBooleanAttributeSet(value);
+  @Input('clrColor')
+  set clrColor(value: string) {
+    switch (value) {
+      case 'success':
+        this._success = true;
+        this._warning = false;
+        this._danger = false;
+        break;
+      case 'warning':
+        this._success = false;
+        this._warning = true;
+        this._danger = false;
+        break;
+      case 'danger':
+        this._success = false;
+        this._warning = false;
+        this._danger = true;
+        break;
+      default:
+        this._success = false;
+        this._warning = false;
+        this._danger = false;
+    }
   }
 
   @HostBinding('class.warning')
@@ -106,21 +125,9 @@ export class ClrProgressBar {
     return this._warning;
   }
 
-  /** @deprecated since 2.0, remove in 4.0 */
-  @Input('clrSuccess')
-  set clrSuccess(value: boolean | string) {
-    this._success = isBooleanAttributeSet(value);
-  }
-
   @HostBinding('class.success')
   get successClass() {
     return this._success;
-  }
-
-  /** @deprecated since 2.0, remove in 4.0 */
-  @Input('clrDanger')
-  set clrDanger(value: boolean | string) {
-    this._danger = isBooleanAttributeSet(value);
   }
 
   @HostBinding('class.danger')

--- a/projects/demo/src/app/progress-bars/progress-bar-component.html
+++ b/projects/demo/src/app/progress-bars/progress-bar-component.html
@@ -21,10 +21,10 @@
       <h1>Styles</h1>
 
       <h5>Success</h5>
-      <clr-progress-bar clrValue="20" clrMax="100" clrSuccess></clr-progress-bar>
+      <clr-progress-bar clrValue="20" clrMax="100" clrColor="success"></clr-progress-bar>
 
       <h5>Danger</h5>
-      <clr-progress-bar clrValue="50" clrMax="100" clrDanger></clr-progress-bar>
+      <clr-progress-bar clrValue="50" clrMax="100" clrColor="danger"></clr-progress-bar>
 
       <h1>Animations</h1>
 
@@ -32,10 +32,10 @@
       <clr-progress-bar clrLoop></clr-progress-bar>
 
       <h5>Loop & Success</h5>
-      <clr-progress-bar clrLoop clrSuccess></clr-progress-bar>
+      <clr-progress-bar clrLoop clrColor="success"></clr-progress-bar>
 
       <h5>Loop & Danger</h5>
-      <clr-progress-bar clrLoop clrDanger></clr-progress-bar>
+      <clr-progress-bar clrLoop clrColor="danger"></clr-progress-bar>
     </div>
 
     <div class="clr-col-12">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Current API uses different properties for assign colors to progress bar `clrSuccess`, `clrWarning` and `clrDanger`.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-1406

## What is the new behavior?
The new API is using property `clrColor` with possible values `'success' | 'warning' | 'danger'` for better understanding and ease of use.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

BREAKING CHANGES: API properties used for color assign `clrSuccess`, `clrWarning` and `clrDanger` are replaced with single property `clrColor` with possible values `'success' | 'warning' | 'danger'`.
