### PR TITLE
fix(datagrid): fix pressed action overflow icon color (backport to 16.x)

### DIFF
--- a/projects/ui/src/shim.cds-core.scss
+++ b/projects/ui/src/shim.cds-core.scss
@@ -1910,7 +1910,7 @@ $metropolis-font-family: Metropolis, 'Avenir Next', 'Helvetica Neue', Arial, san
   --clr-datagrid-row-hover-color: #{tokens.$cds-alias-object-interaction-background-hover}; // var(--clr-color-neutral-200);
   --clr-datagrid-row-active-color: #{tokens.$cds-alias-object-interaction-background-active};
   --clr-datagrid-row-hover-font-color: #{tokens.$cds-alias-typography-color-500}; // var(--clr-color-neutral-1000);
-  --clr-datagrid-action-toggle-color: #{tokens.$cds-alias-object-interaction-background-active}; // #{tokens.$cds-global-color-gray-700}; // var(--clr-color-neutral-700);
+  --clr-datagrid-action-toggle-color: #{tokens.$cds-alias-object-interaction-color-active}; // #{tokens.$cds-global-color-gray-700}; // var(--clr-color-neutral-700);
   --clr-datagrid-pagination-btn-color: #{tokens.$cds-alias-object-interaction-color}; // var(--clr-color-neutral-700);
   --clr-datagrid-pagination-btn-disabled-color: #{tokens.$cds-alias-status-disabled}; // var(--clr-color-neutral-600);
   --clr-datagrid-pagination-input-border-color: #{tokens.$cds-alias-object-border-color}; // indirectly mapped;


### PR DESCRIPTION
Backport of https://github.com/vmware-clarity/ng-clarity/commit/f8cd042f72946a216e14bc74e2ccf638f2c9d29d

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

When the action overflow button is in a pressed state, the icon color shifts to a lighter tone background color and the icon appears to disappear due to a lack of color contrast with the hover background color. this is a result of the icon color being mapped to a background color in the system, when it should be mapped to color-active.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-1689

The icon does not appear to disappear when the user is pressing the button.

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->
