### PR TITLE
fix(file-input): add vertical spacing between label and browse button

### DIFF
--- a/projects/angular/src/forms/styles/_file-input.clarity.scss
+++ b/projects/angular/src/forms/styles/_file-input.clarity.scss
@@ -5,19 +5,18 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+@use 'sass:map';
+
 @use '@cds/core/tokens/tokens.scss';
 
 @use '../../utils/mixins';
-@use '../../utils/variables/variables.global';
+@use '../../utils/variables/variables';
 @use 'variables.forms' as forms-variables;
 
 @include mixins.exports('forms.file-input') {
   .clr-file-input-wrapper {
     position: relative;
-
-    .clr-control-label {
-      display: inline;
-    }
+    margin-top: tokens.$cds-global-space-3;
 
     .clr-file-input {
       @include mixins.equilateral(0);
@@ -42,6 +41,16 @@
     .clr-file-input-browse-button-text {
       overflow: hidden;
       text-overflow: ellipsis;
+    }
+  }
+
+  .clr-form-compact .clr-file-input-wrapper {
+    margin-top: 0;
+  }
+
+  .clr-form-horizontal .clr-file-input-wrapper {
+    @media screen and (min-width: map.get(variables.$clr-grid-breakpoints, md)) {
+      margin-top: 0;
     }
   }
 }


### PR DESCRIPTION
This is a backport of e378c6092db054fe8fddcc029e674f0e19988df2 (#1415) to 16.x.

This commit also removes dead `.clr-control-label` styles. The label is not nested in the wrapper. That is why I didn't add the margin on the label.

CDE-1668