### PR TITLE
fix(tree-view): set node `min-height` instead of `height` (backport of #1264)

### DIFF
--- a/projects/ui/src/shim.cds-core.scss
+++ b/projects/ui/src/shim.cds-core.scss
@@ -1697,7 +1697,7 @@ $metropolis-font-family: Metropolis, 'Avenir Next', 'Helvetica Neue', Arial, san
 
   // ATM: move to tree-view.clarity.scss
   .clr-treenode-content {
-    height: #{tokens.$cds-global-space-10};
+    min-height: #{tokens.$cds-global-space-10};
     color: #{tokens.$cds-alias-typography-color-400}; // static text content color
     background-color: var(--clr-tree-node-content-bg-color);
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Tree node have strictly defined height of 32px.

Issue Number: CDE-1683

## What is the new behavior?

Tree node have defined min-height of 32px.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
