### PR TITLE
fix(a11y): timeline steps should have a list structure

### DIFF
--- a/projects/angular/src/timeline/timeline-step.ts
+++ b/projects/angular/src/timeline/timeline-step.ts
@@ -34,7 +34,7 @@ import { ClrTimelineStepTitle } from './timeline-step-title';
       <clr-spinner clrMedium [attr.aria-label]="iconAriaLabel"></clr-spinner>
     </ng-template>
   `,
-  host: { '[class.clr-timeline-step]': 'true' },
+  host: { '[class.clr-timeline-step]': 'true', '[attr.role]': '"listitem"' },
 })
 export class ClrTimelineStep {
   @Input('clrState') state: ClrTimelineStepState = ClrTimelineStepState.NOT_STARTED;

--- a/projects/angular/src/timeline/timeline.ts
+++ b/projects/angular/src/timeline/timeline.ts
@@ -13,7 +13,7 @@ import { TimelineIconAttributeService } from './providers/timeline-icon-attribut
 @Component({
   selector: 'clr-timeline',
   template: `<ng-content></ng-content>`,
-  host: { '[class.clr-timeline]': 'true' },
+  host: { '[class.clr-timeline]': 'true', '[attr.role]': '"list"' },
   providers: [TimelineIconAttributeService],
 })
 export class ClrTimeline {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Due to the absence of semantic tags `<ul>` and `<li>` in the angular version of the timeline component, screen readers do not announce the number of steps in the timeline.
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: [CDE-1181](https://jira.eng.vmware.com/browse/CDE-1181)

## What is the new behavior?
Added aria roles: `role="list"` to the timeline container and `role="listitem"` to each timeline step so that screen readers consider the timeline as a list and announce the number of steps.
## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
