### PR TITLE
fix(stepper): improve panel status updates (port to 16.x)

### DIFF
--- a/projects/angular/src/accordion/stepper/models/stepper.model.ts
+++ b/projects/angular/src/accordion/stepper/models/stepper.model.ts
@@ -61,6 +61,14 @@ export class StepperModel extends AccordionModel {
       });
   }
 
+  setPanelValid(panelId: string) {
+    this._panels[panelId].status = AccordionStatus.Complete;
+  }
+
+  setPanelInvalid(panelId: string) {
+    this._panels[panelId].status = AccordionStatus.Error;
+  }
+
   setPanelsWithErrors(ids: string[]) {
     ids.forEach(id => this.setPanelError(id));
   }

--- a/projects/angular/src/accordion/stepper/providers/stepper.service.ts
+++ b/projects/angular/src/accordion/stepper/providers/stepper.service.ts
@@ -31,6 +31,16 @@ export class StepperService extends AccordionService {
     this.emitUpdatedPanels();
   }
 
+  setPanelValid(panelId: string) {
+    this.accordion.setPanelValid(panelId);
+    this.emitUpdatedPanels();
+  }
+
+  setPanelInvalid(panelId: string) {
+    this.accordion.setPanelInvalid(panelId);
+    this.emitUpdatedPanels();
+  }
+
   setPanelsWithErrors(ids: string[]) {
     this.accordion.setPanelsWithErrors(ids);
     this.emitUpdatedPanels();

--- a/projects/angular/src/accordion/stepper/stepper.spec.ts
+++ b/projects/angular/src/accordion/stepper/stepper.spec.ts
@@ -94,7 +94,7 @@ describe('ClrStepper', () => {
 
     it('should reset if a previously completed panel is revisited and put into an invalid state', () => {
       // all setup...
-      spyOn(stepperService, 'navigateToNextPanel');
+      spyOn(stepperService, 'setPanelInvalid');
       const group1 = testComponent.form.controls.group as FormGroup;
       group1.controls.name.setValue('lmnop');
       fixture.detectChanges();
@@ -109,8 +109,50 @@ describe('ClrStepper', () => {
       fixture.detectChanges();
 
       expect(group1.valid).toBe(false, 'first panel form is now invalid');
-      // making a previously valid form invalid forces navigation; called once earlier and only once after this
-      expect(stepperService.navigateToNextPanel).toHaveBeenCalledTimes(2);
+      expect(stepperService.setPanelInvalid).toHaveBeenCalledTimes(1);
+    });
+
+    it('should set the panel status to invalid immediately', () => {
+      // setup
+      spyOn(stepperService, 'setPanelInvalid');
+      const form = testComponent.form.controls.group;
+
+      // act (make form invalid)
+      form.controls.name.setValue('');
+      fixture.detectChanges();
+
+      // assert
+      expect(stepperService.setPanelInvalid).toHaveBeenCalledTimes(1);
+    });
+
+    it('should set the panel status to valid if form was previously invalid', () => {
+      // setup
+      spyOn(stepperService, 'setPanelValid');
+      const form = testComponent.form.controls.group;
+
+      // act 1 (make form invalid)
+      form.controls.name.setValue('');
+      fixture.detectChanges();
+
+      // act 2 (make form valid)
+      form.controls.name.setValue('Bob');
+      fixture.detectChanges();
+
+      // assert
+      expect(stepperService.setPanelValid).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not set the panel status to valid if the form was not previously invalid', () => {
+      // setup
+      spyOn(stepperService, 'setPanelInvalid');
+      const form = testComponent.form.controls.group;
+
+      // act (make form valid)
+      form.controls.name.setValue('Bob');
+      fixture.detectChanges();
+
+      // assert
+      expect(stepperService.setPanelInvalid).not.toHaveBeenCalled();
     });
   });
 


### PR DESCRIPTION
This is a port of dcb5c293d2b27ba8293e0796f6d6350b4641b47c (#1184) to 16.x.

- Set the panel status to invalid immediately when the form becomes invalid.
- Set the panel status back to valid immediately when the form becomes valid after being invalid.

CDE-1463