### PR TITLE
fix(signpost): allow keyboard scrolling in overflow content (backport to 15.x)

### DIFF
--- a/projects/angular/src/popover/signpost/signpost-content.ts
+++ b/projects/angular/src/popover/signpost/signpost-content.ts
@@ -47,7 +47,7 @@ const POSITIONS: string[] = [
           <cds-icon shape="window-close" [attr.title]="commonStrings.keys.close"></cds-icon>
         </button>
       </div>
-      <div class="signpost-content-body">
+      <div class="signpost-content-body" tabindex="0">
         <ng-content></ng-content>
       </div>
     </div>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When you open a signpost with a scroll you can't use keyboard due to missing focus on the content.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-1397

## What is the new behavior?

Now you can focus the content and scroll freely with the keyboard.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
