### PR TITLE
fix(ui): remove core imports in clr-ui and add documentation steps

### DIFF
--- a/angular.json
+++ b/angular.json
@@ -116,7 +116,11 @@
         "test": {
           "builder": "@angular-devkit/build-angular:karma",
           "options": {
-            "styles": ["projects/ui/src/clr-ui.scss"],
+            "styles": [
+              "node_modules/@cds/core/global.min.css",
+              "node_modules/@cds/core/styles/theme.dark.min.css",
+              "projects/ui/src/clr-ui.scss"
+            ],
             "main": "projects/angular/src/test.ts",
             "tsConfig": "projects/angular/tsconfig.spec.json",
             "karmaConfig": "karma.conf.js"

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,20 +8,15 @@
     npm install @clr/ui
     ```
 
-2.  Include @cds/core/global.min.css and @cds/core/styles/theme.dark.min.css in your HTML file:
+2.  Include @cds/core/global.min.css, @cds/core/styles/theme.dark.min.css and clr-ui.min.css in your HTML file:
 
     ```
     <link rel="stylesheet" href="path/to/node_modules/@cds/core/global.min.css">
     <link rel="stylesheet" href="path/to/node_modules/@cds/core/styles/theme.dark.min.css">
-    ```
-
-3.  Include clr-ui.min.css in your HTML file:
-
-    ```
     <link rel="stylesheet" href="path/to/node_modules/@clr/ui/clr-ui.min.css">
     ```
 
-4.  Write your HTML with the Clarity CSS class names and markup.
+3.  Write your HTML with the Clarity CSS class names and markup.
 
 ## Installing Clarity Angular [![npm version](https://badge.fury.io/js/%40clr%2Fangular.svg)](https://badge.fury.io/js/%40clr%2Fangular)
 

--- a/docs/INSTALLATION.md
+++ b/docs/INSTALLATION.md
@@ -8,13 +8,20 @@
     npm install @clr/ui
     ```
 
-2.  Include clr-ui.min.css in your HTML file:
+2.  Include @cds/core/global.min.css and @cds/core/styles/theme.dark.min.css in your HTML file:
+
+    ```
+    <link rel="stylesheet" href="path/to/node_modules/@cds/core/global.min.css">
+    <link rel="stylesheet" href="path/to/node_modules/@cds/core/styles/theme.dark.min.css">
+    ```
+
+3.  Include clr-ui.min.css in your HTML file:
 
     ```
     <link rel="stylesheet" href="path/to/node_modules/@clr/ui/clr-ui.min.css">
     ```
 
-3.  Write your HTML with the Clarity CSS class names and markup.
+4.  Write your HTML with the Clarity CSS class names and markup.
 
 ## Installing Clarity Angular [![npm version](https://badge.fury.io/js/%40clr%2Fangular.svg)](https://badge.fury.io/js/%40clr%2Fangular)
 

--- a/projects/angular/README.md
+++ b/projects/angular/README.md
@@ -32,6 +32,8 @@
 ```
   //...
   "styles": [
+    "node_modules/@cds/core/global.min.css",
+    "node_modules/@cds/core/styles/theme.dark.min.css",
     "node_modules/@clr/ui/clr-ui.min.css",
     //... any other styles
   ]
@@ -39,6 +41,8 @@
 ```
 
 ```scss
+@use '@cds/core/global.min.css';
+@use '@cds/core/styles/theme.dark.min.css';
 @use '@clr/ui/clr-ui.min.css';
 ```
 

--- a/projects/ui/README.md
+++ b/projects/ui/README.md
@@ -6,26 +6,21 @@
     npm install @clr/ui
     ```
 
-2.  Include @cds/core/global.min.css and @cds/core/styles/theme.dark.min.css in your HTML file:
+2.  Include @cds/core/global.min.css, @cds/core/styles/theme.dark.min.css, and clr-ui.min.css in your HTML file and add the cds-theme attribute to your body tag:
 
     ```
     <link rel="stylesheet" href="path/to/node_modules/@cds/core/global.min.css">
     <link rel="stylesheet" href="path/to/node_modules/@cds/core/styles/theme.dark.min.css">
-    ```
-
-3.  Include clr-ui.min.css in your HTML file and add the cds-theme attribute to your body tag:
-
-    ```
     <link rel="stylesheet" href="path/to/node_modules/@clr/ui/clr-ui.min.css">
     ```
 
-4.  Add the `cds-theme="light"` (or `cds-theme="dark"` for dark theme) to the body tag:
+3.  Add the `cds-theme="light"` (or `cds-theme="dark"` for dark theme) to the body tag:
 
     ```
     <body cds-theme"light">
     ```
 
-5.  Write your HTML with the Clarity CSS class names and markup.
+4.  Write your HTML with the Clarity CSS class names and markup.
 
 ## Versioning
 

--- a/projects/ui/README.md
+++ b/projects/ui/README.md
@@ -6,19 +6,26 @@
     npm install @clr/ui
     ```
 
-2.  Include clr-ui.min.css in your HTML file and add the cds-theme attribute to your body tag:
+2.  Include @cds/core/global.min.css and @cds/core/styles/theme.dark.min.css in your HTML file:
+
+    ```
+    <link rel="stylesheet" href="path/to/node_modules/@cds/core/global.min.css">
+    <link rel="stylesheet" href="path/to/node_modules/@cds/core/styles/theme.dark.min.css">
+    ```
+
+3.  Include clr-ui.min.css in your HTML file and add the cds-theme attribute to your body tag:
 
     ```
     <link rel="stylesheet" href="path/to/node_modules/@clr/ui/clr-ui.min.css">
     ```
 
-3.  Add the `cds-theme="light"` (or `cds-theme="dark"` for dark theme) to the body tag:
+4.  Add the `cds-theme="light"` (or `cds-theme="dark"` for dark theme) to the body tag:
 
     ```
     <body cds-theme"light">
     ```
 
-4.  Write your HTML with the Clarity CSS class names and markup.
+5.  Write your HTML with the Clarity CSS class names and markup.
 
 ## Versioning
 

--- a/projects/ui/src/clr-ui.scss
+++ b/projects/ui/src/clr-ui.scss
@@ -4,6 +4,4 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-@use '@cds/core/global.min.css'; // provides the Clarity Core design tokens
 @use '../../angular/src/main';
-@use '@cds/core/styles/theme.dark.min.css'; // dark theme


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [X] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [X] Documentation content changes
- [X] Other... Please describe: Remove core imports from clr-ui

## What is the current behavior?

Currently we import both light and dark core tokens inside `clr-ui` and they are all exported with it but that creates  disability to use different `@cds/core` version from what we specify as peer dependency for `clr-ui`.

Issue Number: CDE-1639

## What is the new behavior?

Clr-ui no longer includes core tokens and these should be imported individually per project. Steps are described in clr-ui readme.

## Does this PR introduce a breaking change?

- [X] Yes
- [ ] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

BREAKING CHANGE: clr-ui no longer includes core tokens and they need to be included individually per project when importing clr-ui ( step 2 in clr-ui readme ).
