### PR TITLE
fix(modal): provide modal config service in root and export

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -2807,7 +2807,6 @@ export class ClrMainContainerModule {
 export class ClrModal implements OnChanges, OnDestroy {
     // Warning: (ae-forgotten-export) The symbol "ScrollingService" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "ModalStackService" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "ClrModalConfigurationService" needs to be exported by the entry point index.d.ts
     constructor(_scrollingService: ScrollingService, commonStrings: ClrCommonStringsService, modalStackService: ModalStackService, configuration: ClrModalConfigurationService);
     // (undocumented)
     altClose: EventEmitter<boolean>;
@@ -2871,6 +2870,18 @@ export class ClrModalBody implements OnDestroy {
     static ɵdir: i0.ɵɵDirectiveDeclaration<ClrModalBody, ".modal-body", never, {}, {}, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrModalBody, never>;
+}
+
+// @public (undocumented)
+export class ClrModalConfigurationService {
+    // (undocumented)
+    backdrop: boolean;
+    // (undocumented)
+    fadeMove: string;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<ClrModalConfigurationService, never>;
+    // (undocumented)
+    static ɵprov: i0.ɵɵInjectableDeclaration<ClrModalConfigurationService>;
 }
 
 // @public (undocumented)

--- a/projects/angular/src/modal/index.ts
+++ b/projects/angular/src/modal/index.ts
@@ -7,6 +7,7 @@
 
 export * from './modal';
 export * from './modal.module';
+export * from './modal-configuration.service';
 export * from './side-panel.module';
 export * from './modal-body';
 export * from './side-panel';

--- a/projects/angular/src/modal/modal-configuration.service.ts
+++ b/projects/angular/src/modal/modal-configuration.service.ts
@@ -7,7 +7,7 @@
 
 import { Injectable } from '@angular/core';
 
-@Injectable()
+@Injectable({ providedIn: 'root' })
 export class ClrModalConfigurationService {
   fadeMove = 'fadeDown';
   backdrop = true;

--- a/projects/angular/src/modal/modal.module.ts
+++ b/projects/angular/src/modal/modal.module.ts
@@ -13,7 +13,6 @@ import { ClrIconModule } from '../icon/icon.module';
 import { CdkTrapFocusModule } from '../utils/cdk/cdk-trap-focus.module';
 import { ClrModal } from './modal';
 import { ClrModalBody } from './modal-body';
-import { ClrModalConfigurationService } from './modal-configuration.service';
 
 export const CLR_MODAL_DIRECTIVES: Type<any>[] = [ClrModal, ClrModalBody];
 
@@ -21,7 +20,6 @@ export const CLR_MODAL_DIRECTIVES: Type<any>[] = [ClrModal, ClrModalBody];
   imports: [CommonModule, CdkTrapFocusModule, ClrIconModule],
   declarations: [CLR_MODAL_DIRECTIVES],
   exports: [CLR_MODAL_DIRECTIVES, ClrIconModule],
-  providers: [ClrModalConfigurationService],
 })
 export class ClrModalModule {
   constructor() {


### PR DESCRIPTION
This fixes a dependency injection error when using the `VmwNgxModalService`.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The following error occurs when using `VmwNgxModalService`:

```
ERROR NullInjectorError: R3InjectorError(Environment Injector)[ClrModalConfigurationService -> ClrModalConfigurationService]: 
  NullInjectorError: No provider for ClrModalConfigurationService!
    at NullInjector.get (core.mjs:1635:21)
    at R3Injector.get (core.mjs:3017:27)
    at R3Injector.get (core.mjs:3017:27)
    at ChainedInjector.get (core.mjs:5288:32)
    at lookupTokenUsingModuleInjector (core.mjs:5631:31)
    at getOrCreateInjectable (core.mjs:5677:10)
    at ɵɵdirectiveInject (core.mjs:11586:17)
    at NodeInjectorFactory.ClrModal_Factory [as factory] (clr-angular.mjs:32885:177)
    at getNodeInjectable (core.mjs:5871:38)
    at instantiateAllDirectives (core.mjs:12403:23)
```

Issue Number: N/A

## What is the new behavior?

No error occurs when using `VmwNgxModalService`.

## Does this PR introduce a breaking change?

No.