### PR TITLE
fix(a11y): clr-password-container show/hide Icon does not have unique label

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -963,6 +963,8 @@ export interface ClrCommonStrings {
     next: string;
     nextPage: string;
     open: string;
+    // (undocumented)
+    passwordFor: string;
     passwordHide: string;
     // (undocumented)
     passwordShow: string;

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -963,8 +963,6 @@ export interface ClrCommonStrings {
     next: string;
     nextPage: string;
     open: string;
-    // (undocumented)
-    passwordFor: string;
     passwordHide: string;
     // (undocumented)
     passwordShow: string;
@@ -2925,7 +2923,11 @@ export class ClrPasswordContainer extends ClrAbstractContainer {
     // (undocumented)
     focusService: FocusService_2;
     // (undocumented)
+    hidePasswordText(label: string): string;
+    // (undocumented)
     show: boolean;
+    // (undocumented)
+    showPasswordText(label: string): string;
     // (undocumented)
     toggle(): void;
     // (undocumented)

--- a/projects/angular/src/forms/password/password-container.spec.ts
+++ b/projects/angular/src/forms/password/password-container.spec.ts
@@ -104,10 +104,10 @@ export default function (): void {
 
       it('should provide screen-reader only text for toggle button', () => {
         const button: HTMLButtonElement = containerEl.querySelector('button');
-        expect(button.textContent.trim()).toEqual('Show password');
+        expect(button.textContent.trim()).toEqual('Show password for Hello World');
         button.click();
         fixture.detectChanges();
-        expect(button.textContent.trim()).toEqual('Hide password');
+        expect(button.textContent.trim()).toEqual('Hide password for Hello World');
       });
     });
   });

--- a/projects/angular/src/forms/password/password-container.ts
+++ b/projects/angular/src/forms/password/password-container.ts
@@ -41,7 +41,7 @@ export const TOGGLE_SERVICE_PROVIDER = { provide: TOGGLE_SERVICE, useFactory: To
             <cds-icon status="info" class="clr-password-eye-icon" [attr.shape]="show ? 'eye-hide' : 'eye'"></cds-icon>
             <span class="clr-sr-only">
               {{ show ? commonStrings.keys.passwordHide : commonStrings.keys.passwordShow }}
-              {{ ' ' + commonStrings.keys.passwordFor + ' ' + label?.labelText }}
+              {{ commonStrings.keys.passwordFor + ' ' + label?.labelText }}
             </span>
           </button>
         </div>

--- a/projects/angular/src/forms/password/password-container.ts
+++ b/projects/angular/src/forms/password/password-container.ts
@@ -40,8 +40,7 @@ export const TOGGLE_SERVICE_PROVIDER = { provide: TOGGLE_SERVICE, useFactory: To
           >
             <cds-icon status="info" class="clr-password-eye-icon" [attr.shape]="show ? 'eye-hide' : 'eye'"></cds-icon>
             <span class="clr-sr-only">
-              {{ show ? commonStrings.keys.passwordHide : commonStrings.keys.passwordShow }}
-              {{ commonStrings.keys.passwordFor + ' ' + label?.labelText }}
+              {{ show ? hidePasswordText(label?.labelText) : showPasswordText(label?.labelText) }}
             </span>
           </button>
         </div>
@@ -118,5 +117,13 @@ export class ClrPasswordContainer extends ClrAbstractContainer {
   toggle() {
     this.show = !this.show;
     this.toggleService.next(this.show);
+  }
+
+  showPasswordText(label: string) {
+    return this.commonStrings.parse(this.commonStrings.keys.passwordShow, { LABEL: label });
+  }
+
+  hidePasswordText(label: string) {
+    return this.commonStrings.parse(this.commonStrings.keys.passwordHide, { LABEL: label });
   }
 }

--- a/projects/angular/src/forms/password/password-container.ts
+++ b/projects/angular/src/forms/password/password-container.ts
@@ -41,6 +41,7 @@ export const TOGGLE_SERVICE_PROVIDER = { provide: TOGGLE_SERVICE, useFactory: To
             <cds-icon status="info" class="clr-password-eye-icon" [attr.shape]="show ? 'eye-hide' : 'eye'"></cds-icon>
             <span class="clr-sr-only">
               {{ show ? commonStrings.keys.passwordHide : commonStrings.keys.passwordShow }}
+              {{ ' ' + commonStrings.keys.passwordFor + ' ' + label?.labelText }}
             </span>
           </button>
         </div>

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -106,9 +106,8 @@ export const commonStringsDefault: ClrCommonStrings = {
    * Password Input
    * Screen-reader text for the hide/show password field button
    */
-  passwordHide: 'Hide password',
-  passwordShow: 'Show password',
-  passwordFor: 'for',
+  passwordHide: 'Hide password for {LABEL}',
+  passwordShow: 'Show password for {LABEL}',
 
   /**
    * Datagrid footer; sr-only text after the number of selected rows.

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -108,6 +108,7 @@ export const commonStringsDefault: ClrCommonStrings = {
    */
   passwordHide: 'Hide password',
   passwordShow: 'Show password',
+  passwordFor: 'for',
 
   /**
    * Datagrid footer; sr-only text after the number of selected rows.

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -277,7 +277,6 @@ export interface ClrCommonStrings {
    */
   passwordHide: string;
   passwordShow: string;
-  passwordFor: string;
 
   /**
    * Datagrid footer; sr-only text after the number of selected rows.

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -277,6 +277,7 @@ export interface ClrCommonStrings {
    */
   passwordHide: string;
   passwordShow: string;
+  passwordFor: string;
 
   /**
    * Datagrid footer; sr-only text after the number of selected rows.


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Clarity uses constants/static text to label the show/ hide icon corresponding to the password input field, this is not unique for each clr-password-container input. It currently only ever reads as Show password / Hide password when using a screen reader.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-1179

## What is the new behavior?
Each individual show/hide icon button corresponding to a password field will now announce the unique label name (associated to that field)  in addition to Show password / Hide password when using a screen reader.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
