### PR TITLE
fix(a11y): stepper-announce step complete/error on vo safari

### DIFF
--- a/projects/angular/src/accordion/accordion-panel.html
+++ b/projects/angular/src/accordion/accordion-panel.html
@@ -13,12 +13,6 @@
         [class.clr-accordion-header-has-description]="(accordionDescription.changes | async)?.length || accordionDescription.length"
         #headerButton
       >
-        <span class="clr-sr-only" role="status">
-          <ng-container *ngIf="panel.status === AccordionStatus.Error"> {{ stepErrorText(panelNumber)}} </ng-container>
-          <ng-container *ngIf="panel.status === AccordionStatus.Complete">
-            {{ stepCompleteText(panelNumber)}}
-          </ng-container>
-        </span>
         <span class="clr-accordion-status">
           <cds-icon shape="angle" direction="right" class="clr-accordion-angle"></cds-icon>
           <span class="clr-accordion-number">{{panelNumber}}.</span>
@@ -28,6 +22,12 @@
         <ng-content select="clr-accordion-title, clr-step-title"></ng-content>
         <ng-content select="clr-accordion-description, clr-step-description"></ng-content>
       </button>
+      <div class="clr-sr-only" role="status">
+        <ng-container *ngIf="panel.status === AccordionStatus.Error"> {{ stepErrorText(panelNumber)}} </ng-container>
+        <ng-container *ngIf="panel.status === AccordionStatus.Complete">
+          {{ stepCompleteText(panelNumber)}}
+        </ng-container>
+      </div>
     </div>
     <div
       @skipInitialRender

--- a/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
+++ b/projects/angular/src/accordion/stepper/stepper-panel.spec.ts
@@ -88,7 +88,7 @@ describe('ClrStep Reactive Forms', () => {
       (stepperService as MockStepperService).step.next(mockStep);
       fixture.detectChanges();
 
-      const statusMessage = fixture.nativeElement.querySelector('button .clr-sr-only');
+      const statusMessage = fixture.nativeElement.querySelector('.clr-accordion-header .clr-sr-only');
       expect(statusMessage.innerText.trim()).toBe('Error in step 1');
 
       mockStep.status = AccordionStatus.Complete;
@@ -121,7 +121,7 @@ describe('ClrStep Reactive Forms', () => {
       expect(input.focus).not.toHaveBeenCalled();
 
       (stepperService as MockStepperService).activeStep.next('groupName');
-      tick();
+      tick(1500);
 
       expect(input.focus).toHaveBeenCalled();
     }));

--- a/projects/angular/src/accordion/stepper/stepper-panel.ts
+++ b/projects/angular/src/accordion/stepper/stepper-panel.ts
@@ -99,7 +99,11 @@ export class ClrStepperPanel extends ClrAccordionPanel implements OnInit {
     this.subscriptions.push(
       this.stepperService.activeStep
         .pipe(filter(panelId => isPlatformBrowser(this.platformId) && panelId === this.id))
-        .subscribe(() => this.headerButton.nativeElement.focus())
+        .subscribe(() => {
+          //Adding timeout so that the status of the previous step is read by Voice Over on Safari,
+          //before focusing on the next stepper panel header
+          setTimeout(() => this.headerButton.nativeElement.focus(), 1500);
+        })
     );
   }
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Voice Over on Safari was reading the next step header before announcing the status of the previous step, which is either complete or an error. 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [CDE-699](https://jira.eng.vmware.com/browse/CDE-699)

## What is the new behavior?
Added a delay for the stepper header button focus so that the status of the previous step is announced before the next step is read.
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
