### PR TITLE
chore: report visual snapshot update bot status to pull request

### DIFF
--- a/.github/workflows/pr-visual-snapshot-update-bot.yml
+++ b/.github/workflows/pr-visual-snapshot-update-bot.yml
@@ -5,9 +5,9 @@ on:
 jobs:
   pr-visual-snapshot-update-bot:
     if: ${{github.event.workflow_run.conclusion == 'failure'}}
-    name: PR Visual Snapshot Update Bot
     runs-on: ubuntu-latest
     steps:
+      - uses: haya14busa/action-workflow_run-status@v1
       - name: Checkout
         uses: actions/checkout@v3
         with:


### PR DESCRIPTION
This is port of f51ce5cd366a111098b5c9951efd3a3822979300 (#1135) to the new `main` branch after the v17 release.

This makes it easier to find the status (and log) of the update bot workflow run for a pull request.

The job name was removed to prevent an error in the status action.