### PR TITLE
feat(modal): add missing `--clr-modal-default-space` CSS variable

### DIFF
--- a/projects/angular/src/modal/STYLES.md
+++ b/projects/angular/src/modal/STYLES.md
@@ -19,6 +19,7 @@
 | --clr-modal-lg-width             | Width of the modal on large layout       |
 | --clr-modal-xl-width             | Width of the modal on extra large layout |
 | --clr-modal-content-box-shadow   | Shadow of modal content                  |
+| --clr-modal-default-space        | Default modal padding                    |
 
 ## CSS Classes
 

--- a/projects/angular/src/modal/_properties.modal.scss
+++ b/projects/angular/src/modal/_properties.modal.scss
@@ -13,6 +13,7 @@
 @include mixins.exports('modal.properties') {
   :root {
     [cds-theme] {
+      --clr-modal-default-space: #{tokens.$cds-global-space-9};
       --clr-modal-border-radius: #{tokens.$cds-alias-object-border-radius-100};
 
       // color

--- a/projects/angular/src/modal/_variables.modal.scss
+++ b/projects/angular/src/modal/_variables.modal.scss
@@ -7,7 +7,7 @@
 @use '@cds/core/tokens/tokens.scss';
 
 // Usage: ../modal/_modal.clarity.scss
-$clr-modal-default-space: tokens.$cds-global-space-9 !default;
+$clr-modal-default-space: var(--clr-modal-default-space) !default;
 $clr-modal-border-radius: var(--clr-modal-border-radius) !default;
 
 $clr-modal-close-color: var(--clr-modal-close-color) !default;


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

refactoring, add missing token

## What is the current behavior?

No token for modal default space. The cds space token is used directly.

Issue Number: N/A

## What is the new behavior?

Customizable token for modal default space: `--clr-modal-default-space`.

## Does this PR introduce a breaking change?

No.