### PR TITLE
fix(accordion): prevent error with nested accordions

### DIFF
--- a/projects/angular/src/accordion/accordion.ts
+++ b/projects/angular/src/accordion/accordion.ts
@@ -35,7 +35,7 @@ export class ClrAccordion implements OnInit, OnChanges, AfterViewInit, OnDestroy
    * Whether the accordion supports multiple panels opened at the same time.
    */
   @Input('clrAccordionMultiPanel') multiPanel: boolean | string = false;
-  @ContentChildren(ClrAccordionPanel, { descendants: true }) panels: QueryList<ClrAccordionPanel>;
+  @ContentChildren(ClrAccordionPanel) panels: QueryList<ClrAccordionPanel>;
   subscriptions: Subscription[] = [];
 
   constructor(private accordionService: AccordionService) {}


### PR DESCRIPTION
An instance of the accordion component should only care about its own panels. Including nested accordions' panels causes an error when trying to update panels that don't belong the parent instance.

closes #1118

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Bugfix

## What is the current behavior?

Issue Number: #1118

## What is the new behavior?

No JS error with nested accordion panels.

## Does this PR introduce a breaking change?

No.