### PR TITLE
chore: delete visual snapshot update branch immediately

### DIFF
--- a/.github/workflows/pr-visual-snapshot-update-bot.yml
+++ b/.github/workflows/pr-visual-snapshot-update-bot.yml
@@ -50,11 +50,11 @@ jobs:
             # push changes
             git push $repositoryUrl HEAD:refs/heads/$updateBranchName --force
 
+            # delete branch (it's not needed, only the commit needs to be in the repo)
+            git push $repositoryUrl -d $updateBranchName
+
             # set commit-sha for next step
             echo "commit-sha=$(git rev-parse HEAD)" >> $GITHUB_OUTPUT
-          else
-            # delete branch if it exists
-            git push $repositoryUrl -d $updateBranchName || true
           fi
       - name: Comment
         if: ${{steps.push-changes.outputs.commit-sha}}


### PR DESCRIPTION
This is port of df0cbc8c484c00fac3a8f19ea2df9f4a97b64dff (#1129) to the new `main` branch after the v17 release.

There was code to cleanup visual snapshot update branches if no changes, but that job only runs after after failed build. This resulted in visual snapshot update branches persisting after successful builds.

We can solve this by immediately deleting the visual snapshot branches. We just need the visual snapshot update commit in the repo. There is no need to keep the branches around for any length of time.