### PR TITLE
chore: refactor active element assertions

### DIFF
--- a/projects/angular/src/button/providers/button-group-focus-handler.spec.ts
+++ b/projects/angular/src/button/providers/button-group-focus-handler.spec.ts
@@ -102,7 +102,7 @@ export default function (): void {
         this.focusHandler.initialFocus = InitialFocus.LAST_ITEM;
         this.focusHandler.initialize({ menu: this.menu, menuToggle: this.menuToggle });
         const lastChild = this.menu.children[this.menu.children.length - 1];
-        expect(document.activeElement).toEqual(lastChild);
+        expect(document.activeElement).toBe(lastChild);
       });
 
       it('focus last button in the menu on key down events', function (this: TestContext) {
@@ -110,7 +110,7 @@ export default function (): void {
         this.menu.dispatchEvent(new KeyboardEvent('keydown', { key: Keys.ArrowDown }));
         this.menu.dispatchEvent(new KeyboardEvent('keydown', { key: Keys.ArrowDown }));
         const lastChild = this.menu.children[this.menu.children.length - 1];
-        expect(document.activeElement).toEqual(lastChild);
+        expect(document.activeElement).toBe(lastChild);
       });
 
       it('does not prevent moving focus to a different part of the page', function (this: TestContext) {

--- a/projects/angular/src/data/datagrid/datagrid-action-overflow.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-action-overflow.spec.ts
@@ -107,7 +107,7 @@ export default function (): void {
       context.detectChanges();
       await context.fixture.whenStable();
       const firstButton: HTMLButtonElement = context.testComponent.actionItem.nativeElement;
-      expect(document.activeElement).toEqual(firstButton);
+      expect(document.activeElement).toBe(firstButton);
     });
   });
 }

--- a/projects/angular/src/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
@@ -219,25 +219,25 @@ export default function (): void {
         sleep(10);
         fixture.detectChanges();
 
-        expect(document.activeElement).toEqual(headerCheckboxCell);
+        expect(document.activeElement).toBe(headerCheckboxCell);
 
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: 'PageDown' }));
         // active checkbox input with ID clr-dg-row-cb364
-        expect(document.activeElement).toEqual(grid.querySelectorAll('[type=checkbox]')[22]);
+        expect(document.activeElement).toBe(grid.querySelectorAll('[type=checkbox]')[22]);
 
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: 'PageDown' }));
         sleep();
         fixture.whenStable();
         fixture.whenRenderingDone();
         // active checkbox input with ID clr-dg-row-cb383
-        expect(document.activeElement).toEqual(grid.querySelectorAll('[type=checkbox]')[41]);
+        expect(document.activeElement).toBe(grid.querySelectorAll('[type=checkbox]')[41]);
 
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: 'PageUp' }));
         sleep();
         fixture.whenStable();
         fixture.whenRenderingDone();
         // active checkbox input with ID clr-dg-row-cb360
-        expect(document.activeElement).toEqual(grid.querySelectorAll('[type=checkbox]')[19]);
+        expect(document.activeElement).toBe(grid.querySelectorAll('[type=checkbox]')[19]);
 
         flush();
         flushMicrotasks();

--- a/projects/angular/src/data/datagrid/datagrid.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid.spec.ts
@@ -696,17 +696,17 @@ export default function (): void {
         });
 
         it('focuses the datagrid on page change', function () {
-          expect(context.clarityDirective.datagridTable.nativeElement).not.toEqual(document.activeElement);
+          expect(document.activeElement).not.toBe(context.clarityDirective.datagridTable.nativeElement);
           context.getClarityProvider(Page).current = 2;
-          expect(context.clarityDirective.datagridTable.nativeElement).toEqual(document.activeElement);
+          expect(document.activeElement).toBe(context.clarityDirective.datagridTable.nativeElement);
         });
 
         it('does not focus the datagrid on page change when disabled', function () {
           context.testComponent.disableFocus = true;
           context.detectChanges();
-          expect(context.clarityDirective.datagridTable.nativeElement).not.toEqual(document.activeElement);
+          expect(document.activeElement).not.toBe(context.clarityDirective.datagridTable.nativeElement);
           context.getClarityProvider(Page).current = 2;
-          expect(context.clarityDirective.datagridTable.nativeElement).not.toEqual(document.activeElement);
+          expect(document.activeElement).not.toBe(context.clarityDirective.datagridTable.nativeElement);
         });
       });
     });
@@ -900,7 +900,7 @@ export default function (): void {
         expect(cells.length).toBe(12); // 3*2 data, 3 select radios, 3 headers
         // need to start with this cell exactly, because it has tabindex=0
         cells[0].focus();
-        expect(document.activeElement).toEqual(cells[0]);
+        expect(document.activeElement).toBe(cells[0]);
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: Keys.ArrowRight }));
         // second time, to avoid cycling over cells with radios
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: Keys.ArrowRight }));
@@ -917,32 +917,32 @@ export default function (): void {
         const grid = context.clarityElement.querySelector('[role=grid]');
         const cells = grid.querySelectorAll('[role=gridcell], [role=columnheader]');
         cells[0].focus();
-        expect(document.activeElement).toEqual(cells[0]);
+        expect(document.activeElement).toBe(cells[0]);
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: Keys.ArrowDown }));
-        expect(document.activeElement).toEqual(cells[3].querySelector('[type=radio]'));
+        expect(document.activeElement).toBe(cells[3].querySelector('[type=radio]'));
       });
 
       it('Does not move focus to the placeholder element', function () {
         const grid = context.clarityElement.querySelector('[role=grid]');
         const cells = grid.querySelectorAll('[role=gridcell], [role=columnheader]');
         cells[0].focus();
-        expect(document.activeElement).toEqual(cells[0]);
+        expect(document.activeElement).toBe(cells[0]);
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: Keys.ArrowDown }));
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: Keys.ArrowDown }));
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: Keys.ArrowDown }));
-        expect(document.activeElement).toEqual(cells[9].querySelector('[type=radio]'));
+        expect(document.activeElement).toBe(cells[9].querySelector('[type=radio]'));
         // we're at the edge, then we click once more to get to the placeholder
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: Keys.ArrowDown }));
-        expect(document.activeElement).toEqual(cells[9].querySelector('[type=radio]'));
+        expect(document.activeElement).toBe(cells[9].querySelector('[type=radio]'));
       });
 
       it('Moves focus to a clicked element', function () {
         const grid = context.clarityElement.querySelector('[role=grid]');
         const cells = grid.querySelectorAll('[role=gridcell], [role=columnheader]');
         const testCell = 7;
-        expect(document.activeElement).not.toEqual(cells[testCell]);
+        expect(document.activeElement).not.toBe(cells[testCell]);
         cells[testCell].dispatchEvent(new MouseEvent('mousedown', { buttons: 1, bubbles: true }));
-        expect(document.activeElement).toEqual(cells[testCell]);
+        expect(document.activeElement).toBe(cells[testCell]);
       });
 
       it('Moves focus on PageDown and PageUp', function () {
@@ -951,37 +951,37 @@ export default function (): void {
 
         // focus at most left header cell
         cells[0].focus();
-        expect(document.activeElement).toEqual(cells[0]);
+        expect(document.activeElement).toBe(cells[0]);
 
         // focus at bottom datagrid radio input
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: 'PageDown' }));
-        expect(document.activeElement).toEqual(cells[9].querySelector('[type=radio]'));
+        expect(document.activeElement).toBe(cells[9].querySelector('[type=radio]'));
 
         // focus at top datagrid radio input
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: 'PageUp' }));
-        expect(document.activeElement).toEqual(cells[3].querySelector('[type=radio]'));
+        expect(document.activeElement).toBe(cells[3].querySelector('[type=radio]'));
       });
 
       it('Moves focus on Home and End', function () {
         const grid = context.clarityElement.querySelector('[role=grid]');
         const cells = grid.querySelectorAll('[role=gridcell], [role=columnheader]');
         cells[0].focus();
-        expect(document.activeElement).toEqual(cells[0]);
+        expect(document.activeElement).toBe(cells[0]);
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: 'End' }));
-        expect(document.activeElement).toEqual(cells[2]);
+        expect(document.activeElement).toBe(cells[2]);
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: 'Home' }));
-        expect(document.activeElement).toEqual(cells[0]);
+        expect(document.activeElement).toBe(cells[0]);
       });
 
       it('Moves focus on Ctrl-Home and Ctrl-End', function () {
         const grid = context.clarityElement.querySelector('[role=grid]');
         const cells = grid.querySelectorAll('[role=gridcell], [role=columnheader]');
         cells[0].focus();
-        expect(document.activeElement).toEqual(cells[0]);
+        expect(document.activeElement).toBe(cells[0]);
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: 'End', ctrlKey: true }));
-        expect(document.activeElement).toEqual(cells[11]);
+        expect(document.activeElement).toBe(cells[11]);
         grid.dispatchEvent(new KeyboardEvent('keydown', { code: 'Home', ctrlKey: true }));
-        expect(document.activeElement).toEqual(cells[0]);
+        expect(document.activeElement).toBe(cells[0]);
       });
     });
 

--- a/projects/angular/src/data/datagrid/providers/detail.service.spec.ts
+++ b/projects/angular/src/data/datagrid/providers/detail.service.spec.ts
@@ -42,7 +42,7 @@ export default function (): void {
       provider.open('value', button);
       expect(provider.isOpen);
       provider.close();
-      expect(document.activeElement).toEqual(button);
+      expect(document.activeElement).toBe(button);
       expect(button.focus).toHaveBeenCalled();
       document.body.removeChild(button);
     });

--- a/projects/angular/src/forms/datepicker/date-container.spec.ts
+++ b/projects/angular/src/forms/datepicker/date-container.spec.ts
@@ -101,7 +101,7 @@ export default function () {
         context.detectChanges();
         actionButton.click();
         context.detectChanges();
-        expect(document.activeElement).toEqual(actionButton);
+        expect(document.activeElement).toBe(actionButton);
       });
 
       it('should not call focus when date-picker is not visible', () => {

--- a/projects/angular/src/modal/modal.spec.ts
+++ b/projects/angular/src/modal/modal.spec.ts
@@ -181,7 +181,7 @@ describe('Modal', () => {
   }));
 
   it('focuses on the title when opened', fakeAsync(() => {
-    expect(document.activeElement).toEqual(fixture.nativeElement.querySelector('.modal-title-wrapper'));
+    expect(document.activeElement).toBe(fixture.nativeElement.querySelector('.modal-title-wrapper'));
   }));
 
   it('supports a clrModalSize option', fakeAsync(() => {

--- a/projects/angular/src/modal/side-panel.spec.ts
+++ b/projects/angular/src/modal/side-panel.spec.ts
@@ -158,7 +158,7 @@ describe('Side Panel', () => {
   }));
 
   it('focuses on the title when opened', fakeAsync(() => {
-    expect(document.activeElement).toEqual(fixture.nativeElement.querySelector('.modal-title-wrapper'));
+    expect(document.activeElement).toBe(fixture.nativeElement.querySelector('.modal-title-wrapper'));
   }));
 
   it('supports a clrSidePanelSize option', fakeAsync(() => {

--- a/projects/angular/src/wizard/wizard.spec.ts
+++ b/projects/angular/src/wizard/wizard.spec.ts
@@ -798,7 +798,7 @@ export default function (): void {
           wizard.pageCollection.lastPage.makeCurrent();
           context.detectChanges();
           const titleString = context.hostElement.querySelector('.modal-title').textContent.trim();
-          expect(titleString).toEqual(document.activeElement.textContent.trim());
+          expect(document.activeElement.textContent.trim()).toEqual(titleString);
         });
       });
     });

--- a/projects/angular/src/wizard/wizard.spec.ts
+++ b/projects/angular/src/wizard/wizard.spec.ts
@@ -798,7 +798,7 @@ export default function (): void {
           wizard.pageCollection.lastPage.makeCurrent();
           context.detectChanges();
           const titleString = context.hostElement.querySelector('.modal-title').textContent.trim();
-          expect(document.activeElement.textContent.trim()).toEqual(titleString);
+          expect(document.activeElement.textContent.trim()).toBe(titleString);
         });
       });
     });


### PR DESCRIPTION
- Use `toBe` instead of `toEqual`.
- Write assertions as `expect(actualValue).toBe(expectedValue)`.