### PR TITLE
chore: update `rxjs` package

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -66,7 +66,7 @@
         "postcss-cli": "8.3.1",
         "prettier": "2.6.2",
         "rimraf": "3.0.2",
-        "rxjs": "6.6.7",
+        "rxjs": "7.8.1",
         "semantic-release": "19.0.3",
         "semantic-release-slack-bot": "3.5.2",
         "stylelint": "14.6.1",
@@ -182,6 +182,18 @@
       "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
       "dev": true
     },
+    "node_modules/@angular-devkit/architect/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
     "node_modules/@angular-devkit/architect/node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -190,6 +202,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@angular-devkit/architect/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@angular-devkit/build-angular": {
       "version": "15.2.4",
@@ -778,6 +796,24 @@
         "node": ">=8"
       }
     },
+    "node_modules/@angular-devkit/build-angular/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@angular-devkit/build-angular/node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "node_modules/@angular-devkit/build-angular/node_modules/schema-utils": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
@@ -890,6 +926,24 @@
         "webpack-dev-server": "^4.0.0"
       }
     },
+    "node_modules/@angular-devkit/build-webpack/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@angular-devkit/build-webpack/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "node_modules/@angular-devkit/core": {
       "version": "13.3.9",
       "resolved": "https://registry.npmjs.org/@angular-devkit/core/-/core-13.3.9.tgz",
@@ -917,6 +971,24 @@
         }
       }
     },
+    "node_modules/@angular-devkit/core/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@angular-devkit/core/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
+    },
     "node_modules/@angular-devkit/schematics": {
       "version": "13.3.9",
       "resolved": "https://registry.npmjs.org/@angular-devkit/schematics/-/schematics-13.3.9.tgz",
@@ -934,6 +1006,24 @@
         "npm": "^6.11.0 || ^7.5.6 || >=8.0.0",
         "yarn": ">= 1.13.0"
       }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
+    "node_modules/@angular-devkit/schematics/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@angular/animations": {
       "version": "15.2.2",
@@ -1096,6 +1186,18 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/@angular/cli/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
     "node_modules/@angular/cli/node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -1104,6 +1206,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@angular/cli/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@angular/common": {
       "version": "15.2.2",
@@ -6072,6 +6180,18 @@
         "node": ">=12"
       }
     },
+    "node_modules/@schematics/angular/node_modules/rxjs": {
+      "version": "6.6.7",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "dev": true,
+      "dependencies": {
+        "tslib": "^1.9.0"
+      },
+      "engines": {
+        "npm": ">=2.0.0"
+      }
+    },
     "node_modules/@schematics/angular/node_modules/source-map": {
       "version": "0.7.4",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
@@ -6080,6 +6200,12 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/@schematics/angular/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+      "dev": true
     },
     "node_modules/@semantic-release/commit-analyzer": {
       "version": "9.0.2",
@@ -17239,15 +17365,6 @@
         "node": "*"
       }
     },
-    "node_modules/commitizen/node_modules/rxjs": {
-      "version": "7.8.0",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-      "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/commitizen/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -24287,15 +24404,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/inquirer/node_modules/rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/inquirer/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -26283,15 +26391,6 @@
       "dev": true,
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/listr2/node_modules/rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/listr2/node_modules/slice-ansi": {
@@ -28624,15 +28723,6 @@
       },
       "engines": {
         "node": ">=8"
-      }
-    },
-    "node_modules/ng-packagr/node_modules/rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
       }
     },
     "node_modules/ng-packagr/node_modules/semver": {
@@ -36112,22 +36202,13 @@
       "dev": true
     },
     "node_modules/rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "dependencies": {
-        "tslib": "^1.9.0"
-      },
-      "engines": {
-        "npm": ">=2.0.0"
+        "tslib": "^2.1.0"
       }
-    },
-    "node_modules/rxjs/node_modules/tslib": {
-      "version": "1.14.1",
-      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-      "dev": true
     },
     "node_modules/safe-buffer": {
       "version": "5.1.2",
@@ -41200,15 +41281,6 @@
         "node": ">=10.0.0"
       }
     },
-    "node_modules/wait-on/node_modules/rxjs": {
-      "version": "7.5.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-      "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-      "dev": true,
-      "dependencies": {
-        "tslib": "^2.1.0"
-      }
-    },
     "node_modules/wait-port": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/wait-port/-/wait-port-1.0.4.tgz",
@@ -42557,10 +42629,25 @@
           "integrity": "sha512-gfFQZrcTc8CnKXp6Y4/CBT3fTc0OVuDofpre4aEeEpSBPV5X5v4+Vmx+8snU7RLPrNHPKSgLxGo9YuQzz20o+w==",
           "dev": true
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "source-map": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
           "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
       }
@@ -42962,6 +43049,23 @@
             "find-up": "^4.0.0"
           }
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          },
+          "dependencies": {
+            "tslib": {
+              "version": "1.14.1",
+              "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+              "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+              "dev": true
+            }
+          }
+        },
         "schema-utils": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/schema-utils/-/schema-utils-4.0.0.tgz",
@@ -43036,6 +43140,23 @@
       "requires": {
         "@angular-devkit/architect": "0.1502.4",
         "rxjs": "6.6.7"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "@angular-devkit/core": {
@@ -43050,6 +43171,23 @@
         "magic-string": "0.25.7",
         "rxjs": "6.6.7",
         "source-map": "0.7.3"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "@angular-devkit/schematics": {
@@ -43063,6 +43201,23 @@
         "magic-string": "0.25.7",
         "ora": "5.4.1",
         "rxjs": "6.6.7"
+      },
+      "dependencies": {
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
+          "dev": true
+        }
       }
     },
     "@angular/animations": {
@@ -43174,10 +43329,25 @@
             "is-wsl": "^2.2.0"
           }
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "source-map": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
           "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
       }
@@ -46728,10 +46898,25 @@
             "@jridgewell/sourcemap-codec": "^1.4.13"
           }
         },
+        "rxjs": {
+          "version": "6.6.7",
+          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
+          "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+          "dev": true,
+          "requires": {
+            "tslib": "^1.9.0"
+          }
+        },
         "source-map": {
           "version": "0.7.4",
           "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
           "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+          "dev": true
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
       }
@@ -55395,15 +55580,6 @@
             "brace-expansion": "^1.1.7"
           }
         },
-        "rxjs": {
-          "version": "7.8.0",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.0.tgz",
-          "integrity": "sha512-F2+gxDshqmIub1KdvZkaEfGDwLNpPvk9Fs6LD/MyQxNgMds/WH9OdDDXOmxUZpME+iSK3rQCctkL0DYyytUqMg==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -60836,15 +61012,6 @@
           "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
           "dev": true
         },
-        "rxjs": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-          "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        },
         "supports-color": {
           "version": "7.2.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -62295,15 +62462,6 @@
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
           "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
           "dev": true
-        },
-        "rxjs": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-          "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
         },
         "slice-ansi": {
           "version": "3.0.0",
@@ -64109,15 +64267,6 @@
           "dev": true,
           "requires": {
             "find-up": "^4.0.0"
-          }
-        },
-        "rxjs": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-          "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
           }
         },
         "semver": {
@@ -69618,20 +69767,12 @@
       }
     },
     "rxjs": {
-      "version": "6.6.7",
-      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-6.6.7.tgz",
-      "integrity": "sha512-hTdwr+7yYNIT5n4AMYp85KA6yw2Va0FLa3Rguvbpa4W3I5xynaBZo41cM3XM+4Q6fRMj3sBYIR1VAmZMXYJvRQ==",
+      "version": "7.8.1",
+      "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.8.1.tgz",
+      "integrity": "sha512-AA3TVj+0A2iuIoQkWEK/tqFjBq2j+6PO6Y0zJcvzLAFhEFIO3HL0vls9hWLncZbAAbK0mar7oZ4V079I/qPMxg==",
       "dev": true,
       "requires": {
-        "tslib": "^1.9.0"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "1.14.1",
-          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
-          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
-          "dev": true
-        }
+        "tslib": "^2.1.0"
       }
     },
     "safe-buffer": {
@@ -73643,17 +73784,6 @@
         "lodash": "^4.17.21",
         "minimist": "^1.2.5",
         "rxjs": "^7.5.4"
-      },
-      "dependencies": {
-        "rxjs": {
-          "version": "7.5.7",
-          "resolved": "https://registry.npmjs.org/rxjs/-/rxjs-7.5.7.tgz",
-          "integrity": "sha512-z9MzKh/UcOqB3i20H6rtrlaE/CgjLOvheWK/9ILrbhROGTweAi1BaFsTT9FbwZi5Trr1qNRs+MXkhmR06awzQA==",
-          "dev": true,
-          "requires": {
-            "tslib": "^2.1.0"
-          }
-        }
       }
     },
     "wait-port": {

--- a/package.json
+++ b/package.json
@@ -112,7 +112,7 @@
     "postcss-cli": "8.3.1",
     "prettier": "2.6.2",
     "rimraf": "3.0.2",
-    "rxjs": "6.6.7",
+    "rxjs": "7.8.1",
     "semantic-release": "19.0.3",
     "semantic-release-slack-bot": "3.5.2",
     "stylelint": "14.6.1",

--- a/projects/angular/src/data/datagrid/datagrid-if-expanded.service.ts
+++ b/projects/angular/src/data/datagrid/datagrid-if-expanded.service.ts
@@ -17,7 +17,7 @@ export class DatagridIfExpandService extends IfExpandService {
   expandableId = '';
 
   private _replace = new BehaviorSubject(false);
-  private _animate = new Subject<boolean>();
+  private _animate = new Subject<void>();
 
   constructor() {
     super();
@@ -41,7 +41,7 @@ export class DatagridIfExpandService extends IfExpandService {
     return this._replace.asObservable();
   }
 
-  get animate(): Observable<boolean> {
+  get animate(): Observable<void> {
     return this._animate.asObservable();
   }
 

--- a/projects/angular/src/utils/chocolate/willy-wonka.ts
+++ b/projects/angular/src/utils/chocolate/willy-wonka.ts
@@ -20,9 +20,9 @@ import { Subject } from 'rxjs';
 export class WillyWonka implements AfterViewChecked {
   disableChocolateCheck = false;
 
-  private _chocolate = new Subject<string>();
+  private _chocolate = new Subject<void>();
 
-  get chocolate(): Observable<string> {
+  get chocolate(): Observable<void> {
     return this._chocolate.asObservable();
   }
 

--- a/projects/angular/src/utils/focus/key-focus/key-focus.ts
+++ b/projects/angular/src/utils/focus/key-focus/key-focus.ts
@@ -161,7 +161,7 @@ export class ClrKeyFocus {
 
       if (this.focusOnLoad) {
         this.currentItem.focus();
-        this.focusChange.next();
+        this.focusChange.emit();
       }
     }
   }

--- a/projects/angular/src/wizard/providers/button-hub.service.ts
+++ b/projects/angular/src/wizard/providers/button-hub.service.ts
@@ -12,34 +12,34 @@ import { Subject } from 'rxjs';
 export class ButtonHubService {
   buttonsReady = false;
 
-  private _previousBtnClicked = new Subject<any>();
-  private _nextBtnClicked = new Subject<any>();
-  private _dangerBtnClicked = new Subject<any>();
-  private _cancelBtnClicked = new Subject<any>();
-  private _finishBtnClicked = new Subject<any>();
-  private _customBtnClicked = new Subject<any>();
+  private _previousBtnClicked = new Subject<void>();
+  private _nextBtnClicked = new Subject<void>();
+  private _dangerBtnClicked = new Subject<void>();
+  private _cancelBtnClicked = new Subject<void>();
+  private _finishBtnClicked = new Subject<void>();
+  private _customBtnClicked = new Subject<string>();
 
-  get previousBtnClicked(): Observable<any> {
+  get previousBtnClicked(): Observable<void> {
     return this._previousBtnClicked.asObservable();
   }
 
-  get nextBtnClicked(): Observable<any> {
+  get nextBtnClicked(): Observable<void> {
     return this._nextBtnClicked.asObservable();
   }
 
-  get dangerBtnClicked(): Observable<any> {
+  get dangerBtnClicked(): Observable<void> {
     return this._dangerBtnClicked.asObservable();
   }
 
-  get cancelBtnClicked(): Observable<any> {
+  get cancelBtnClicked(): Observable<void> {
     return this._cancelBtnClicked.asObservable();
   }
 
-  get finishBtnClicked(): Observable<any> {
+  get finishBtnClicked(): Observable<void> {
     return this._finishBtnClicked.asObservable();
   }
 
-  get customBtnClicked(): Observable<any> {
+  get customBtnClicked(): Observable<string> {
     return this._customBtnClicked.asObservable();
   }
 

--- a/projects/angular/src/wizard/providers/wizard-navigation.service.ts
+++ b/projects/angular/src/wizard/providers/wizard-navigation.service.ts
@@ -168,7 +168,7 @@ export class WizardNavigationService implements OnDestroy {
   /**
    * @memberof WizardNavigationService
    */
-  private _wizardFinished = new Subject<boolean>();
+  private _wizardFinished = new Subject<void>();
 
   /**
    * @memberof WizardNavigationService
@@ -178,7 +178,7 @@ export class WizardNavigationService implements OnDestroy {
   /**
    * @memberof WizardNavigationService
    */
-  private _cancelWizard = new Subject<any>();
+  private _cancelWizard = new Subject<void>();
 
   /**
    * Creates an instance of WizardNavigationService. Also sets up subscriptions
@@ -333,7 +333,7 @@ export class WizardNavigationService implements OnDestroy {
    *
    * @memberof WizardNavigationService
    */
-  get wizardFinished(): Observable<boolean> {
+  get wizardFinished(): Observable<void> {
     return this._wizardFinished.asObservable();
   }
 

--- a/projects/angular/src/wizard/wizard.spec.ts
+++ b/projects/angular/src/wizard/wizard.spec.ts
@@ -218,14 +218,14 @@ export default function (): void {
           it('should call the pageCollection and update the nav', () => {
             const firstPage = pageCollectionService.firstPage;
             spyOn(pageCollectionService, 'reset').and.callThrough();
-            spyOn(wizard.onReset, 'next');
+            spyOn(wizard.onReset, 'emit');
             expect(wizard.currentPage).toBe(firstPage, 'inits as expected');
             wizard.next();
             context.detectChanges();
             expect(wizard.currentPage).not.toBe(firstPage, 'navigates as expected');
             wizard.reset();
             expect(pageCollectionService.reset).toHaveBeenCalledTimes(1);
-            expect(wizard.onReset.next).toHaveBeenCalledTimes(1);
+            expect(wizard.onReset.emit).toHaveBeenCalledTimes(1);
             context.detectChanges();
             expect(wizard.currentPage).toBe(firstPage, 'resets to first page');
           });

--- a/projects/angular/src/wizard/wizard.ts
+++ b/projects/angular/src/wizard/wizard.ts
@@ -438,7 +438,7 @@ export class ClrWizard implements OnDestroy, AfterContentInit, DoCheck {
    */
   reset(): void {
     this.pageCollection.reset();
-    this.onReset.next();
+    this.onReset.emit();
   }
 
   private listenForNextPageChanges(): Subscription {

--- a/projects/demo/src/app/forms/dynamic-controls/dynamic-controls.demo.ts
+++ b/projects/demo/src/app/forms/dynamic-controls/dynamic-controls.demo.ts
@@ -14,7 +14,7 @@ import { filter, takeUntil, tap } from 'rxjs/operators';
   templateUrl: './dynamic-controls.demo.html',
 })
 export class DynamicControlsDemo {
-  destroyed = new Subject();
+  destroyed = new Subject<void>();
   form = new FormGroup<any>({
     platform: new FormControl(),
     scenario: new FormControl('one'),


### PR DESCRIPTION
This prevents the following build error on Angular 17:

```
./node_modules/@angular/core/fesm2022/testing.mjs:283:11-25
- Error: export 'firstValueFrom' (imported as 'firstValueFrom') was not found in 'rxjs'
```

This issue was introduced in 17.1.0. See angular/angular#54210 for more details.

Note: I changed `EventEmitter#next` to `EventEmitter#emit` only where required to get a successful build.