### PR TITLE
fix(datagrid): remove cell input focus by `tab` key

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1243,6 +1243,8 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     // (undocumented)
     singleSelectedChanged: EventEmitter<T>;
     // (undocumented)
+    toggleAllSelected($event: any): void;
+    // (undocumented)
     set trackBy(value: ClrDatagridItemsTrackByFunction<T>);
     // (undocumented)
     static ɵcmp: i0.ɵɵComponentDeclaration<ClrDatagrid<any>, "clr-datagrid", never, { "loadingMoreItems": "clrLoadingMoreItems"; "clrDgSingleSelectionAriaLabel": "clrDgSingleSelectionAriaLabel"; "clrDgSingleActionableAriaLabel": "clrDgSingleActionableAriaLabel"; "clrDetailExpandableAriaLabel": "clrDetailExpandableAriaLabel"; "clrDgDisablePageFocus": "clrDgDisablePageFocus"; "loading": "clrDgLoading"; "selected": "clrDgSelected"; "singleSelected": "clrDgSingleSelected"; "clrDgPreserveSelection": "clrDgPreserveSelection"; "rowSelectionMode": "clrDgRowSelection"; "trackBy": "clrDgItemsTrackBy"; }, { "selectedChanged": "clrDgSelectedChange"; "singleSelectedChanged": "clrDgSingleSelectedChange"; "refresh": "clrDgRefresh"; }, ["iterator", "placeholder", "columns", "rows"], ["clr-dg-action-bar", "clr-dg-placeholder", "clr-dg-footer", "[clrIfDetail],clr-dg-detail"], false, never>;

--- a/projects/angular/src/data/datagrid/datagrid-action-overflow.ts
+++ b/projects/angular/src/data/datagrid/datagrid-action-overflow.ts
@@ -37,6 +37,7 @@ let clrDgActionId = 0;
   hostDirectives: [ClrPopoverHostDirective],
   template: `
     <button
+      tabindex="-1"
       class="datagrid-action-toggle"
       type="button"
       role="button"

--- a/projects/angular/src/data/datagrid/datagrid-row.html
+++ b/projects/angular/src/data/datagrid/datagrid-row.html
@@ -49,6 +49,7 @@
         >
           <clr-checkbox-wrapper>
             <input
+              tabindex="-1"
               type="checkbox"
               clrCheckbox
               [ngModel]="selected"
@@ -71,6 +72,7 @@
         >
           <clr-radio-wrapper>
             <input
+              tabindex="-1"
               type="radio"
               clrRadio
               [id]="radioId"
@@ -100,6 +102,7 @@
         >
           <ng-container *ngIf="expand.expandable">
             <button
+              tabindex="-1"
               *ngIf="!expand.loading"
               (click)="toggleExpand()"
               type="button"
@@ -124,6 +127,7 @@
           role="gridcell"
         >
           <button
+            tabindex="-1"
             (click)="detailService.toggle(item, detailButton)"
             type="button"
             #detailButton

--- a/projects/angular/src/data/datagrid/datagrid.html
+++ b/projects/angular/src/data/datagrid/datagrid.html
@@ -20,7 +20,7 @@
                     role="columnheader"
                     class="datagrid-column datagrid-select datagrid-fixed-column"
                     *ngIf="selection.selectionType === SELECTION_TYPE.Multi"
-                    (keydown.space)="allSelected = !allSelected; $event.preventDefault()"
+                    (keydown.space)="toggleAllSelected($event)"
                   >
                     <div *ngIf="!hasVirtualScroller" class="clr-checkbox-wrapper">
                       <!-- We need to move focus and space-key handling to the parent because of keyboard arrow key navigation,

--- a/projects/angular/src/data/datagrid/datagrid.ts
+++ b/projects/angular/src/data/datagrid/datagrid.ts
@@ -382,6 +382,16 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     this._subscriptions.forEach((sub: Subscription) => sub.unsubscribe());
   }
 
+  toggleAllSelected($event: any) {
+    $event.preventDefault();
+
+    if (this.hasVirtualScroller) {
+      return;
+    }
+
+    this.allSelected = !this.allSelected;
+  }
+
   resize(): void {
     this.organizer.resize();
   }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
All datagrid static inputs and buttons are focusable by `tab` key. 

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-1943

## What is the new behavior?
Static datagrid inputs and buttons are focusable only within the datagrid by `Arrow keys` and `PageUp/Down` keys. 


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
