### PR TITLE
fix(datepicker): don't read all days of month on focus with screen reader

### DIFF
--- a/projects/angular/src/forms/datepicker/calendar.html
+++ b/projects/angular/src/forms/datepicker/calendar.html
@@ -1,12 +1,12 @@
-<table class="calendar-table">
+<table class="calendar-table" role="presentation">
   <tr class="calendar-row weekdays">
-    <th *ngFor="let day of localeDays" class="calendar-cell weekday" role="heading" [attr.aria-label]="day.day">
-      {{day.narrow}}
+    <th *ngFor="let day of localeDays" class="calendar-cell weekday">
+      <span [attr.aria-label]="day.day">{{day.narrow}}</span>
     </th>
   </tr>
   <tr class="calendar-row" *ngFor="let row of calendarViewModel.calendarView">
     <td *ngFor="let dayView of row" class="calendar-cell">
-      <clr-day [clrDayView]="dayView"></clr-day>
+      <clr-day [clrDayView]="dayView" aria-hidden="true"></clr-day>
     </td>
   </tr>
 </table>

--- a/projects/angular/src/forms/datepicker/model/day.model.spec.ts
+++ b/projects/angular/src/forms/datepicker/model/day.model.spec.ts
@@ -69,7 +69,7 @@ export default function (): void {
 
     it('provides a toDateString method that returns the local date string', () => {
       const testString = dayModel1.toDateString();
-      expect(testString).toEqual('1/1/2018');
+      expect(testString).toEqual('Monday, January 1, 2018');
     });
 
     it('provides a toComparisonString method to compare dates', () => {

--- a/projects/angular/src/forms/datepicker/model/day.model.ts
+++ b/projects/angular/src/forms/datepicker/model/day.model.ts
@@ -44,7 +44,12 @@ export class DayModel {
   }
 
   toDateString(): string {
-    return this.toDate().toLocaleDateString();
+    return this.toDate().toLocaleDateString(undefined, {
+      weekday: 'long',
+      month: 'long',
+      day: 'numeric',
+      year: 'numeric',
+    });
   }
 
   private pad(num: number): string {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: - [VPAT-661](https://jira.eng.vmware.com/browse/VPAT-661) / [CDE-34](https://jira.eng.vmware.com/browse/CDE-34)

## What is the new behavior?
The unnecessary row/column info is not announced by NVDA, additionally the day of week is announced as expected.
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
This fix was done in v16 & v17 , but not moved to v15, added the same fix to v15.
Older PR for reference: https://github.com/vmware-clarity/ng-clarity/pull/957