### PR TITLE
chore: various fixes for style documentation

### DIFF
--- a/projects/angular/src/forms/STYLES.md
+++ b/projects/angular/src/forms/STYLES.md
@@ -49,7 +49,7 @@
 | --clr-forms-datalist-caret-icon-size                         | Size of datalist caret                                |
 | --clr-forms-input-group-icon-action-size                     | Size of action icon                                   |
 
-## Class names
+## CSS Classes
 
 | Class name        | Description                          |
 | ----------------- | ------------------------------------ |

--- a/projects/angular/src/layout/STYLES.md
+++ b/projects/angular/src/layout/STYLES.md
@@ -73,7 +73,7 @@
 ## CSS Classes
 
 | Class         | Description                                                                      |
-| ------------- | -------------------------------------------------------------------------------- | --- |
+| ------------- | -------------------------------------------------------------------------------- |
 | login         | The login form is a predefined form for applications that require authentication |
 | login-body    | Wrapper for login content                                                        |
 | login-header  | Wrapper for login header elements                                                |
@@ -81,7 +81,7 @@
 | logo          | VMware logo                                                                      |
 | actions       | Wrapper for header actions                                                       |
 | copyright     | Copyright label                                                                  |
-| login-wrapper | Wrapper element                                                                  |     |
+| login-wrapper | Wrapper element                                                                  |
 | title         | The title `section` of the login form                                            |
 | welcome       | The heading of the login form                                                    |
 | hint          | Hint/helper text within the title of the login form                              |

--- a/projects/angular/src/layout/tabs/STYLES.md
+++ b/projects/angular/src/layout/tabs/STYLES.md
@@ -13,7 +13,7 @@
 | --clr-vertical-nav-header-font-weight     | Vertical nav header font weight             |
 | --clr-nav-selected-hover-background-color | Tabs nav selected background color on hover |
 
-## Class names
+## CSS Classes
 
 | Class name    | Description                                   |
 | ------------- | --------------------------------------------- |


### PR DESCRIPTION
- Fix bad table syntax in login style documentation. This will fix a display bug on the website.
- Rename forms style documentation file for case sensitivity. This will make the file included in the build.
- Use "CSS Classes" instead "Class names" headings. This will make the website include the warning about overriding CSS classes.