### PR TITLE
fix(datagrid): use correct layers, remove no-op z-indexes (port to 17.x)

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -271,10 +271,6 @@
         line-height: tokens.$cds-global-space-9;
       }
     }
-
-    .datagrid-row-sticky {
-      z-index: map.get(variables.$clr-layers, datagrid-row-sticky);
-    }
   }
 
   .datagrid-row-sticky {
@@ -283,7 +279,7 @@
     flex-wrap: nowrap;
     position: sticky;
     left: 0;
-    z-index: map.get(variables.$clr-layers, datagrid-header-sticky);
+    z-index: map.get(variables.$clr-layers, datagrid-row-sticky);
 
     .datagrid-cell:last-child {
       &:after {
@@ -373,7 +369,7 @@
 
       .datagrid-row-sticky {
         @include clr-datagrid-header-bg;
-        z-index: map.get(variables.$clr-layers, datagrid-sticky-header);
+        z-index: map.get(variables.$clr-layers, datagrid-header-sticky);
       }
 
       &:hover {


### PR DESCRIPTION
This is a port of 5599159a4cb89a19b2d430f72e1beeec98b4e946 (#774) to 17.x.

- remove rule for missing `datagrid-popover` layer
- remove redundant `datagrid-row-sticky` z-index declaration
- use correct z-index for sticky row elements
- use correct z-index for header row sticky element

closes #773