### PR TITLE
fix(a11y): datagrid detail pane has role dialog with no aria label

### DIFF
--- a/.storybook/stories/datagrid/datagrid-detail.stories.ts
+++ b/.storybook/stories/datagrid/datagrid-detail.stories.ts
@@ -24,12 +24,19 @@ export default {
     // story helpers
     elements: { control: { disable: true }, table: { disable: true } },
     detailContentType: { control: 'inline-radio', options: ['json', 'datagrid'] },
+    clrDetailAriaLabel: {
+      type: 'text',
+      description: 'Title of the modal',
+    },
+    clrDetailAriaLabelledBy: {
+      type: 'array',
+      description: "Id or Id's referencing existing text on the page",
+    },
   },
   args: {
     //inputs
     clrDetailAriaLabel: '',
-    clrDetailAriaLabelledBy: '',
-    clrDetailAriaDescribedBy: '',
+    clrDetailAriaLabelledBy: [],
     // story helpers
     elements,
     detailContentType: 'json',
@@ -102,7 +109,6 @@ const DetailTemplate: StoryFn = args => {
           *clrIfDetail="let element"
           [clrDetailAriaLabel]="clrDetailAriaLabel"
           [clrDetailAriaLabelledBy]="clrDetailAriaLabelledBy"
-          [clrDetailAriaDescribedBy]="clrDetailAriaDescribedBy"
         >
           <clr-dg-detail-header>{{ element.name }}</clr-dg-detail-header>
           <clr-dg-detail-body [ngSwitch]="detailContentType">

--- a/.storybook/stories/datagrid/datagrid-detail.stories.ts
+++ b/.storybook/stories/datagrid/datagrid-detail.stories.ts
@@ -26,6 +26,10 @@ export default {
     detailContentType: { control: 'inline-radio', options: ['json', 'datagrid'] },
   },
   args: {
+    //inputs
+    clrDetailAriaLabel: '',
+    clrDetailAriaLabelledBy: '',
+    clrDetailAriaDescribedBy: '',
     // story helpers
     elements,
     detailContentType: 'json',
@@ -93,12 +97,16 @@ const DetailTemplate: StoryFn = args => {
           </ng-container>
         </clr-dg-row>
 
-        <clr-dg-detail [ngClass]="{ highlight }" *clrIfDetail="let element">
+        <clr-dg-detail
+          [ngClass]="{ highlight }"
+          *clrIfDetail="let element"
+          [clrDetailAriaLabel]="clrDetailAriaLabel"
+          [clrDetailAriaLabelledBy]="clrDetailAriaLabelledBy"
+          [clrDetailAriaDescribedBy]="clrDetailAriaDescribedBy"
+        >
           <clr-dg-detail-header>{{ element.name }}</clr-dg-detail-header>
           <clr-dg-detail-body [ngSwitch]="detailContentType">
-            <ng-container *ngSwitchCase="'json'">
-              {{ element | json }}
-            </ng-container>
+            <ng-container *ngSwitchCase="'json'"> {{ element | json }} </ng-container>
 
             <clr-datagrid *ngSwitchCase="'datagrid'">
               <clr-dg-column>Key</clr-dg-column>

--- a/.storybook/stories/datagrid/datagrid-detail.stories.ts
+++ b/.storybook/stories/datagrid/datagrid-detail.stories.ts
@@ -28,7 +28,7 @@ export default {
       description: 'Title of the modal',
     },
     clrDetailAriaLabelledBy: {
-      description: "Id or Id's referencing existing text on the page",
+      description: "Id or multiple space separated Id's referencing existing text on the page",
     },
   },
   args: {

--- a/.storybook/stories/datagrid/datagrid-detail.stories.ts
+++ b/.storybook/stories/datagrid/datagrid-detail.stories.ts
@@ -25,18 +25,16 @@ export default {
     elements: { control: { disable: true }, table: { disable: true } },
     detailContentType: { control: 'inline-radio', options: ['json', 'datagrid'] },
     clrDetailAriaLabel: {
-      type: 'text',
       description: 'Title of the modal',
     },
     clrDetailAriaLabelledBy: {
-      type: 'array',
       description: "Id or Id's referencing existing text on the page",
     },
   },
   args: {
     //inputs
     clrDetailAriaLabel: '',
-    clrDetailAriaLabelledBy: [],
+    clrDetailAriaLabelledBy: '',
     // story helpers
     elements,
     detailContentType: 'json',
@@ -107,8 +105,8 @@ const DetailTemplate: StoryFn = args => {
         <clr-dg-detail
           [ngClass]="{ highlight }"
           *clrIfDetail="let element"
-          [clrDetailAriaLabel]="clrDetailAriaLabel"
-          [clrDetailAriaLabelledBy]="clrDetailAriaLabelledBy"
+          ${args.clrDetailAriaLabel ? '[clrDetailAriaLabel]="clrDetailAriaLabel"' : ''}
+          ${args.clrDetailAriaLabelledBy ? '[clrDetailAriaLabelledBy]="clrDetailAriaLabelledBy"' : ''}
         >
           <clr-dg-detail-header>{{ element.name }}</clr-dg-detail-header>
           <clr-dg-detail-body [ngSwitch]="detailContentType">

--- a/.storybook/stories/datagrid/datagrid-detail.stories.ts
+++ b/.storybook/stories/datagrid/datagrid-detail.stories.ts
@@ -106,7 +106,7 @@ const DetailTemplate: StoryFn = args => {
         >
           <clr-dg-detail-header>{{ element.name }}</clr-dg-detail-header>
           <clr-dg-detail-body [ngSwitch]="detailContentType">
-            <ng-container *ngSwitchCase="'json'"> {{ element | json }} </ng-container>
+            <ng-container *ngSwitchCase="'json'">{{ element | json }}</ng-container>
 
             <clr-datagrid *ngSwitchCase="'datagrid'">
               <clr-dg-column>Key</clr-dg-column>

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1448,6 +1448,12 @@ export interface ClrDatagridComparatorInterface<T> {
 export class ClrDatagridDetail {
     constructor(detailService: DetailService, commonStrings: ClrCommonStringsService);
     // (undocumented)
+    ariaDescribedBy: string;
+    // (undocumented)
+    ariaLabel: string;
+    // (undocumented)
+    ariaLabelledBy: string;
+    // (undocumented)
     close(): void;
     // (undocumented)
     commonStrings: ClrCommonStringsService;
@@ -1456,7 +1462,9 @@ export class ClrDatagridDetail {
     // (undocumented)
     header: ClrDatagridDetailHeader;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridDetail, "clr-dg-detail", never, {}, {}, ["header"], ["*"], false, never>;
+    get labelledBy(): string;
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridDetail, "clr-dg-detail", never, { "ariaDescribedBy": "clrDetailAriaDescribedBy"; "ariaLabelledBy": "clrDetailAriaLabelledBy"; "ariaLabel": "clrDetailAriaLabel"; }, {}, ["header"], ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrDatagridDetail, never>;
 }
@@ -1472,6 +1480,8 @@ export class ClrDatagridDetailBody {
 // @public (undocumented)
 export class ClrDatagridDetailHeader implements AfterViewInit {
     constructor(detailService: DetailService, commonStrings: ClrCommonStringsService);
+    // (undocumented)
+    close(): void;
     // (undocumented)
     commonStrings: ClrCommonStringsService;
     // (undocumented)

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1448,8 +1448,6 @@ export interface ClrDatagridComparatorInterface<T> {
 export class ClrDatagridDetail {
     constructor(detailService: DetailService, commonStrings: ClrCommonStringsService);
     // (undocumented)
-    ariaDescribedBy: string;
-    // (undocumented)
     ariaLabel: string;
     // (undocumented)
     ariaLabelledBy: string;
@@ -1464,7 +1462,7 @@ export class ClrDatagridDetail {
     // (undocumented)
     get labelledBy(): string;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridDetail, "clr-dg-detail", never, { "ariaDescribedBy": "clrDetailAriaDescribedBy"; "ariaLabelledBy": "clrDetailAriaLabelledBy"; "ariaLabel": "clrDetailAriaLabel"; }, {}, ["header"], ["*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridDetail, "clr-dg-detail", never, { "ariaLabelledBy": "clrDetailAriaLabelledBy"; "ariaLabel": "clrDetailAriaLabel"; }, {}, ["header"], ["*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrDatagridDetail, never>;
 }
@@ -1480,8 +1478,6 @@ export class ClrDatagridDetailBody {
 // @public (undocumented)
 export class ClrDatagridDetailHeader implements AfterViewInit {
     constructor(detailService: DetailService, commonStrings: ClrCommonStringsService);
-    // (undocumented)
-    close(): void;
     // (undocumented)
     commonStrings: ClrCommonStringsService;
     // (undocumented)

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1460,6 +1460,8 @@ export class ClrDatagridDetail {
     // (undocumented)
     header: ClrDatagridDetailHeader;
     // (undocumented)
+    get label(): string;
+    // (undocumented)
     get labelledBy(): string;
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagridDetail, "clr-dg-detail", never, { "ariaLabelledBy": "clrDetailAriaLabelledBy"; "ariaLabel": "clrDetailAriaLabel"; }, {}, ["header"], ["*"], false, never>;

--- a/projects/angular/src/data/datagrid/datagrid-detail.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-detail.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { Component } from '@angular/core';
-import { waitForAsync } from '@angular/core/testing';
+import { async } from '@angular/core/testing';
 
 import { ClrDatagridDetail } from './datagrid-detail';
 import { TestContext } from './helpers.spec';
@@ -54,7 +54,7 @@ export default function (): void {
         expect(context.clarityElement.innerHTML).not.toContain(content);
       });
 
-      it('hides content with the esc key', waitForAsync(() => {
+      it('hides content with the esc key', async(() => {
         spyOn(detailService, 'close');
         detailService.open({});
         context.detectChanges();

--- a/projects/angular/src/data/datagrid/datagrid-detail.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-detail.spec.ts
@@ -34,11 +34,11 @@ export default function (): void {
     });
 
     describe('View', function () {
-      let context: TestContext<ClrDatagridDetail, DataGridPaneTestComponent>;
+      let context: TestContext<ClrDatagridDetail, FullTest>;
       let detailService: DetailService;
 
       beforeEach(function () {
-        context = this.create(ClrDatagridDetail, DataGridPaneTestComponent, [DetailService]);
+        context = this.create(ClrDatagridDetail, FullTest, [DetailService]);
         detailService = context.getClarityProvider(DetailService);
         detailService.id = 'clr-id-1';
         context.detectChanges();
@@ -125,11 +125,6 @@ export default function (): void {
 }
 
 @Component({
-  template: `<clr-dg-detail>${content}</clr-dg-detail>`,
-})
-class FullTest {}
-
-@Component({
   template: `
     <clr-dg-detail [clrDetailAriaLabelledBy]="ariaLabelledBy" [clrDetailAriaLabel]="ariaLabel">
       <clr-dg-detail-header>Title</clr-dg-detail-header>
@@ -137,7 +132,7 @@ class FullTest {}
     </clr-dg-detail>
   `,
 })
-class DataGridPaneTestComponent {
+class FullTest {
   ariaLabelledBy: string;
   ariaLabel: string;
 }

--- a/projects/angular/src/data/datagrid/datagrid-detail.ts
+++ b/projects/angular/src/data/datagrid/datagrid-detail.ts
@@ -46,9 +46,14 @@ export class ClrDatagridDetail {
 
   get labelledBy(): string {
     if (this.ariaLabelledBy) {
-      return this.header ? this.header.titleId + ' ' + this.ariaLabelledBy : this.ariaLabelledBy;
+      return this.header ? `${this.header.titleId} ${this.ariaLabelledBy}` : this.ariaLabelledBy;
     } else {
-      return this.ariaLabel ? null : this.header ? this.header.titleId : '';
+      // If aria-label is set by the end user, do not set aria-labelledby
+      if (this.ariaLabel) {
+        return null;
+      } else {
+        return this.header?.titleId || '';
+      }
     }
   }
 

--- a/projects/angular/src/data/datagrid/datagrid-detail.ts
+++ b/projects/angular/src/data/datagrid/datagrid-detail.ts
@@ -46,7 +46,7 @@ export class ClrDatagridDetail {
 
   get labelledBy(): string {
     if (this.ariaLabelledBy) {
-      return this.ariaLabelledBy;
+      return this.header ? this.header.titleId + ' ' + this.ariaLabelledBy : this.ariaLabelledBy;
     } else {
       return this.ariaLabel ? null : this.header ? this.header.titleId : '';
     }

--- a/projects/angular/src/data/datagrid/datagrid-detail.ts
+++ b/projects/angular/src/data/datagrid/datagrid-detail.ts
@@ -5,7 +5,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, ContentChild } from '@angular/core';
+import { Component, ContentChild, Input } from '@angular/core';
 
 import { ClrCommonStringsService } from '../../utils/i18n/common-strings.service';
 import { ClrDatagridDetailHeader } from './datagrid-detail-header';
@@ -27,7 +27,9 @@ import { DetailService } from './providers/detail.service';
       role="dialog"
       [id]="detailService.id"
       aria-modal="true"
-      [attr.aria-labelledby]="header ? header.titleId : ''"
+      [attr.aria-labelledby]="labelledBy"
+      [attr.aria-describedby]="ariaDescribedBy ? ariaDescribedBy : null"
+      [attr.aria-label]="ariaLabel ? ariaLabel : null"
     >
       <div class="clr-sr-only">{{ commonStrings.keys.detailPaneStart }}</div>
       <ng-content></ng-content>
@@ -38,7 +40,19 @@ import { DetailService } from './providers/detail.service';
 export class ClrDatagridDetail {
   @ContentChild(ClrDatagridDetailHeader) header: ClrDatagridDetailHeader;
 
+  @Input('clrDetailAriaDescribedBy') ariaDescribedBy: string;
+  @Input('clrDetailAriaLabelledBy') ariaLabelledBy: string;
+  @Input('clrDetailAriaLabel') ariaLabel: string;
+
   constructor(public detailService: DetailService, public commonStrings: ClrCommonStringsService) {}
+
+  get labelledBy(): string {
+    if (!this.ariaLabel) {
+      return this.ariaLabelledBy ? this.ariaLabelledBy : this.header ? this.header.titleId : '';
+    } else {
+      return null;
+    }
+  }
 
   close(): void {
     this.detailService.close();

--- a/projects/angular/src/data/datagrid/datagrid-detail.ts
+++ b/projects/angular/src/data/datagrid/datagrid-detail.ts
@@ -28,7 +28,7 @@ import { DetailService } from './providers/detail.service';
       [id]="detailService.id"
       aria-modal="true"
       [attr.aria-labelledby]="labelledBy"
-      [attr.aria-label]="ariaLabel ? ariaLabel : null"
+      [attr.aria-label]="label"
     >
       <div class="clr-sr-only">{{ commonStrings.keys.detailPaneStart }}</div>
       <ng-content></ng-content>
@@ -45,8 +45,16 @@ export class ClrDatagridDetail {
   constructor(public detailService: DetailService, public commonStrings: ClrCommonStringsService) {}
 
   get labelledBy(): string {
-    if (!this.ariaLabel) {
-      return this.ariaLabelledBy ? this.ariaLabelledBy : this.header ? this.header.titleId : '';
+    if (this.ariaLabelledBy) {
+      return this.ariaLabelledBy;
+    } else {
+      return this.ariaLabel ? null : this.header ? this.header.titleId : '';
+    }
+  }
+
+  get label(): string {
+    if (!this.ariaLabelledBy) {
+      return this.ariaLabel ? this.ariaLabel : null;
     } else {
       return null;
     }

--- a/projects/angular/src/data/datagrid/datagrid-detail.ts
+++ b/projects/angular/src/data/datagrid/datagrid-detail.ts
@@ -28,7 +28,6 @@ import { DetailService } from './providers/detail.service';
       [id]="detailService.id"
       aria-modal="true"
       [attr.aria-labelledby]="labelledBy"
-      [attr.aria-describedby]="ariaDescribedBy ? ariaDescribedBy : null"
       [attr.aria-label]="ariaLabel ? ariaLabel : null"
     >
       <div class="clr-sr-only">{{ commonStrings.keys.detailPaneStart }}</div>
@@ -40,7 +39,6 @@ import { DetailService } from './providers/detail.service';
 export class ClrDatagridDetail {
   @ContentChild(ClrDatagridDetailHeader) header: ClrDatagridDetailHeader;
 
-  @Input('clrDetailAriaDescribedBy') ariaDescribedBy: string;
   @Input('clrDetailAriaLabelledBy') ariaLabelledBy: string;
   @Input('clrDetailAriaLabel') ariaLabel: string;
 

--- a/projects/angular/src/data/datagrid/datagrid-detail.ts
+++ b/projects/angular/src/data/datagrid/datagrid-detail.ts
@@ -27,7 +27,7 @@ import { DetailService } from './providers/detail.service';
       role="dialog"
       [id]="detailService.id"
       aria-modal="true"
-      [attr.aria-describedby]="header ? header.titleId : ''"
+      [attr.aria-labelledby]="header ? header.titleId : ''"
     >
       <div class="clr-sr-only">{{ commonStrings.keys.detailPaneStart }}</div>
       <ng-content></ng-content>

--- a/projects/angular/src/data/datagrid/datagrid-detail.ts
+++ b/projects/angular/src/data/datagrid/datagrid-detail.ts
@@ -37,29 +37,27 @@ import { DetailService } from './providers/detail.service';
   `,
 })
 export class ClrDatagridDetail {
-  @ContentChild(ClrDatagridDetailHeader) header: ClrDatagridDetailHeader;
-
   @Input('clrDetailAriaLabelledBy') ariaLabelledBy: string;
   @Input('clrDetailAriaLabel') ariaLabel: string;
+
+  @ContentChild(ClrDatagridDetailHeader) header: ClrDatagridDetailHeader;
 
   constructor(public detailService: DetailService, public commonStrings: ClrCommonStringsService) {}
 
   get labelledBy(): string {
     if (this.ariaLabelledBy) {
       return this.header ? `${this.header.titleId} ${this.ariaLabelledBy}` : this.ariaLabelledBy;
-    } else {
+    } else if (this.ariaLabel) {
       // If aria-label is set by the end user, do not set aria-labelledby
-      if (this.ariaLabel) {
-        return null;
-      } else {
-        return this.header?.titleId || '';
-      }
+      return null;
+    } else {
+      return this.header?.titleId || '';
     }
   }
 
   get label(): string {
     if (!this.ariaLabelledBy) {
-      return this.ariaLabel ? this.ariaLabel : null;
+      return this.ariaLabel || null;
     } else {
       return null;
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
`aria-describedby` is used on the datagrid detail pane instead of `aria-labelledby` 
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [CDE-645](https://jira.eng.vmware.com/browse/CDE-645)

## What is the new behavior?

- By default if the user does not add anything: `aria-labelledby` will be added by the library with the id of the modal title.
- The user can set additional `aria-labelledby` (using the [clrDetailAriaLabelledBy] input) which could have a value referencing other text on the page , it can have multiple space separated id's. In this case the default title id will be added along with the user defined IDs.
- The user can add `aria-label` (using [clrDetailAriaLabel] input), in this case the aria-label provided will be used. 
- If both `aria-label` & `aria-labelledby` is added by the user, then only `aria-labelledby` will be added to the modal.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
