### PR TITLE
fix(tabs): fix aria-labelledby attribute (#1309)

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -3771,6 +3771,8 @@ export class ClrTabLink {
     // (undocumented)
     el: ElementRef;
     // (undocumented)
+    readonly id: number;
+    // (undocumented)
     ifActiveService: IfActiveService;
     // (undocumented)
     get inOverflow(): boolean;

--- a/projects/angular/src/layout/tabs/tab-content.ts
+++ b/projects/angular/src/layout/tabs/tab-content.ts
@@ -49,7 +49,7 @@ export class ClrTabContent implements OnDestroy {
   }
 
   get ariaLabelledBy(): string {
-    return this.tabsService.children.find(tab => tab.tabContent === this)?.tabLink?.tabLinkId;
+    return this.tabsService.children.find(tab => tab.tabLink.id === this.id)?.tabLink?.tabLinkId;
   }
 
   // The template must be applied on the top-down phase of view-child initialization to prevent

--- a/projects/angular/src/layout/tabs/tab-link.directive.ts
+++ b/projects/angular/src/layout/tabs/tab-link.directive.ts
@@ -40,7 +40,7 @@ export class ClrTabLink {
 
   constructor(
     public ifActiveService: IfActiveService,
-    @Inject(IF_ACTIVE_ID) private id: number,
+    @Inject(IF_ACTIVE_ID) readonly id: number,
     public el: ElementRef,
     private cfr: ComponentFactoryResolver,
     private viewContainerRef: ViewContainerRef,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-1354

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

This PR fixes getter method ariaLabelledBy to return correct tabLinkId. Previously nothing was found in the getter function so the aria-labelledby attrbute was not set. To be able to find the correct tabLink I had to expose a getter of the id of the tabLink.

Port of https://github.com/vmware-clarity/ng-clarity/pull/1309 to 16.x
