### PR TITLE
chore(datepicker): use static dates in date range picker screenshots

### DIFF
--- a/.storybook/stories/datepicker/datepicker.stories.ts
+++ b/.storybook/stories/datepicker/datepicker.stories.ts
@@ -81,7 +81,7 @@ export const Datepicker: StoryObj = {
 export const DefaultDate: StoryObj = {
   render: DatePickerTemplate,
   args: {
-    clrDate: 1641038400000,
+    clrDate: '2022-01-01 00:00:00.000',
   },
 };
 

--- a/.storybook/stories/datepicker/daterangepicker.stories.ts
+++ b/.storybook/stories/datepicker/daterangepicker.stories.ts
@@ -93,8 +93,8 @@ export const DateRangePicker: StoryObj = {
 export const DefaultDate: StoryObj = {
   render: DateRangePickerTemplate,
   args: {
-    clrRangeStartDate: Date.now() - 2592000000,
-    clrRangeEndDate: Date.now() + 2592000000,
+    clrRangeStartDate: '2024-06-22 00:00:00.000',
+    clrRangeEndDate: '2024-08-21 00:00:00.000',
   },
 };
 


### PR DESCRIPTION
This prevents the visual regression tests from failing due to the current date being different.

I also changed the default value in the single date picker story to be more readable.