### PR TITLE
chore(datagrid): demo full page expose name filter to control form

### DIFF
--- a/projects/demo/src/app/datagrid/full/full.html
+++ b/projects/demo/src/app/datagrid/full/full.html
@@ -50,6 +50,12 @@
     </select>
   </clr-select-container>
 
+  <clr-input-container *ngIf="!isServerDriven">
+    <label>Name filter</label>
+    <input clrInput type="text" name="nameFilter" [(ngModel)]="options.nameFilter" />
+    <clr-control-helper>Pre applied client side filter</clr-control-helper>
+  </clr-input-container>
+
   <button class="btn btn-primary">Apply</button>
 </form>
 
@@ -66,7 +72,7 @@
     <clr-dg-column>
       <ng-container *clrDgHideableColumn>User ID</ng-container>
     </clr-dg-column>
-    <clr-dg-column [clrDgField]="'name'" [(clrFilterValue)]="nameFilter">
+    <clr-dg-column [clrDgField]="'name'" [(clrFilterValue)]="options.nameFilter">
       <ng-container *clrDgHideableColumn>Name</ng-container>
     </clr-dg-column>
     <clr-dg-column [clrDgField]="'creation'">

--- a/projects/demo/src/app/datagrid/full/full.ts
+++ b/projects/demo/src/app/datagrid/full/full.ts
@@ -29,6 +29,7 @@ export class DatagridFullDemo {
 
     server: false,
     latency: '500',
+    nameFilter: 'd',
   };
 
   resetting = true;
@@ -40,8 +41,6 @@ export class DatagridFullDemo {
   isServerDriven = false;
   loading = true;
   total: number;
-
-  nameFilter = 'd';
 
   pokemonComparator = new PokemonComparator();
   pokemonFilter = new PokemonFilter();


### PR DESCRIPTION
## What is the current behavior?
Datagrid demo `full` page have pre applied filter on name column on client side datagrid. It may confuse that some of the items are not loaded.

Issue Number: CDE-1097

## What is the new behavior?
Pre applied filter is exposed in the control form and easly used.