### PR TITLE
chore(accordion): just a test - this should not be merged

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        angular: ['Angular v15', 'Angular v16']
+        angular: ['Angular v15', 'Angular v16', 'Angular v17']
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -22,11 +22,15 @@ jobs:
       - name: Install Dependencies
         run: npm ci
       - name: Update to Angular v16
-        if: ${{matrix.angular == 'Angular v16'}}
+        if: ${{matrix.angular == 'Angular v16' || matrix.angular == 'Angular v17'}}
         run: |
           npx ng update @angular/core@16 @angular/common@16 @angular/cli@16 @angular/cdk@16 --force
+      - name: Update to Angular v17
+        if: ${{matrix.angular == 'Angular v17'}}
+        run: |
+          npx ng update @angular/core@17 @angular/common@17 @angular/cli@17 @angular/cdk@17 --allow-dirty --force
       - name: Disable Storybook Build
-        if: ${{matrix.angular == 'Angular v16'}}
+        if: ${{matrix.angular != 'Angular v15'}}
         run: node ./scripts/clear-npm-script.js _build:storybook
       - name: Lint
         if: ${{matrix.angular == 'Angular v15'}}

--- a/.storybook/stories/accordion/accordion.stories.ts
+++ b/.storybook/stories/accordion/accordion.stories.ts
@@ -30,7 +30,7 @@ export default {
     openIndices: [],
     createArray: n => new Array(n),
     panelCount: 4,
-    title: 'Title',
+    title: 'Title1',
     content: 'Hello World!',
   },
 };

--- a/projects/angular/package.json
+++ b/projects/angular/package.json
@@ -18,9 +18,9 @@
     "url": "https://github.com/vmware-clarity/ng-clarity/issues"
   },
   "peerDependencies": {
-    "@angular/cdk": "15 || 16",
-    "@angular/common": "15 || 16",
-    "@angular/core": "15 || 16",
+    "@angular/cdk": "15 || 16 || 17",
+    "@angular/common": "15 || 16 || 17",
+    "@angular/core": "15 || 16 || 17",
     "@cds/core": ">= 6.7.0"
   }
 }


### PR DESCRIPTION
This PR is intended to test the changes in branch

[cde-1597-set-workflow-to-build-against-angular-17-port-to-16.x](https://github.com/vmware-clarity/ng-clarity/tree/cde-1597-set-workflow-to-build-against-angular-17-port-to-16.x)

We must not merge this: 

[cde-1597-set-workflow-to-build-against-angular-17-port-to-16.x](https://github.com/vmware-clarity/ng-clarity/tree/cde-1597-set-workflow-to-build-against-angular-17-port-to-16.x)