### PR TITLE
fix(datagrid): retain focus on closing detail

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1282,13 +1282,15 @@
   .datagrid-detail-overlay {
     // too specific query needed to avoid issues with nested datagrids
     &.datagrid-detail-open > .datagrid-outer-wrapper > .datagrid-inner-wrapper {
-      display: none;
+      width: 0;
+      min-width: unset;
     }
 
     .datagrid-detail-pane {
       border-left: tokens.$cds-alias-object-border-width-100 solid;
       border-color: datagrid-variables.$clr-datagrid-detail-pane-border-color;
       border-radius: tokens.$cds-alias-object-border-radius-100;
+      width: 100%;
     }
   }
 

--- a/projects/angular/src/data/datagrid/providers/detail.service.ts
+++ b/projects/angular/src/data/datagrid/providers/detail.service.ts
@@ -51,11 +51,9 @@ export class DetailService {
 
   close() {
     this.toggleState = false;
+    this.returnFocus();
     this._state.next(this.toggleState);
     this.modalStackService.trackModalClose(this);
-    // In the case of browser zoom greater than 250%, the detail pane toggle button is not visible on the page.
-    // Wait for the detail pane to close, and return focus to the detail toggle button.
-    setTimeout(() => this.returnFocus(), 0);
   }
 
   returnFocus() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When closing detail in datagrid trough the 'X' button it loses the focus for a second which triggers a scroll inside and fails to focus the button triger sometimes.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-2043

## What is the new behavior?

Overlay detail is no longer setting the datagrid to `display:none` which block us from return the focus to the trigger at the right moment and we moved the focus trigger just before the close so we skip the moment where the focus is lost and it focuses the body.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
