### PR TITLE
fix(a11y): stepper-completed step does not have accessible notification after completion

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -318,9 +318,9 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
     // (undocumented)
     panelOpenChange: EventEmitter<boolean>;
     // (undocumented)
-    stepCompleteText(panelNumber: number): string;
+    protected stepCompleteText(panelNumber: number): string;
     // (undocumented)
-    stepErrorText(panelNumber: number): string;
+    protected stepErrorText(panelNumber: number): string;
     // (undocumented)
     togglePanel(): void;
     // (undocumented)

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -320,7 +320,7 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
     // (undocumented)
     stepCompleteText(panelNumber: number): string;
     // (undocumented)
-    stepFailedText(panelNumber: number): string;
+    stepErrorText(panelNumber: number): string;
     // (undocumented)
     togglePanel(): void;
     // (undocumented)
@@ -1006,7 +1006,7 @@ export interface ClrCommonStrings {
     // (undocumented)
     stepComplete: string;
     // (undocumented)
-    stepFailed: string;
+    stepError: string;
     success: string;
     // (undocumented)
     timelineStepCurrent: string;

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -318,6 +318,10 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
     // (undocumented)
     panelOpenChange: EventEmitter<boolean>;
     // (undocumented)
+    stepCompleteText(panelNumber: number): string;
+    // (undocumented)
+    stepFailedText(panelNumber: number): string;
+    // (undocumented)
     togglePanel(): void;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<ClrAccordionPanel, "clr-accordion-panel", never, { "disabled": "clrAccordionPanelDisabled"; "panelOpen": "clrAccordionPanelOpen"; }, { "panelOpenChange": "clrAccordionPanelOpenChange"; }, ["accordionDescription"], ["clr-accordion-title, clr-step-title", "clr-accordion-description, clr-step-description", "*"], false, never>;
@@ -999,6 +1003,10 @@ export interface ClrCommonStrings {
     singleSelectionAriaLabel: string;
     sortColumn: string;
     stackViewChanged: string;
+    // (undocumented)
+    stepComplete: string;
+    // (undocumented)
+    stepFailed: string;
     success: string;
     // (undocumented)
     timelineStepCurrent: string;

--- a/projects/angular/src/accordion/accordion-panel.html
+++ b/projects/angular/src/accordion/accordion-panel.html
@@ -14,7 +14,7 @@
         #headerButton
       >
         <span class="clr-sr-only" role="status">
-          <ng-container *ngIf="panel.status === AccordionStatus.Error"> {{ stepFailedText(panelNumber)}} </ng-container>
+          <ng-container *ngIf="panel.status === AccordionStatus.Error"> {{ stepErrorText(panelNumber)}} </ng-container>
           <ng-container *ngIf="panel.status === AccordionStatus.Complete">
             {{ stepCompleteText(panelNumber)}}
           </ng-container>

--- a/projects/angular/src/accordion/accordion-panel.html
+++ b/projects/angular/src/accordion/accordion-panel.html
@@ -13,9 +13,11 @@
         [class.clr-accordion-header-has-description]="(accordionDescription.changes | async)?.length || accordionDescription.length"
         #headerButton
       >
-        <span class="clr-sr-only">
-          <ng-container *ngIf="panel.status === AccordionStatus.Error">{{commonStrings.keys.danger}}</ng-container>
-          <ng-container *ngIf="panel.status === AccordionStatus.Complete">{{commonStrings.keys.success}}</ng-container>
+        <span class="clr-sr-only" role="status">
+          <ng-container *ngIf="panel.status === AccordionStatus.Error"> {{ stepFailedText(panelNumber)}} </ng-container>
+          <ng-container *ngIf="panel.status === AccordionStatus.Complete">
+            {{ stepCompleteText(panelNumber)}}
+          </ng-container>
         </span>
         <span class="clr-accordion-status">
           <cds-icon shape="angle" direction="right" class="clr-accordion-angle"></cds-icon>

--- a/projects/angular/src/accordion/accordion-panel.ts
+++ b/projects/angular/src/accordion/accordion-panel.ts
@@ -115,8 +115,8 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
     return this.commonStrings.parse(this.commonStrings.keys.stepComplete, { STEP: panelNumber.toString() });
   }
 
-  stepFailedText(panelNumber: number) {
-    return this.commonStrings.parse(this.commonStrings.keys.stepFailed, { STEP: panelNumber.toString() });
+  stepErrorText(panelNumber: number) {
+    return this.commonStrings.parse(this.commonStrings.keys.stepError, { STEP: panelNumber.toString() });
   }
 
   private emitPanelChange(panel: AccordionPanelModel) {

--- a/projects/angular/src/accordion/accordion-panel.ts
+++ b/projects/angular/src/accordion/accordion-panel.ts
@@ -111,11 +111,11 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
     return `clr-accordion-header-${id}`;
   }
 
-  stepCompleteText(panelNumber: number) {
+  protected stepCompleteText(panelNumber: number) {
     return this.commonStrings.parse(this.commonStrings.keys.stepComplete, { STEP: panelNumber.toString() });
   }
 
-  stepErrorText(panelNumber: number) {
+  protected stepErrorText(panelNumber: number) {
     return this.commonStrings.parse(this.commonStrings.keys.stepError, { STEP: panelNumber.toString() });
   }
 

--- a/projects/angular/src/accordion/accordion-panel.ts
+++ b/projects/angular/src/accordion/accordion-panel.ts
@@ -111,6 +111,14 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
     return `clr-accordion-header-${id}`;
   }
 
+  stepCompleteText(panelNumber: number) {
+    return this.commonStrings.parse(this.commonStrings.keys.stepComplete, { STEP: panelNumber.toString() });
+  }
+
+  stepFailedText(panelNumber: number) {
+    return this.commonStrings.parse(this.commonStrings.keys.stepFailed, { STEP: panelNumber.toString() });
+  }
+
   private emitPanelChange(panel: AccordionPanelModel) {
     if (panel.index !== this._panelIndex) {
       this._panelIndex = panel.index;

--- a/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
+++ b/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
@@ -88,7 +88,7 @@ describe('ClrStep Reactive Forms', () => {
       fixture.detectChanges();
 
       const statusMessage = fixture.nativeElement.querySelector('button .clr-sr-only');
-      expect(statusMessage.innerText.trim()).toBe(`Step ${mockStep?.index + 1} failed`);
+      expect(statusMessage.innerText.trim()).toBe(`Error in step ${mockStep?.index + 1}`);
 
       mockStep.status = AccordionStatus.Complete;
       (stepperService as MockStepperService).step.next(mockStep);

--- a/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
+++ b/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
@@ -88,13 +88,13 @@ describe('ClrStep Reactive Forms', () => {
       fixture.detectChanges();
 
       const statusMessage = fixture.nativeElement.querySelector('button .clr-sr-only');
-      expect(statusMessage.innerText.trim()).toBe('Error');
+      expect(statusMessage.innerText.trim()).toBe(`Step ${mockStep?.index + 1} failed`);
 
       mockStep.status = AccordionStatus.Complete;
       (stepperService as MockStepperService).step.next(mockStep);
       fixture.detectChanges();
 
-      expect(statusMessage.innerText.trim()).toBe('Success');
+      expect(statusMessage.innerText.trim()).toBe(`Step ${mockStep?.index + 1} complete`);
     });
 
     it('should add aria-disabled attribute to the header button based on the appropriate step state', () => {

--- a/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
+++ b/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
@@ -88,13 +88,13 @@ describe('ClrStep Reactive Forms', () => {
       fixture.detectChanges();
 
       const statusMessage = fixture.nativeElement.querySelector('button .clr-sr-only');
-      expect(statusMessage.innerText.trim()).toBe(`Error in step ${mockStep?.index + 1}`);
+      expect(statusMessage.innerText.trim()).toBe('Error in step 1');
 
       mockStep.status = AccordionStatus.Complete;
       (stepperService as MockStepperService).step.next(mockStep);
       fixture.detectChanges();
 
-      expect(statusMessage.innerText.trim()).toBe(`Step ${mockStep?.index + 1} complete`);
+      expect(statusMessage.innerText.trim()).toBe(`Step 1 complete`);
     });
 
     it('should add aria-disabled attribute to the header button based on the appropriate step state', () => {

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -115,4 +115,8 @@ export const commonStringsDefault: ClrCommonStrings = {
    * Datagrid footer; sr-only text after the number of selected rows.
    */
   selectedRows: 'Selected rows',
+
+  // Accordion/Stepper
+  stepComplete: 'Step {STEP} complete',
+  stepFailed: 'Step {STEP} failed',
 };

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -118,5 +118,5 @@ export const commonStringsDefault: ClrCommonStrings = {
 
   // Accordion/Stepper
   stepComplete: 'Step {STEP} complete',
-  stepFailed: 'Error in step {STEP}',
+  stepError: 'Error in step {STEP}',
 };

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -118,5 +118,5 @@ export const commonStringsDefault: ClrCommonStrings = {
 
   // Accordion/Stepper
   stepComplete: 'Step {STEP} complete',
-  stepFailed: 'Step {STEP} failed',
+  stepFailed: 'Error in step {STEP}',
 };

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -290,4 +290,8 @@ export interface ClrCommonStrings {
    * Datagrid footer; sr-only text after the number of selected rows.
    */
   selectedRows: string;
+
+  //Stepper: Screen-reader text for completed/failed step
+  stepComplete: string;
+  stepFailed: string;
 }

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -293,5 +293,5 @@ export interface ClrCommonStrings {
 
   //Stepper: Screen-reader text for completed/failed step
   stepComplete: string;
-  stepFailed: string;
+  stepError: string;
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
In the Stepper, when the step is complete, keyboard focus moves to the next step but there's no indication that the previous step is completed by the screen reader.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [CDE-699](https://jira.eng.vmware.com/browse/CDE-699)

## What is the new behavior?
The screen reader will announce that the current step is complete (or failed) and move focus to the next step or stay in the same step in case of an error.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
