### PR TITLE
chore: use `async`/`await` instead of `.then`

### DIFF
--- a/projects/angular/src/forms/combobox/combobox.spec.ts
+++ b/projects/angular/src/forms/combobox/combobox.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { Component } from '@angular/core';
-import { async, ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 import { NoopAnimationsModule } from '@angular/platform-browser/animations';
@@ -127,21 +127,19 @@ export default function (): void {
 
       // The forms framework has some inner asychronisity, which requires the async/whenStable
       // approach in the following tests
-      it('sets selection model based on selection binding', async(() => {
+      it('sets selection model based on selection binding', async () => {
         fixture.componentInstance.selection = 'test';
         fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          expect(selectionService.selectionModel.containsItem('test')).toBeTrue();
-        });
-      }));
+        await fixture.whenStable();
+        expect(selectionService.selectionModel.containsItem('test')).toBeTrue();
+      });
 
-      it('clears selection model', async(() => {
+      it('clears selection model', async () => {
         fixture.componentInstance.selection = null;
         fixture.detectChanges();
-        fixture.whenStable().then(() => {
-          expect(selectionService.selectionModel.isEmpty()).toBeTrue();
-        });
-      }));
+        await fixture.whenStable();
+        expect(selectionService.selectionModel.isEmpty()).toBeTrue();
+      });
     });
 
     describe('Template API', function () {

--- a/projects/angular/src/forms/datepicker/date-container.spec.ts
+++ b/projects/angular/src/forms/datepicker/date-container.spec.ts
@@ -6,7 +6,7 @@
  */
 
 import { Component } from '@angular/core';
-import { async, TestBed } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { FormsModule } from '@angular/forms';
 
 import { TestContext } from '../../data/datagrid/helpers.spec';
@@ -150,16 +150,15 @@ export default function () {
         expect(document.querySelector('clr-datepicker-view-manager')).not.toBeNull();
       });
 
-      it('tracks the disabled state', async(() => {
+      it('tracks the disabled state', async () => {
         expect(context.clarityElement.className).not.toContain('clr-form-control-disabled');
         context.testComponent.disabled = true;
         context.detectChanges();
         // Have to wait for the whole control to settle or it doesn't track
-        context.fixture.whenStable().then(() => {
-          context.detectChanges();
-          expect(context.clarityElement.className).toContain('clr-form-control-disabled');
-        });
-      }));
+        await context.fixture.whenStable();
+        context.detectChanges();
+        expect(context.clarityElement.className).toContain('clr-form-control-disabled');
+      });
 
       it('should set disabled state when dateFormControlService.disabled is true', () => {
         dateFormControlService.disabled = true;

--- a/projects/angular/src/forms/datepicker/date-input.spec.ts
+++ b/projects/angular/src/forms/datepicker/date-input.spec.ts
@@ -582,30 +582,26 @@ export default function () {
         expect(TestBed.inject(NgControlService).setControl).toHaveBeenCalled();
       }));
 
-      it('marks the form as touched when the markAsTouched event is received', done => {
-        fixture.whenStable().then(() => {
-          const form = fixture.componentInstance.templateForm.form;
-          expect(form.get('date').touched).toBe(false);
+      it('marks the form as touched when the markAsTouched event is received', async () => {
+        await fixture.whenStable();
+        const form = fixture.componentInstance.templateForm.form;
+        expect(form.get('date').touched).toBe(false);
 
-          dateFormControlService.markAsTouched();
+        dateFormControlService.markAsTouched();
 
-          fixture.detectChanges();
-          expect(form.get('date').touched).toBe(true);
-          done();
-        });
+        fixture.detectChanges();
+        expect(form.get('date').touched).toBe(true);
       });
 
-      it('marks the form as dirty when the markAsDirty event is received', done => {
-        fixture.whenStable().then(() => {
-          const form = fixture.componentInstance.templateForm.form;
-          expect(form.get('date').dirty).toBe(false);
+      it('marks the form as dirty when the markAsDirty event is received', async () => {
+        await fixture.whenStable();
+        const form = fixture.componentInstance.templateForm.form;
+        expect(form.get('date').dirty).toBe(false);
 
-          dateFormControlService.markAsDirty();
+        dateFormControlService.markAsDirty();
 
-          fixture.detectChanges();
-          expect(form.get('date').dirty).toBe(true);
-          done();
-        });
+        fixture.detectChanges();
+        expect(form.get('date').dirty).toBe(true);
       });
 
       it('outputs the date when the user manually changes the date', () => {

--- a/projects/angular/src/forms/tests/container.spec.ts
+++ b/projects/angular/src/forms/tests/container.spec.ts
@@ -5,7 +5,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { TestBed, waitForAsync } from '@angular/core/testing';
+import { TestBed } from '@angular/core/testing';
 import { FormsModule, NgControl, ReactiveFormsModule } from '@angular/forms';
 import { By } from '@angular/platform-browser';
 
@@ -216,21 +216,20 @@ function fullSpec(description, testContainer, directives: any | any[], testCompo
       expect(container.showInvalid).toBeTrue();
     });
 
-    it('tracks the disabled state', waitForAsync(() => {
+    it('tracks the disabled state', async () => {
       const test = fixture.debugElement.componentInstance;
       test.disabled = true;
       fixture.detectChanges();
       // Have to wait for the whole control to settle or it doesn't track
-      fixture.whenStable().then(() => {
-        expect(containerEl.className).not.toContain('clr-form-control-disabled');
-        if (test.form) {
-          // Handle setting disabled based on reactive form
-          test.form.get('model').reset({ value: '', disabled: true });
-        }
-        fixture.detectChanges();
-        expect(containerEl.className).toContain('clr-form-control-disabled');
-      });
-    }));
+      await fixture.whenStable();
+      expect(containerEl.className).not.toContain('clr-form-control-disabled');
+      if (test.form) {
+        // Handle setting disabled based on reactive form
+        test.form.get('model').reset({ value: '', disabled: true });
+      }
+      fixture.detectChanges();
+      expect(containerEl.className).toContain('clr-form-control-disabled');
+    });
 
     it('implements ngOnDestroy', () => {
       expect(container.ngOnDestroy).toBeDefined();

--- a/projects/angular/src/layout/vertical-nav/vertical-nav-group.spec.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav-group.spec.ts
@@ -74,7 +74,7 @@ export default function (): void {
         expect(navGroup.expandAnimationState).toBe('collapsed');
       });
 
-      it('provides a method which toggles the expanded state of a nav group', () => {
+      it('provides a method which toggles the expanded state of a nav group', async () => {
         expect(navGroup.expanded).toBe(false);
 
         navGroup.toggleExpand();
@@ -86,13 +86,12 @@ export default function (): void {
         fixture.detectChanges();
         expect(navGroup.expandAnimationState).toBe('collapsed');
 
-        fixture.whenStable().then(() => {
-          expect(navGroup.expanded).toBe(false);
-          expect(expandService.expanded).toBe(false);
-        });
+        await fixture.whenStable();
+        expect(navGroup.expanded).toBe(false);
+        expect(expandService.expanded).toBe(false);
       });
 
-      it('sets the expanded state to false when the nav is collapsed', () => {
+      it('sets the expanded state to false when the nav is collapsed', async () => {
         vertNavService.collapsible = true;
 
         navGroup.toggleExpand();
@@ -103,10 +102,9 @@ export default function (): void {
 
         fixture.detectChanges();
 
-        fixture.whenStable().then(() => {
-          expect(navGroup.expandAnimationState).toBe('collapsed');
-          expect(navGroup.expanded).toBe(false);
-        });
+        await fixture.whenStable();
+        expect(navGroup.expandAnimationState).toBe('collapsed');
+        expect(navGroup.expanded).toBe(false);
       });
 
       it(
@@ -167,7 +165,7 @@ export default function (): void {
         fixture.destroy();
       });
 
-      it('provides an input to set the expanded state of the nav group', () => {
+      it('provides an input to set the expanded state of the nav group', async () => {
         expect(fixture.componentInstance.expanded).toBe(false);
 
         fixture.componentInstance.expanded = true;
@@ -181,10 +179,9 @@ export default function (): void {
 
         // when stable because collapse animation happens first.
         // need when stable for the nav group to complete the animation.
-        fixture.whenStable().then(() => {
-          expect(navGroup.expanded).toBe(false);
-          expect(expandService.expanded).toBe(false);
-        });
+        await fixture.whenStable();
+        expect(navGroup.expanded).toBe(false);
+        expect(expandService.expanded).toBe(false);
       });
 
       it('emits the expanded state when its changed', fakeAsync(function () {

--- a/projects/demo/src/app/datagrid/full/full.ts
+++ b/projects/demo/src/app/datagrid/full/full.ts
@@ -8,7 +8,7 @@
 import { Component, TrackByFunction } from '@angular/core';
 import { ClrDatagridStateInterface } from '@clr/angular';
 
-import { FetchResult, Inventory } from '../inventory/inventory';
+import { Inventory } from '../inventory/inventory';
 import { User } from '../inventory/user';
 import { ColorFilter } from '../utils/color-filter';
 import { PokemonComparator } from '../utils/pokemon-comparator';
@@ -75,7 +75,7 @@ export class DatagridFullDemo {
     });
   }
 
-  refresh(state: ClrDatagridStateInterface) {
+  async refresh(state: ClrDatagridStateInterface) {
     if (!this.isServerDriven) {
       return;
     }
@@ -91,15 +91,15 @@ export class DatagridFullDemo {
         }
       }
     }
-    this.inventory
+
+    const result = await this.inventory
       .filter(filters)
       .sort(state.sort as { by: string; reverse: boolean })
-      .fetch(state.page && state.page.from, state.page && state.page.size)
-      .then((result: FetchResult) => {
-        this.users = result.users;
-        this.total = result.length;
-        this.loading = false;
-      });
+      .fetch(state.page && state.page.from, state.page && state.page.size);
+
+    this.users = result.users;
+    this.total = result.length;
+    this.loading = false;
   }
 
   clrDgActionOverflowOpenChangeFn($event: boolean) {

--- a/projects/demo/src/app/datagrid/preserve-selection/preserve-selection.ts
+++ b/projects/demo/src/app/datagrid/preserve-selection/preserve-selection.ts
@@ -8,7 +8,7 @@
 import { Component, TrackByFunction } from '@angular/core';
 import { ClrDatagridStateInterface } from '@clr/angular';
 
-import { FetchResult, Inventory } from '../inventory/inventory';
+import { Inventory } from '../inventory/inventory';
 import { User } from '../inventory/user';
 
 @Component({
@@ -58,7 +58,7 @@ export class DatagridPreserveSelectionDemo {
   trackByIndex: TrackByFunction<User> = index => index;
   trackById: TrackByFunction<User> = (_index, item) => item.id;
 
-  refresh(state: ClrDatagridStateInterface) {
+  async refresh(state: ClrDatagridStateInterface) {
     this.loading = true;
     const filters: { [prop: string]: any[] } = {};
     if (state.filters) {
@@ -67,14 +67,14 @@ export class DatagridPreserveSelectionDemo {
         filters[property] = [value];
       }
     }
-    this.inventory
+
+    const result = await this.inventory
       .filter(filters)
       .sort(state.sort as { by: string; reverse: boolean })
-      .fetch(state.page.size * (state.page.current - 1), state.page.size)
-      .then((result: FetchResult) => {
-        this.serverTrackByIdUsers = result.users;
-        this.loading = false;
-      });
+      .fetch(state.page.size * (state.page.current - 1), state.page.size);
+
+    this.serverTrackByIdUsers = result.users;
+    this.loading = false;
   }
 
   updateInventorySize(): void {

--- a/projects/demo/src/app/datagrid/selection-single/selection-single.ts
+++ b/projects/demo/src/app/datagrid/selection-single/selection-single.ts
@@ -8,7 +8,7 @@
 import { Component, TrackByFunction } from '@angular/core';
 import { ClrDatagridStateInterface } from '@clr/angular';
 
-import { FetchResult, Inventory } from '../inventory/inventory';
+import { Inventory } from '../inventory/inventory';
 import { User } from '../inventory/user';
 
 @Component({
@@ -43,7 +43,7 @@ export class DatagridSelectionSingleDemo {
   trackByIndex: TrackByFunction<User> = index => index;
   trackById: TrackByFunction<User> = (_index, item) => item.id;
 
-  refresh(state: ClrDatagridStateInterface) {
+  async refresh(state: ClrDatagridStateInterface) {
     // this.loading = true;
     const filters: { [prop: string]: any[] } = {};
     if (state.filters) {
@@ -52,16 +52,16 @@ export class DatagridSelectionSingleDemo {
         filters[property] = [value];
       }
     }
-    this.inventory
+
+    const result = await this.inventory
       .filter(filters)
       .sort(state.sort as { by: string; reverse: boolean })
-      .fetch(state.page.size * (state.page.current - 1), state.page.size)
-      .then((result: FetchResult) => {
-        setTimeout(() => {
-          this.trackByIdServerUsers = result.users;
-          this.total = result.length;
-          this.loading = false;
-        });
-      });
+      .fetch(state.page.size * (state.page.current - 1), state.page.size);
+
+    setTimeout(() => {
+      this.trackByIdServerUsers = result.users;
+      this.total = result.length;
+      this.loading = false;
+    });
   }
 }

--- a/projects/demo/src/app/datagrid/selection/selection.ts
+++ b/projects/demo/src/app/datagrid/selection/selection.ts
@@ -8,7 +8,7 @@
 import { Component, TrackByFunction } from '@angular/core';
 import { ClrDatagridStateInterface } from '@clr/angular';
 
-import { FetchResult, Inventory } from '../inventory/inventory';
+import { Inventory } from '../inventory/inventory';
 import { User } from '../inventory/user';
 
 @Component({
@@ -39,7 +39,7 @@ export class DatagridSelectionDemo {
   trackByIndex: TrackByFunction<User> = index => index;
   trackById: TrackByFunction<User> = (_index, item) => item.id;
 
-  refresh(state: ClrDatagridStateInterface) {
+  async refresh(state: ClrDatagridStateInterface) {
     this.loading = true;
     const filters: { [prop: string]: any[] } = {};
     if (state.filters) {
@@ -48,13 +48,13 @@ export class DatagridSelectionDemo {
         filters[property] = [value];
       }
     }
-    this.inventory
+
+    const result = await this.inventory
       .filter(filters)
       .sort(state.sort as { by: string; reverse: boolean })
-      .fetch(state.page.size * (state.page.current - 1), state.page.size)
-      .then((result: FetchResult) => {
-        this.serverTrackByIdUsers = result.users;
-        this.loading = false;
-      });
+      .fetch(state.page.size * (state.page.current - 1), state.page.size);
+
+    this.serverTrackByIdUsers = result.users;
+    this.loading = false;
   }
 }

--- a/projects/demo/src/app/datagrid/server-driven/server-driven.ts
+++ b/projects/demo/src/app/datagrid/server-driven/server-driven.ts
@@ -8,7 +8,7 @@
 import { Component } from '@angular/core';
 import { ClrDatagridStateInterface } from '@clr/angular';
 
-import { FetchResult, Inventory } from '../inventory/inventory';
+import { Inventory } from '../inventory/inventory';
 import { User } from '../inventory/user';
 
 @Component({
@@ -28,7 +28,7 @@ export class DatagridServerDrivenDemo {
     inventory.reset();
   }
 
-  refresh(state: ClrDatagridStateInterface<User>) {
+  async refresh(state: ClrDatagridStateInterface<User>) {
     this.loading = true;
     const filters: { [prop: string]: any[] } = {};
     if (state.filters) {
@@ -37,14 +37,13 @@ export class DatagridServerDrivenDemo {
         filters[property] = [value];
       }
     }
-    this.inventory
+    const result = await this.inventory
       .filter(filters)
       .sort(state.sort as { by: string; reverse: boolean })
-      .fetch(state.page.size * (state.page.current - 1), state.page.size)
-      .then((result: FetchResult) => {
-        this.users = result.users;
-        this.total = result.length;
-        this.loading = false;
-      });
+      .fetch(state.page.size * (state.page.current - 1), state.page.size);
+
+    this.users = result.users;
+    this.total = result.length;
+    this.loading = false;
   }
 }

--- a/projects/demo/src/app/datagrid/virtual-scroll-server-side/virtual-scroll-server-side.ts
+++ b/projects/demo/src/app/datagrid/virtual-scroll-server-side/virtual-scroll-server-side.ts
@@ -10,7 +10,7 @@ import { ChangeDetectorRef, Component, OnInit } from '@angular/core';
 import { ClrDatagridStateInterface } from '@clr/angular';
 import { Observable } from 'rxjs';
 
-import { FetchResult, Inventory } from '../inventory/inventory';
+import { Inventory } from '../inventory/inventory';
 import { User } from '../inventory/user';
 import { ColorFilter } from '../utils/color-filter';
 
@@ -86,7 +86,7 @@ export class DatagridVirtualScrollServerSideDemo implements OnInit {
     }, 2000);
   }
 
-  refresh(state: ClrDatagridStateInterface) {
+  async refresh(state: ClrDatagridStateInterface) {
     const filters: { [key: string]: any[] } = {};
     this.loading = true;
 
@@ -101,13 +101,12 @@ export class DatagridVirtualScrollServerSideDemo implements OnInit {
       }
     }
 
-    this._inventory
+    const result = await this._inventory
       .filter(filters)
       .sort(state.sort as { by: string; reverse: boolean })
-      .fetch()
-      .then((result: FetchResult) => {
-        this._inventory.getAllUsersSubject().next(result.users);
-        this.loading = false;
-      });
+      .fetch();
+
+    this._inventory.getAllUsersSubject().next(result.users);
+    this.loading = false;
   }
 }


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Refactoring (no functional changes, no api changes)

## What is the current behavior?

Legacy `.then` syntax is used in several places.

Issue Number: CDE-2082

## What is the new behavior?

Modern `async`/`await` syntax is used.

## Does this PR introduce a breaking change?

No.