### PR TITLE
fix(alert): prevent error if alert is initially closed

### DIFF
--- a/projects/angular/src/emphasis/alert/alert.ts
+++ b/projects/angular/src/emphasis/alert/alert.ts
@@ -121,7 +121,7 @@ export class ClrAlert implements OnInit, OnDestroy {
     }
     const isCurrentAlert = this.multiAlertService?.currentAlert === this;
     this._closed = true;
-    if (this.multiAlertService) {
+    if (this.multiAlertService?.activeAlerts) {
       this.multiAlertService.close(isCurrentAlert);
     }
     this._closedChanged.emit(true);

--- a/projects/angular/src/emphasis/alert/alerts.spec.ts
+++ b/projects/angular/src/emphasis/alert/alerts.spec.ts
@@ -237,6 +237,35 @@ export default function () {
       });
     });
   });
+
+  describe('with an initially-closed alert', () => {
+    @Component({
+      template: `
+        <clr-alerts>
+          <clr-alert [clrAlertClosed]="true">
+            <clr-alert-item>
+              <span class="alert-text">This is the alert!</span>
+            </clr-alert-item>
+          </clr-alert>
+        </clr-alerts>
+      `,
+    })
+    class InitiallyClosedAlertTestComponent {}
+
+    beforeEach(() => {
+      TestBed.configureTestingModule({
+        imports: [ClrEmphasisModule],
+        declarations: [InitiallyClosedAlertTestComponent],
+      });
+    });
+
+    it('does not throw an error', () => {
+      const fixture = TestBed.createComponent(InitiallyClosedAlertTestComponent);
+      fixture.detectChanges();
+
+      // test will pass if no error is thrown
+    });
+  });
 }
 
 @Component({


### PR DESCRIPTION
This change prevents if the multi-alerts `clr-alerts` component contains an alert with `[clrAlertClosed]` set to false. The error was thrown because the code attempted to close an alert that was never rendered.

CDE-1606
closes #92

## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

JS error thrown if an alert in a multi-alert is initially closed. The error was thrown because the code attempted to close an alert that was never rendered.

Issue Number: #92

## What is the new behavior?

No JS error thrown if an alert in a multi-alert is initially closed. The `MultiAlertService#close` method is not called if the alerts have not yet been rendered.

## Does this PR introduce a breaking change?

No.