### PR TITLE
fix(datagrid): hide sticky columns for loading more items row

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -277,6 +277,14 @@
         line-height: tokens.$cds-global-space-9;
       }
     }
+
+    &.datagrid-row-loading .datagrid-cell {
+      display: flex;
+      padding: tokens.$cds-global-space-9;
+      align-items: center;
+      gap: tokens.$cds-global-space-6;
+      justify-content: center;
+    }
   }
 
   .datagrid-row-sticky {
@@ -403,14 +411,6 @@
     flex-direction: column;
     flex: 1 1 auto;
     align-content: flex-start;
-
-    .datagrid-loading-more-items-row .datagrid-loading-more-items-cell {
-      display: flex;
-      padding: tokens.$cds-global-space-9;
-      align-items: center;
-      gap: tokens.$cds-global-space-6;
-      justify-content: center;
-    }
 
     .datagrid-body {
       width: auto;

--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -278,12 +278,18 @@
       }
     }
 
-    &.datagrid-row-loading .datagrid-cell {
-      display: flex;
-      padding: tokens.$cds-global-space-9;
-      align-items: center;
-      gap: tokens.$cds-global-space-6;
-      justify-content: center;
+    &.datagrid-row-loading {
+      .datagrid-row-sticky {
+        display: none;
+      }
+
+      .datagrid-cell {
+        display: flex;
+        padding: tokens.$cds-global-space-9;
+        align-items: center;
+        gap: tokens.$cds-global-space-6;
+        justify-content: center;
+      }
     }
   }
 

--- a/projects/angular/src/data/datagrid/datagrid.html
+++ b/projects/angular/src/data/datagrid/datagrid.html
@@ -76,21 +76,25 @@
           </div>
 
           <div role="presentation" class="datagrid-rows">
-            <clr-dg-row class="datagrid-loading-more-items-row" *ngIf="loadingMoreItems">
-              <clr-dg-cell class="datagrid-loading-more-items-cell">
-                <clr-spinner [clrMedium]="true"></clr-spinner>
-                <span>{{ commonStrings.keys.loading }}</span>
-              </clr-dg-cell>
-            </clr-dg-row>
+            <div role="row" class="datagrid-row datagrid-row-loading" *ngIf="loadingMoreItems">
+              <div class="datagrid-row-master datagrid-row-flex">
+                <div class="datagrid-cell">
+                  <clr-spinner [clrMedium]="true"></clr-spinner>
+                  <span>{{ commonStrings.keys.loading }}</span>
+                </div>
+              </div>
+            </div>
 
             <ng-container #displayedRows></ng-container>
 
-            <clr-dg-row class="datagrid-loading-more-items-row" *ngIf="loadingMoreItems">
-              <clr-dg-cell class="datagrid-loading-more-items-cell">
-                <clr-spinner [clrMedium]="true"></clr-spinner>
-                <span>{{ commonStrings.keys.loading }}</span>
-              </clr-dg-cell>
-            </clr-dg-row>
+            <div role="row" class="datagrid-row datagrid-row-loading" *ngIf="loadingMoreItems">
+              <div class="datagrid-row-master datagrid-row-flex">
+                <div class="datagrid-cell">
+                  <clr-spinner [clrMedium]="true"></clr-spinner>
+                  <span>{{ commonStrings.keys.loading }}</span>
+                </div>
+              </div>
+            </div>
 
             <!-- Custom placeholder overrides the default empty one -->
             <ng-content select="clr-dg-placeholder"></ng-content>

--- a/projects/angular/src/data/datagrid/datagrid.html
+++ b/projects/angular/src/data/datagrid/datagrid.html
@@ -76,25 +76,21 @@
           </div>
 
           <div role="presentation" class="datagrid-rows">
-            <div role="row" class="datagrid-row datagrid-row-loading" *ngIf="loadingMoreItems">
-              <div class="datagrid-row-master datagrid-row-flex">
-                <div class="datagrid-cell">
-                  <clr-spinner [clrMedium]="true"></clr-spinner>
-                  <span>{{ commonStrings.keys.loading }}</span>
-                </div>
-              </div>
-            </div>
+            <clr-dg-row class="datagrid-row-loading" *ngIf="loadingMoreItems">
+              <clr-dg-cell>
+                <clr-spinner clrMedium></clr-spinner>
+                <span>{{ commonStrings.keys.loading }}</span>
+              </clr-dg-cell>
+            </clr-dg-row>
 
             <ng-container #displayedRows></ng-container>
 
-            <div role="row" class="datagrid-row datagrid-row-loading" *ngIf="loadingMoreItems">
-              <div class="datagrid-row-master datagrid-row-flex">
-                <div class="datagrid-cell">
-                  <clr-spinner [clrMedium]="true"></clr-spinner>
-                  <span>{{ commonStrings.keys.loading }}</span>
-                </div>
-              </div>
-            </div>
+            <clr-dg-row class="datagrid-row-loading" *ngIf="loadingMoreItems">
+              <clr-dg-cell>
+                <clr-spinner clrMedium></clr-spinner>
+                <span>{{ commonStrings.keys.loading }}</span>
+              </clr-dg-cell>
+            </clr-dg-row>
 
             <!-- Custom placeholder overrides the default empty one -->
             <ng-content select="clr-dg-placeholder"></ng-content>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently loading rows are using `clr-dg-row` which shows the sticky columns if available
![Screenshot 2024-06-03 at 23 53 10](https://github.com/vmware-clarity/ng-clarity/assets/127101685/0fb09866-ea69-4679-9d8f-d1a691ae4a65)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-2069

## What is the new behavior?

Hide sticky columns for loading row.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
