### PR TITLE
fix(shim): remove body-font-weight override

### DIFF
--- a/projects/ui/src/shim.cds-core.scss
+++ b/projects/ui/src/shim.cds-core.scss
@@ -24,14 +24,12 @@ $metropolis-font-family: Metropolis, 'Avenir Next', 'Helvetica Neue', Arial, san
  */
 [cds-text],
 [cds-theme] {
-  --cds-global-typography-body-font-weight: 500;
   --cds-global-typography-display-font-weight: 500;
   --cds-global-typography-heading-font-weight: 500;
   --cds-global-typography-headline-font-weight: 500;
   --cds-global-typography-title-font-weight: 500;
   --cds-global-typography-section-font-weight: 500;
   --cds-global-typography-subsection-font-weight: 500;
-  --cds-alias-typography-body-font-weight: 500;
   --cds-alias-typography-display-font-weight: 500;
   --cds-alias-typography-heading-font-weight: 500;
   --cds-alias-typography-headline-font-weight: 500;


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When adding the v16 shim overrides for font-weight, the body font-weight was accidentally included in the list. 

Issue Number: N/A

## What is the new behavior?

The body font-weight value is removed, resulting in the body font returning to the correct 400 weight. 

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
