### PR TITLE
fix(accordion): prevent error with nested accordions

### DIFF
--- a/projects/angular/src/accordion/accordion.ts
+++ b/projects/angular/src/accordion/accordion.ts
@@ -32,7 +32,7 @@ import { AccordionService } from './providers/accordion.service';
 })
 export class ClrAccordion implements OnInit, OnChanges, AfterViewInit, OnDestroy {
   @Input('clrAccordionMultiPanel') multiPanel: boolean | string = false;
-  @ContentChildren(ClrAccordionPanel, { descendants: true }) panels: QueryList<ClrAccordionPanel>;
+  @ContentChildren(ClrAccordionPanel) panels: QueryList<ClrAccordionPanel>;
   subscriptions: Subscription[] = [];
 
   constructor(private accordionService: AccordionService) {}


### PR DESCRIPTION
This is a port of 898e1df3ea72df015119509f6ec335d2e591d29d (#1119) to 17.x.

An instance of the accordion component should only care about its own panels. Including nested accordions' panels causes an error when trying to update panels that don't belong the parent instance.

closes #1118