### PR TITLE
fix(wizard): improve screen reader text for stepnav items

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1049,6 +1049,7 @@ export interface ClrCommonStrings {
     // (undocumented)
     verticalNavToggle: string;
     warning: string;
+    wizardStep: string;
     wizardStepError: string;
     wizardStepnavAriaLabel: string;
     wizardStepSuccess: string;

--- a/projects/angular/src/utils/i18n/common-strings.default.ts
+++ b/projects/angular/src/utils/i18n/common-strings.default.ts
@@ -101,6 +101,7 @@ export const commonStringsDefault: ClrCommonStrings = {
   datagridExpandableRowContent: 'Expandable row content',
   datagridExpandableRowsHelperText: `Screen reader table commands may not work for viewing expanded content, please use your screen reader's browse mode to read the content exposed by this button`,
   // Wizard
+  wizardStep: 'Step',
   wizardStepSuccess: 'Completed',
   wizardStepError: 'Error',
   wizardStepnavAriaLabel: 'Step navigation',

--- a/projects/angular/src/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/src/utils/i18n/common-strings.interface.ts
@@ -266,6 +266,11 @@ export interface ClrCommonStrings {
   comboboxOpen: string;
 
   /**
+   * Wizard: Screen-reader text for "step" (read before step number).
+   */
+  wizardStep: string;
+
+  /**
    * Wizard: Screen-reader text for completed step.
    */
   wizardStepSuccess: string;

--- a/projects/angular/src/wizard/wizard-stepnav-item.spec.ts
+++ b/projects/angular/src/wizard/wizard-stepnav-item.spec.ts
@@ -255,10 +255,12 @@ export default function (): void {
         const expectedUpdatedTitle = 'This is my bar';
 
         it('projects page nav title as expected', () => {
-          expect(myStepnavItem.textContent.trim()).toBe(expectedInitialTitle, 'projects initial value');
+          const titleElement = myStepnavItem.querySelector('.clr-wizard-stepnav-link-title');
+
+          expect(titleElement.textContent.trim()).toBe(expectedInitialTitle, 'projects initial value');
           fixture.componentInstance.projector = 'bar';
           fixture.detectChanges();
-          expect(myStepnavItem.textContent.trim()).toBe(expectedUpdatedTitle, 'projects updated value');
+          expect(titleElement.textContent.trim()).toBe(expectedUpdatedTitle, 'projects updated value');
         });
       });
     });
@@ -475,7 +477,10 @@ export default function (): void {
           fakeOutPage.completed = true;
           fakeOutPage.hasError = true;
           fixture.detectChanges();
-          expect(myStepnavItem.querySelector('cds-icon[shape="error-standard"]')).not.toBeNull();
+
+          const iconElement = myStepnavItem.querySelector('cds-icon[shape="error-standard"]');
+          expect(iconElement).not.toBeNull();
+          expect(iconElement.getAttribute('aria-label')).toBe('Error');
         });
 
         it('should have a cds-icon when page has is complete', () => {
@@ -486,25 +491,10 @@ export default function (): void {
           fakeOutPage.completed = true;
           fakeOutPage.hasError = false;
           fixture.detectChanges();
-          expect(myStepnavItem.querySelector('cds-icon[shape="success-standard"]')).not.toBeNull();
-        });
 
-        it('should have a span with text "Error" when page has an error', () => {
-          fakeOutPage.completed = true;
-          fakeOutPage.hasError = true;
-          fixture.detectChanges();
-          const spans: NodeList = myStepnavItem.querySelectorAll('span.clr-sr-only');
-          expect(spans.length).toEqual(1);
-          expect(spans[0].textContent).toEqual('Error');
-        });
-
-        it('should have a span with text "Completed" when page is completed', () => {
-          fakeOutPage.completed = true;
-          fakeOutPage.hasError = false;
-          fixture.detectChanges();
-          const spans: NodeList = myStepnavItem.querySelectorAll('span.clr-sr-only');
-          expect(spans.length).toEqual(1);
-          expect(spans[0].textContent).toEqual('Completed');
+          const iconElement = myStepnavItem.querySelector('cds-icon[shape="success-standard"]');
+          expect(iconElement).not.toBeNull();
+          expect(iconElement.getAttribute('aria-label')).toBe('Completed');
         });
       });
 

--- a/projects/angular/src/wizard/wizard-stepnav-item.ts
+++ b/projects/angular/src/wizard/wizard-stepnav-item.ts
@@ -22,16 +22,23 @@ import { ClrWizardPage } from './wizard-page';
       [attr.disabled]="isDisabled ? '' : null"
     >
       <div class="clr-wizard-stepnav-link-icon">
-        <cds-icon *ngIf="hasError" shape="error-standard" aria-label="error"></cds-icon>
-        <cds-icon *ngIf="!hasError && isComplete" shape="success-standard" aria-label="complete"></cds-icon>
+        <cds-icon
+          *ngIf="hasError"
+          shape="error-standard"
+          [attr.aria-label]="commonStrings.keys.wizardStepError"
+        ></cds-icon>
+        <cds-icon
+          *ngIf="!hasError && isComplete"
+          shape="success-standard"
+          [attr.aria-label]="commonStrings.keys.wizardStepSuccess"
+        ></cds-icon>
       </div>
 
+      <span class="clr-sr-only">{{ commonStrings.keys.wizardStep }}</span>
       <div class="clr-wizard-stepnav-link-page-number"><ng-content></ng-content></div>
       <span class="clr-wizard-stepnav-link-title">
         <ng-template [ngTemplateOutlet]="page.navTitle"></ng-template>
       </span>
-      <span *ngIf="hasError" class="clr-sr-only">{{ commonStrings.keys.wizardStepError }}</span>
-      <span *ngIf="!hasError && isComplete" class="clr-sr-only">{{ commonStrings.keys.wizardStepSuccess }}</span>
     </button>
   `,
   host: {


### PR DESCRIPTION
- Add "Step" before step number.
- Replace untranslated step status icon labels with translated text.

## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

- For uncompleted steps, the wizard step nav reads "1 [step title]". I doesn't read "step" before the step number.
- For completed steps, the wizard step nav reads "complete 1 [step title] completed". The first "complete" is not translated, and the second one is redundant.
- For steps with an error, the wizard step nav reads "error 1 [step title] error". The first "error" is not translated, and the second one is redundant.

Issue Number: CDE-2292

## What is the new behavior?

- For uncompleted steps, the wizard step nav reads "step 1 [step title]".
- For completed steps, the wizard step nav reads "completed step 1 [step title]".
- For steps with an error, the wizard step nav reads "error step 1 [step title]".

## Does this PR introduce a breaking change?

The "Step" text will need to be translated. We don't count new common strings as breaking changes.