### PR TITLE
feat(deps): bump cds/core to 6.9.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "@angular/platform-browser": "15.2.2",
         "@angular/platform-browser-dynamic": "15.2.2",
         "@angular/router": "15.2.2",
-        "@cds/core": "6.9.1",
+        "@cds/core": "6.9.2",
         "@commitlint/cz-commitlint": "16.2.3",
         "@compodoc/compodoc": "1.1.19",
         "@microsoft/api-extractor": "7.33.6",
@@ -3362,9 +3362,9 @@
       "optional": true
     },
     "node_modules/@cds/core": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@cds/core/-/core-6.9.1.tgz",
-      "integrity": "sha512-nlysMYtdv5eo0EZNoK9sZqqve/nLXrQ174HAD0aHp4c6lFkLb+MFbe52+yJE4jARe3/rQDRSaNR6GS10PmVUfQ==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/@cds/core/-/core-6.9.2.tgz",
+      "integrity": "sha512-Tx5L8/kLueBoSpu18w9eLonqFk1CVromp9bBXk6FLVVmYghE/lSt/WsYi6c0xyv7rJZpcHoGS/gh5p9Erelk3Q==",
       "dev": true,
       "dependencies": {
         "lit": "^2.1.3",
@@ -44831,9 +44831,9 @@
       "optional": true
     },
     "@cds/core": {
-      "version": "6.9.1",
-      "resolved": "https://registry.npmjs.org/@cds/core/-/core-6.9.1.tgz",
-      "integrity": "sha512-nlysMYtdv5eo0EZNoK9sZqqve/nLXrQ174HAD0aHp4c6lFkLb+MFbe52+yJE4jARe3/rQDRSaNR6GS10PmVUfQ==",
+      "version": "6.9.2",
+      "resolved": "https://registry.npmjs.org/@cds/core/-/core-6.9.2.tgz",
+      "integrity": "sha512-Tx5L8/kLueBoSpu18w9eLonqFk1CVromp9bBXk6FLVVmYghE/lSt/WsYi6c0xyv7rJZpcHoGS/gh5p9Erelk3Q==",
       "dev": true,
       "requires": {
         "@cds/city": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -65,7 +65,7 @@
     "@angular/platform-browser": "15.2.2",
     "@angular/platform-browser-dynamic": "15.2.2",
     "@angular/router": "15.2.2",
-    "@cds/core": "6.9.1",
+    "@cds/core": "6.9.2",
     "@commitlint/cz-commitlint": "16.2.3",
     "@compodoc/compodoc": "1.1.19",
     "@microsoft/api-extractor": "7.33.6",

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -21,6 +21,6 @@
     "@angular/cdk": "15 || 16 || 17",
     "@angular/common": "15 || 16 || 17",
     "@angular/core": "15 || 16 || 17",
-    "@cds/core": ">= 6.8.0"
+    "@cds/core": ">= 6.9.2"
   }
 }

--- a/projects/ui/package.json
+++ b/projects/ui/package.json
@@ -12,6 +12,6 @@
     "url": "https://github.com/vmware-clarity/ng-clarity/issues"
   },
   "peerDependencies": {
-    "@cds/core": "^6.8.0"
+    "@cds/core": "^6.9.2"
   }
 }


### PR DESCRIPTION
BREAKING CHANGE: Bump the cds/core peer dependency to the latest, 6.9.2