### PR TITLE
fix(datagrid): use outline token for cell focus (backport to 16.x)

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -567,7 +567,13 @@
       border: none;
 
       &:focus {
-        outline: -webkit-focus-ring-color solid variables.$clr_baselineRem_2px;
+        @include mixins.css-var(
+          outline,
+          cds-alias-object-interaction-outline,
+          Highlight solid variables.$clr_baselineRem_2px,
+          variables.$clr-use-custom-properties
+        );
+        outline-color: -webkit-focus-ring-color;
         outline-offset: -(variables.$clr_baselineRem_2px);
       }
 
@@ -999,7 +1005,13 @@
       }
 
       &:focus {
-        outline: -webkit-focus-ring-color solid variables.$clr_baselineRem_2px;
+        @include mixins.css-var(
+          outline,
+          cds-alias-object-interaction-outline,
+          Highlight solid variables.$clr_baselineRem_2px,
+          variables.$clr-use-custom-properties
+        );
+        outline-color: -webkit-focus-ring-color;
         outline-offset: -(variables.$clr_baselineRem_2px);
       }
 


### PR DESCRIPTION
Backport of #1467 

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Focus outline for datagrid cells is not visible in firefox browser.

Issue Number: CDE-2124

## What is the new behavior?
Using object interaction outline token to show the focus for all browsers.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
