### PR TITLE
chore: clean up parameter properties

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -50,6 +50,7 @@ module.exports = {
           },
         ],
         '@typescript-eslint/no-var-requires': 'error',
+        '@typescript-eslint/parameter-properties': ['error', { prefer: 'parameter-property' }],
         curly: 'error',
         'decorator-position/decorator-position': 'error',
         eqeqeq: 'error',

--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -32,7 +32,14 @@ module.exports = {
     {
       files: ['**/*.ts'],
       extends: ['eslint:recommended', 'plugin:@typescript-eslint/recommended', 'prettier'],
-      plugins: ['license-header', '@typescript-eslint', 'jasmine', 'unused-imports', 'decorator-position'],
+      plugins: [
+        'license-header',
+        '@typescript-eslint',
+        'jasmine',
+        'unused-imports',
+        'decorator-position',
+        'ng-clarity-eslint-rules',
+      ],
       rules: {
         '@typescript-eslint/explicit-member-accessibility': [
           'error',
@@ -81,6 +88,9 @@ module.exports = {
           },
         ],
         'unused-imports/no-unused-imports-ts': 'error',
+
+        // custom eslint-rules
+        'ng-clarity-eslint-rules/no-parameter-property-this-in-constructor': 'error',
       },
     },
     {

--- a/eslint-rules/index.js
+++ b/eslint-rules/index.js
@@ -1,0 +1,22 @@
+/*
+ * Copyright (c) 2016-2024 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+const noParameterPropertyThisInConstructorRule = require('./no-parameter-property-this-in-constructor');
+
+const projectName = 'ng-clarity-eslint-rules';
+
+const configs = {
+  all: {
+    plugins: [projectName],
+  },
+};
+
+const rules = {
+  'no-parameter-property-this-in-constructor': noParameterPropertyThisInConstructorRule,
+};
+
+module.exports = { configs, rules };

--- a/eslint-rules/no-parameter-property-this-in-constructor.js
+++ b/eslint-rules/no-parameter-property-this-in-constructor.js
@@ -1,0 +1,38 @@
+/*
+ * Copyright (c) 2016-2024 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+module.exports = {
+  meta: {
+    type: 'problem',
+    fixable: 'code',
+    docs: {
+      description: "Disallow using 'this' in constructors for parameter properties",
+    },
+  },
+  create: context => {
+    let parameterPropertyNames;
+
+    return {
+      "MethodDefinition[kind='constructor']": node => {
+        parameterPropertyNames = node.value.params
+          .filter(param => param.type === 'TSParameterProperty')
+          .map(param => param.parameter.name);
+      },
+      "MethodDefinition[kind='constructor'] MemberExpression > ThisExpression": node => {
+        const memberName = node.parent.property.name;
+
+        if (parameterPropertyNames.includes(memberName)) {
+          context.report({
+            node: node,
+            message: "Don't use 'this' in constructors for parameter properties.",
+            fix: fixer => fixer.replaceText(node.parent, memberName),
+          });
+        }
+      },
+    };
+  },
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
         "eslint-plugin-jasmine": "4.1.3",
         "eslint-plugin-json": "3.1.0",
         "eslint-plugin-license-header": "0.4.0",
+        "eslint-plugin-ng-clarity-eslint-rules": "file:./eslint-rules",
         "eslint-plugin-storybook": "0.8.0",
         "eslint-plugin-unused-imports": "^2.0.0",
         "glob": "9.3.1",
@@ -82,6 +83,9 @@
         "npm": ">=8.19.0",
         "yarn": "please-use-npm"
       }
+    },
+    "eslint-rules": {
+      "dev": true
     },
     "node_modules/@aduh95/viz.js": {
       "version": "3.7.0",
@@ -19058,6 +19062,10 @@
       "dependencies": {
         "requireindex": "^1.2.0"
       }
+    },
+    "node_modules/eslint-plugin-ng-clarity-eslint-rules": {
+      "resolved": "eslint-rules",
+      "link": true
     },
     "node_modules/eslint-plugin-storybook": {
       "version": "0.8.0",
@@ -50168,6 +50176,9 @@
       "requires": {
         "requireindex": "^1.2.0"
       }
+    },
+    "eslint-plugin-ng-clarity-eslint-rules": {
+      "version": "file:eslint-rules"
     },
     "eslint-plugin-storybook": {
       "version": "0.8.0",

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "eslint-plugin-jasmine": "4.1.3",
     "eslint-plugin-json": "3.1.0",
     "eslint-plugin-license-header": "0.4.0",
+    "eslint-plugin-ng-clarity-eslint-rules": "file:./eslint-rules",
     "eslint-plugin-storybook": "0.8.0",
     "eslint-plugin-unused-imports": "^2.0.0",
     "glob": "9.3.1",

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -4455,7 +4455,7 @@ export class ClrVerticalNav implements OnDestroy {
 // @public (undocumented)
 export class ClrVerticalNavGroup implements AfterContentInit, OnDestroy {
     // Warning: (ae-forgotten-export) The symbol "VerticalNavGroupService" needs to be exported by the entry point index.d.ts
-    constructor(_itemExpand: IfExpandService, _navGroupRegistrationService: VerticalNavGroupRegistrationService, _navGroupService: VerticalNavGroupService, _navService: VerticalNavService, commonStrings: ClrCommonStringsService);
+    constructor(_itemExpand: IfExpandService, _navGroupRegistrationService: VerticalNavGroupRegistrationService, navGroupService: VerticalNavGroupService, _navService: VerticalNavService, commonStrings: ClrCommonStringsService);
     // (undocumented)
     collapseGroup(): void;
     // (undocumented)

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1153,8 +1153,7 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     // Warning: (ae-forgotten-export) The symbol "StateProvider" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "DisplayModeService" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "Page" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "ColumnsService" needs to be exported by the entry point index.d.ts
-    constructor(organizer: DatagridRenderOrganizer, items: Items<T>, expandableRows: ExpandableRowsCount, selection: Selection_2<T>, rowActionService: RowActionService, stateProvider: StateProvider<T>, displayMode: DisplayModeService, renderer: Renderer2, detailService: DetailService, document: any, el: ElementRef<HTMLElement>, page: Page, commonStrings: ClrCommonStringsService, columnsService: ColumnsService, keyNavigation: KeyNavigationGridController, zone: NgZone);
+    constructor(organizer: DatagridRenderOrganizer, items: Items<T>, expandableRows: ExpandableRowsCount, selection: Selection_2<T>, rowActionService: RowActionService, stateProvider: StateProvider<T>, displayMode: DisplayModeService, renderer: Renderer2, detailService: DetailService, document: any, el: ElementRef<HTMLElement>, page: Page, commonStrings: ClrCommonStringsService, keyNavigation: KeyNavigationGridController, zone: NgZone);
     get allSelected(): boolean;
     set allSelected(_value: boolean);
     // (undocumented)
@@ -1263,7 +1262,7 @@ export class ClrDatagridActionBar {
 
 // @public (undocumented)
 export class ClrDatagridActionOverflow implements OnDestroy {
-    constructor(rowActionService: RowActionService, commonStrings: ClrCommonStringsService, platformId: any, zone: NgZone, smartToggleService: ClrPopoverToggleService);
+    constructor(rowActionService: RowActionService, commonStrings: ClrCommonStringsService, platformId: any, smartToggleService: ClrPopoverToggleService);
     // (undocumented)
     buttonLabel: string;
     // (undocumented)
@@ -1388,6 +1387,7 @@ export class ClrDatagridColumnSeparator implements AfterViewInit, OnDestroy {
 
 // @public (undocumented)
 export class ClrDatagridColumnToggle implements OnDestroy {
+    // Warning: (ae-forgotten-export) The symbol "ColumnsService" needs to be exported by the entry point index.d.ts
     constructor(commonStrings: ClrCommonStringsService, columnsService: ColumnsService, popoverToggleService: ClrPopoverToggleService);
     // (undocumented)
     allColumnsSelected(): void;
@@ -5253,7 +5253,7 @@ export class ÇlrDatagridHeaderRenderer implements OnDestroy {
 
 // @public (undocumented)
 export class ÇlrDatagridMainRenderer implements AfterContentInit, AfterViewInit, AfterViewChecked, OnDestroy {
-    constructor(organizer: DatagridRenderOrganizer, items: Items, page: Page, domAdapter: DomAdapter, el: ElementRef<HTMLElement>, renderer: Renderer2, detailService: DetailService, tableSizeService: TableSizeService, columnsService: ColumnsService, ngZone: NgZone, keyNavigation: KeyNavigationGridController);
+    constructor(organizer: DatagridRenderOrganizer, items: Items, page: Page, el: ElementRef<HTMLElement>, renderer: Renderer2, detailService: DetailService, tableSizeService: TableSizeService, columnsService: ColumnsService, ngZone: NgZone, keyNavigation: KeyNavigationGridController);
     // (undocumented)
     ngAfterContentInit(): void;
     // (undocumented)

--- a/projects/angular/src/data/datagrid/datagrid-action-overflow.ts
+++ b/projects/angular/src/data/datagrid/datagrid-action-overflow.ts
@@ -6,17 +6,7 @@
  */
 
 import { isPlatformBrowser } from '@angular/common';
-import {
-  Component,
-  EventEmitter,
-  Inject,
-  Input,
-  NgZone,
-  OnDestroy,
-  Output,
-  PLATFORM_ID,
-  ViewChild,
-} from '@angular/core';
+import { Component, EventEmitter, Inject, Input, OnDestroy, Output, PLATFORM_ID, ViewChild } from '@angular/core';
 import { Subscription } from 'rxjs';
 
 import { ClrKeyFocus } from '../../utils/focus/key-focus';
@@ -89,7 +79,6 @@ export class ClrDatagridActionOverflow implements OnDestroy {
     private rowActionService: RowActionService,
     public commonStrings: ClrCommonStringsService,
     @Inject(PLATFORM_ID) private platformId: any,
-    private zone: NgZone,
     private smartToggleService: ClrPopoverToggleService
   ) {
     this.rowActionService.register();

--- a/projects/angular/src/data/datagrid/datagrid-action-overflow.ts
+++ b/projects/angular/src/data/datagrid/datagrid-action-overflow.ts
@@ -81,12 +81,12 @@ export class ClrDatagridActionOverflow implements OnDestroy {
     @Inject(PLATFORM_ID) private platformId: any,
     private smartToggleService: ClrPopoverToggleService
   ) {
-    this.rowActionService.register();
+    rowActionService.register();
     this.subscriptions.push(
-      this.smartToggleService.openChange.subscribe(openState => {
+      smartToggleService.openChange.subscribe(openState => {
         this.open = openState;
       }),
-      this.smartToggleService.popoverVisible.subscribe(visible => {
+      smartToggleService.popoverVisible.subscribe(visible => {
         if (visible) {
           this.initializeFocus();
         }

--- a/projects/angular/src/data/datagrid/datagrid-detail-registerer.ts
+++ b/projects/angular/src/data/datagrid/datagrid-detail-registerer.ts
@@ -18,8 +18,8 @@ import { ExpandableRowsCount } from './providers/global-expandable-rows';
 })
 export class DatagridDetailRegisterer {
   constructor(@Optional() private expandableRowsCount: ExpandableRowsCount) {
-    if (this.expandableRowsCount) {
-      this.expandableRowsCount.register();
+    if (expandableRowsCount) {
+      expandableRowsCount.register();
     }
   }
 

--- a/projects/angular/src/data/datagrid/datagrid-hideable-column.ts
+++ b/projects/angular/src/data/datagrid/datagrid-hideable-column.ts
@@ -57,15 +57,15 @@ export class ClrDatagridHideableColumn implements OnDestroy {
 
   constructor(
     private titleTemplateRef: TemplateRef<any>,
-    private viewContainerRef: ViewContainerRef,
+    viewContainerRef: ViewContainerRef,
     private columnsService: ColumnsService,
     @Optional()
     @Inject(COLUMN_STATE)
     private columnState: BehaviorSubject<ColumnState>
   ) {
-    this.viewContainerRef.createEmbeddedView(this.titleTemplateRef);
+    viewContainerRef.createEmbeddedView(titleTemplateRef);
 
-    if (!this.columnState) {
+    if (!columnState) {
       throw new Error('The *clrDgHideableColumn directive can only be used inside of a clr-dg-column component.');
     }
   }

--- a/projects/angular/src/data/datagrid/datagrid-if-detail.ts
+++ b/projects/angular/src/data/datagrid/datagrid-if-detail.ts
@@ -35,7 +35,7 @@ export class ClrIfDetail implements OnInit, OnDestroy {
     private viewContainer: ViewContainerRef,
     private detailService: DetailService
   ) {
-    this.detailService.enabled = true;
+    detailService.enabled = true;
   }
 
   @Input('clrIfDetail')

--- a/projects/angular/src/data/datagrid/datagrid-items.ts
+++ b/projects/angular/src/data/datagrid/datagrid-items.ts
@@ -34,10 +34,10 @@ export class ClrDatagridItems<T> implements DoCheck, OnDestroy {
     public template: TemplateRef<NgForOfContext<T>>,
     private differs: IterableDiffers,
     private items: Items,
-    private vcr: ViewContainerRef
+    vcr: ViewContainerRef
   ) {
     items.smartenUp();
-    this.iterableProxy = new NgForOf<T>(this.vcr, this.template, this.differs);
+    this.iterableProxy = new NgForOf<T>(vcr, template, differs);
     this.subscriptions.push(
       items.change.subscribe(newItems => {
         this.iterableProxy.ngForOf = newItems;

--- a/projects/angular/src/data/datagrid/datagrid-pagination.ts
+++ b/projects/angular/src/data/datagrid/datagrid-pagination.ts
@@ -138,7 +138,7 @@ export class ClrDatagridPagination implements OnDestroy, OnInit {
   private _pageSubscription: Subscription;
 
   constructor(public page: Page, public commonStrings: ClrCommonStringsService, public detailService: DetailService) {
-    this.page.activated = true;
+    page.activated = true;
   }
 
   /**

--- a/projects/angular/src/data/datagrid/datagrid-row.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.ts
@@ -114,8 +114,8 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     public detailService: DetailService,
     private displayMode: DisplayModeService,
     private vcr: ViewContainerRef,
-    private renderer: Renderer2,
-    private el: ElementRef<HTMLElement>,
+    renderer: Renderer2,
+    el: ElementRef<HTMLElement>,
     public commonStrings: ClrCommonStringsService,
     private items: Items,
     @Inject(DOCUMENT) private document: any
@@ -127,20 +127,18 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     this.expandableId = expand.expandableId;
 
     this.subscriptions.push(
-      combineLatest(this.expand.replace, this.expand.expandChange).subscribe(
-        ([expandReplaceValue, expandChangeValue]) => {
-          if (expandReplaceValue && expandChangeValue) {
-            // replaced and expanding
-            this.replaced = true;
-            this.renderer.addClass(this.el.nativeElement, 'datagrid-row-replaced');
-          } else {
-            this.replaced = false;
-            // Handles these cases: not replaced and collapsing & replaced and
-            // collapsing and not replaced and expanding.
-            this.renderer.removeClass(this.el.nativeElement, 'datagrid-row-replaced');
-          }
+      combineLatest(expand.replace, expand.expandChange).subscribe(([expandReplaceValue, expandChangeValue]) => {
+        if (expandReplaceValue && expandChangeValue) {
+          // replaced and expanding
+          this.replaced = true;
+          renderer.addClass(el.nativeElement, 'datagrid-row-replaced');
+        } else {
+          this.replaced = false;
+          // Handles these cases: not replaced and collapsing & replaced and
+          // collapsing and not replaced and expanding.
+          renderer.removeClass(el.nativeElement, 'datagrid-row-replaced');
         }
-      )
+      })
     );
   }
 

--- a/projects/angular/src/data/datagrid/datagrid-virtual-scroll.directive.ts
+++ b/projects/angular/src/data/datagrid/datagrid-virtual-scroll.directive.ts
@@ -102,11 +102,11 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
     private columnsService: ColumnsService,
     private readonly injector: EnvironmentInjector
   ) {
-    this.items.smartenUp();
-    this.datagrid.hasVirtualScroller = true;
-    this.datagrid.detailService.preventFocusScroll = true;
+    items.smartenUp();
+    datagrid.hasVirtualScroller = true;
+    datagrid.detailService.preventFocusScroll = true;
 
-    this.datagridElementRef = this.datagrid.el;
+    this.datagridElementRef = datagrid.el;
 
     // default
     this.cdkVirtualForTemplateCacheSize = 20;

--- a/projects/angular/src/data/datagrid/datagrid.ts
+++ b/projects/angular/src/data/datagrid/datagrid.ts
@@ -150,7 +150,6 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     public el: ElementRef<HTMLElement>,
     private page: Page,
     public commonStrings: ClrCommonStringsService,
-    private columnsService: ColumnsService,
     public keyNavigation: KeyNavigationGridController,
     private zone: NgZone
   ) {

--- a/projects/angular/src/data/datagrid/datagrid.ts
+++ b/projects/angular/src/data/datagrid/datagrid.ts
@@ -156,7 +156,7 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     const datagridId = uniqueIdFactory();
 
     this.selectAllId = 'clr-dg-select-all-' + datagridId;
-    this.detailService.id = datagridId;
+    detailService.id = datagridId;
   }
 
   /**

--- a/projects/angular/src/data/datagrid/providers/selection.ts
+++ b/projects/angular/src/data/datagrid/providers/selection.ts
@@ -59,11 +59,11 @@ export class Selection<T = any> {
    */
   private subscriptions: Subscription[] = [];
 
-  constructor(private _items: Items<T>, private _filters: FiltersProvider<T>) {
+  constructor(private _items: Items<T>, filters: FiltersProvider<T>) {
     this.id = 'clr-dg-selection' + nbSelection++;
 
     this.subscriptions.push(
-      this._filters.change.subscribe(() => {
+      filters.change.subscribe(() => {
         if (!this._selectable || this.preserveSelection) {
           return;
         }
@@ -72,7 +72,7 @@ export class Selection<T = any> {
     );
 
     this.subscriptions.push(
-      this._items.allChanges.subscribe(updatedItems => {
+      _items.allChanges.subscribe(updatedItems => {
         // Reset the lockedRefs;
         const updateLockedRef: T[] = [];
 
@@ -87,11 +87,11 @@ export class Selection<T = any> {
 
             // if the currentSingle has been set before data was loaded, we look up and save the ref from current data set
             if (this.currentSingle && !this.prevSingleSelectionRef) {
-              this.prevSingleSelectionRef = this._items.trackBy(this.currentSingle);
+              this.prevSingleSelectionRef = _items.trackBy(this.currentSingle);
             }
 
             updatedItems.forEach(item => {
-              const ref = this._items.trackBy(item);
+              const ref = _items.trackBy(item);
               // If one of the updated items is the previously selectedSingle, set it as the new one
               if (this.prevSingleSelectionRef === ref) {
                 newSingle = item;
@@ -106,7 +106,7 @@ export class Selection<T = any> {
             // Therefore, we should delete the currentSingle if it used to be defined but doesn't exist anymore.
             // No explicit "delete" is required, since newSingle would be undefined at this point.
             // Marking it as selectionUpdated here will set currentSingle to undefined below in the setTimeout.
-            if (this._items.smart && !newSingle) {
+            if (_items.smart && !newSingle) {
               selectionUpdated = true;
             }
 
@@ -130,7 +130,7 @@ export class Selection<T = any> {
             if (this.current.length > 0 && this.prevSelectionRefs.length !== this.current.length) {
               this.prevSelectionRefs = [];
               this.current.forEach(item => {
-                this.prevSelectionRefs.push(this._items.trackBy(item));
+                this.prevSelectionRefs.push(_items.trackBy(item));
               });
             }
 
@@ -140,7 +140,7 @@ export class Selection<T = any> {
             //
             // The both loops below that goes over updatedItems could be combined into one.
             updatedItems.forEach(item => {
-              const ref = this._items.trackBy(item);
+              const ref = _items.trackBy(item);
               if (this.lockedRefs.indexOf(ref) > -1) {
                 updateLockedRef.push(ref);
               }
@@ -151,7 +151,7 @@ export class Selection<T = any> {
             // the if statement below results in broken behavior.
             if (leftOver.length > 0) {
               updatedItems.forEach(item => {
-                const ref = this._items.trackBy(item);
+                const ref = _items.trackBy(item);
                 // Look in current selected refs array if item is selected, and update actual value
                 const selectedIndex = this.prevSelectionRefs.indexOf(ref);
                 if (selectedIndex > -1) {
@@ -162,7 +162,7 @@ export class Selection<T = any> {
 
               // Filter out any unmatched items if we're using smart datagrids where we expect all items to be
               // present
-              if (this._items.smart) {
+              if (_items.smart) {
                 leftOver = leftOver.filter(selected => updatedItems.indexOf(selected) > -1);
                 if (this.current.length !== leftOver.length) {
                   selectionUpdated = true;

--- a/projects/angular/src/data/datagrid/render/header-renderer.ts
+++ b/projects/angular/src/data/datagrid/render/header-renderer.ts
@@ -34,14 +34,14 @@ export class DatagridHeaderRenderer implements OnDestroy {
   constructor(
     private el: ElementRef<HTMLElement>,
     private renderer: Renderer2,
-    private organizer: DatagridRenderOrganizer,
+    organizer: DatagridRenderOrganizer,
     private domAdapter: DomAdapter,
     private columnResizerService: ColumnResizerService,
     private columnsService: ColumnsService,
     @Inject(COLUMN_STATE) private columnState: BehaviorSubject<ColumnState>
   ) {
     this.subscriptions.push(
-      this.organizer.filterRenderSteps(DatagridRenderStep.CLEAR_WIDTHS).subscribe(() => this.clearWidth())
+      organizer.filterRenderSteps(DatagridRenderStep.CLEAR_WIDTHS).subscribe(() => this.clearWidth())
     );
   }
 

--- a/projects/angular/src/data/datagrid/render/main-renderer.ts
+++ b/projects/angular/src/data/datagrid/render/main-renderer.ts
@@ -71,7 +71,6 @@ export class DatagridMainRenderer implements AfterContentInit, AfterViewInit, Af
     private organizer: DatagridRenderOrganizer,
     private items: Items,
     private page: Page,
-    private domAdapter: DomAdapter,
     private el: ElementRef<HTMLElement>,
     private renderer: Renderer2,
     private detailService: DetailService,

--- a/projects/angular/src/data/datagrid/render/main-renderer.ts
+++ b/projects/angular/src/data/datagrid/render/main-renderer.ts
@@ -73,27 +73,25 @@ export class DatagridMainRenderer implements AfterContentInit, AfterViewInit, Af
     private page: Page,
     private el: ElementRef<HTMLElement>,
     private renderer: Renderer2,
-    private detailService: DetailService,
+    detailService: DetailService,
     private tableSizeService: TableSizeService,
     private columnsService: ColumnsService,
     private ngZone: NgZone,
     private keyNavigation: KeyNavigationGridController
   ) {
     this.subscriptions.push(
-      this.organizer
-        .filterRenderSteps(DatagridRenderStep.COMPUTE_COLUMN_WIDTHS)
-        .subscribe(() => this.computeHeadersWidth())
+      organizer.filterRenderSteps(DatagridRenderStep.COMPUTE_COLUMN_WIDTHS).subscribe(() => this.computeHeadersWidth())
     );
 
     this.subscriptions.push(
-      this.page.sizeChange.subscribe(() => {
+      page.sizeChange.subscribe(() => {
         if (this._heightSet) {
           this.resetDatagridHeight();
         }
       })
     );
-    this.subscriptions.push(this.detailService.stateChange.subscribe(state => this.toggleDetailPane(state)));
-    this.subscriptions.push(this.items.change.subscribe(() => (this.shouldStabilizeColumns = true)));
+    this.subscriptions.push(detailService.stateChange.subscribe(state => this.toggleDetailPane(state)));
+    this.subscriptions.push(items.change.subscribe(() => (this.shouldStabilizeColumns = true)));
   }
 
   ngOnInit() {

--- a/projects/angular/src/data/tree-view/recursive-children.ts
+++ b/projects/angular/src/data/tree-view/recursive-children.ts
@@ -42,8 +42,8 @@ export class RecursiveChildren<T> {
 
   constructor(public featuresService: TreeFeaturesService<T>, @Optional() private expandService: IfExpandService) {
     if (expandService) {
-      this.subscription = this.expandService.expandChange.subscribe(value => {
-        if (!value && this.parent && !this.featuresService.eager && this.featuresService.recursion) {
+      this.subscription = expandService.expandChange.subscribe(value => {
+        if (!value && this.parent && !featuresService.eager && featuresService.recursion) {
           // In the case of lazy-loading recursive trees, we clear the children on collapse.
           // This is better in case they change between two user interaction, and that way
           // the app itself can decide whether to cache them or not.

--- a/projects/angular/src/data/tree-view/tree-node.ts
+++ b/projects/angular/src/data/tree-view/tree-node.ts
@@ -102,7 +102,7 @@ export class ClrTreeNode<T> implements OnInit, AfterContentInit, AfterViewInit, 
     private elementRef: ElementRef<HTMLElement>,
     injector: Injector
   ) {
-    if (this.featuresService.recursion) {
+    if (featuresService.recursion) {
       // I'm completely stuck, we have to hack into private properties until either
       // https://github.com/angular/angular/issues/14935 or https://github.com/angular/angular/issues/15998
       // are fixed

--- a/projects/angular/src/data/tree-view/tree.ts
+++ b/projects/angular/src/data/tree-view/tree.ts
@@ -55,7 +55,7 @@ export class ClrTree<T> implements AfterContentInit, OnDestroy {
         if (event.target === nativeElement) {
           // After discussing with the team, I've made it so that when the tree receives focus, the first visible node will be focused.
           // This will prevent from the page scrolling abruptly to the first selected node if it exist in a deeply nested tree.
-          this.focusManagerService.focusFirstVisibleNode();
+          focusManagerService.focusFirstVisibleNode();
           // when the first child gets focus,
           // tree should no longer have tabindex of 0.
           renderer.removeAttribute(nativeElement, 'tabindex');

--- a/projects/angular/src/forms/combobox/combobox.ts
+++ b/projects/angular/src/forms/combobox/combobox.ts
@@ -129,7 +129,7 @@ export class ClrCombobox<T>
       control.valueAccessor = this;
     }
     // default to SingleSelectComboboxModel, in case the optional input [ClrMulti] isn't used
-    this.optionSelectionService.selectionModel = new SingleSelectComboboxModel<T>();
+    optionSelectionService.selectionModel = new SingleSelectComboboxModel<T>();
     this.updateControlValue();
   }
 

--- a/projects/angular/src/forms/combobox/option-items.directive.ts
+++ b/projects/angular/src/forms/combobox/option-items.directive.ts
@@ -39,9 +39,9 @@ export class ClrOptionItems<T> implements DoCheck, OnDestroy {
     private differs: IterableDiffers,
     private optionService: OptionSelectionService<T>,
     private positionService: ClrPopoverPositionService,
-    private vcr: ViewContainerRef
+    vcr: ViewContainerRef
   ) {
-    this.iterableProxy = new NgForOf<T>(this.vcr, this.template, this.differs);
+    this.iterableProxy = new NgForOf<T>(vcr, template, differs);
     this.subscriptions.push(
       optionService.inputChanged.subscribe(filter => {
         this.filter = filter;

--- a/projects/angular/src/forms/combobox/option.ts
+++ b/projects/angular/src/forms/combobox/option.ts
@@ -38,7 +38,7 @@ export class ClrOption<T> implements OnInit {
     private focusHandler: ComboboxFocusHandler<T>,
     private optionSelectionService: OptionSelectionService<T>
   ) {
-    this.optionProxy.el = this.elRef.nativeElement;
+    this.optionProxy.el = elRef.nativeElement;
   }
 
   @Input('id')

--- a/projects/angular/src/forms/combobox/providers/combobox-focus-handler.service.ts
+++ b/projects/angular/src/forms/combobox/providers/combobox-focus-handler.service.ts
@@ -224,13 +224,10 @@ export class ComboboxFocusHandler<T> {
 export const COMBOBOX_FOCUS_HANDLER_PROVIDER = customFocusableItemProvider(ComboboxFocusHandler);
 
 export class OptionData<T> {
-  id: string;
   el: HTMLElement;
-  value: T;
-  constructor(id: string, value: T) {
-    this.id = id;
-    this.value = value;
-  }
+
+  constructor(public id: string, public value: T) {}
+
   equals(other: OptionData<T>): boolean {
     if (!other) {
       return false;

--- a/projects/angular/src/forms/common/abstract-container.ts
+++ b/projects/angular/src/forms/common/abstract-container.ts
@@ -40,7 +40,7 @@ export abstract class ClrAbstractContainer implements DynamicWrapper, OnDestroy,
     protected ngControlService: NgControlService
   ) {
     this.subscriptions.push(
-      this.ifControlStateService.statusChanges.subscribe((state: CONTROL_STATE) => {
+      ifControlStateService.statusChanges.subscribe((state: CONTROL_STATE) => {
         this.state = state;
         // Make sure everything is updated before dispatching the values for helpers
         setTimeout(() => {
@@ -50,7 +50,7 @@ export abstract class ClrAbstractContainer implements DynamicWrapper, OnDestroy,
     );
 
     this.subscriptions.push(
-      this.ngControlService.controlChanges.subscribe(control => {
+      ngControlService.controlChanges.subscribe(control => {
         this.control = control;
       })
     );

--- a/projects/angular/src/forms/common/if-control-state/abstract-if-state.ts
+++ b/projects/angular/src/forms/common/if-control-state/abstract-if-state.ts
@@ -24,7 +24,7 @@ export abstract class AbstractIfState {
   ) {
     if (ngControlService) {
       this.subscriptions.push(
-        this.ngControlService.controlChanges.subscribe(control => {
+        ngControlService.controlChanges.subscribe(control => {
           this.control = control;
         })
       );
@@ -32,7 +32,7 @@ export abstract class AbstractIfState {
 
     if (ifControlStateService) {
       this.subscriptions.push(
-        this.ifControlStateService.statusChanges.subscribe((state: CONTROL_STATE) => {
+        ifControlStateService.statusChanges.subscribe((state: CONTROL_STATE) => {
           this.handleState(state);
         })
       );

--- a/projects/angular/src/forms/common/if-control-state/if-control-state.service.ts
+++ b/projects/angular/src/forms/common/if-control-state/if-control-state.service.ts
@@ -25,10 +25,10 @@ export class IfControlStateService implements OnDestroy {
   // Implement our own status changes observable, since Angular controls don't
   private _statusChanges = new BehaviorSubject(CONTROL_STATE.NONE);
 
-  constructor(private ngControlService: NgControlService) {
+  constructor(ngControlService: NgControlService) {
     // Wait for the control to be available
     this.subscriptions.push(
-      this.ngControlService.controlChanges.subscribe(control => {
+      ngControlService.controlChanges.subscribe(control => {
         if (control) {
           this.control = control;
           // Subscribe to the status change events, only after touched

--- a/projects/angular/src/forms/common/wrapped-control.ts
+++ b/projects/angular/src/forms/common/wrapped-control.ts
@@ -44,10 +44,8 @@ export enum CHANGE_KEYS {
 export class WrappedFormControl<W extends DynamicWrapper> implements OnInit, DoCheck, OnDestroy {
   _id: string;
 
-  protected renderer: Renderer2;
   protected controlIdService: ControlIdService;
   protected ngControlService: NgControlService;
-  protected el: ElementRef<HTMLElement>;
   protected index = 0;
   protected subscriptions: Subscription[] = [];
 
@@ -66,12 +64,9 @@ export class WrappedFormControl<W extends DynamicWrapper> implements OnInit, DoC
     protected wrapperType: Type<W>,
     injector: Injector,
     private ngControl: NgControl | null,
-    renderer: Renderer2,
-    el: ElementRef<HTMLElement>
+    protected renderer: Renderer2,
+    protected el: ElementRef<HTMLElement>
   ) {
-    this.renderer = renderer;
-    this.el = el;
-
     if (injector) {
       this.ngControlService = injector.get(NgControlService, null);
       this.ifControlStateService = injector.get(IfControlStateService, null);

--- a/projects/angular/src/forms/datalist/datalist-container.ts
+++ b/projects/angular/src/forms/datalist/datalist-container.ts
@@ -69,11 +69,11 @@ export class ClrDatalistContainer extends ClrAbstractContainer {
     controlClassService: ControlClassService,
     @Optional() layoutService: LayoutService,
     ngControlService: NgControlService,
-    private focusService: FocusService,
+    focusService: FocusService,
     protected override ifControlStateService: IfControlStateService
   ) {
     super(ifControlStateService, layoutService, controlClassService, ngControlService);
 
-    this.subscriptions.push(this.focusService.focusChange.subscribe(state => (this.focus = state)));
+    this.subscriptions.push(focusService.focusChange.subscribe(state => (this.focus = state)));
   }
 }

--- a/projects/angular/src/forms/datalist/datalist-input.ts
+++ b/projects/angular/src/forms/datalist/datalist-input.ts
@@ -46,7 +46,7 @@ export class ClrDatalistInput extends WrappedFormControl<ClrDatalistContainer> i
   ) {
     super(vcr, ClrDatalistContainer, injector, control, renderer, el);
 
-    if (!this.focusService) {
+    if (!focusService) {
       throw new Error('clrDatalist requires being wrapped in <clr-datalist-container>');
     }
   }

--- a/projects/angular/src/forms/datepicker/date-container.ts
+++ b/projects/angular/src/forms/datepicker/date-container.ts
@@ -106,7 +106,7 @@ export class ClrDateContainer extends ClrAbstractContainer implements AfterViewI
     private dateFormControlService: DateFormControlService,
     private dateIOService: DateIOService,
     public commonStrings: ClrCommonStringsService,
-    private focusService: FocusService,
+    focusService: FocusService,
     private viewManagerService: ViewManagerService,
     protected override controlClassService: ControlClassService,
     @Optional() protected override layoutService: LayoutService,
@@ -116,14 +116,14 @@ export class ClrDateContainer extends ClrAbstractContainer implements AfterViewI
     super(ifControlStateService, layoutService, controlClassService, ngControlService);
 
     this.subscriptions.push(
-      this.focusService.focusChange.subscribe(state => {
+      focusService.focusChange.subscribe(state => {
         this.focus = state;
       })
     );
 
     this.subscriptions.push(
-      this.toggleService.openChange.subscribe(() => {
-        this.dateFormControlService.markAsTouched();
+      toggleService.openChange.subscribe(() => {
+        dateFormControlService.markAsTouched();
       })
     );
   }

--- a/projects/angular/src/forms/datepicker/datepicker-view-manager.spec.ts
+++ b/projects/angular/src/forms/datepicker/datepicker-view-manager.spec.ts
@@ -69,7 +69,7 @@ export default function () {
   template: `<clr-datepicker-view-manager></clr-datepicker-view-manager>`,
 })
 class TestComponent {
-  constructor(private dateNavigationService: DateNavigationService) {
-    this.dateNavigationService.initializeCalendar();
+  constructor(dateNavigationService: DateNavigationService) {
+    dateNavigationService.initializeCalendar();
   }
 }

--- a/projects/angular/src/forms/datepicker/providers/date-io.service.ts
+++ b/projects/angular/src/forms/datepicker/providers/date-io.service.ts
@@ -39,8 +39,8 @@ export class DateIOService {
   private localeDisplayFormat: InputDateDisplayFormat = LITTLE_ENDIAN;
   private delimiters: [string, string] = ['/', '/'];
 
-  constructor(private _localeHelperService: LocaleHelperService) {
-    this.cldrLocaleDateFormat = this._localeHelperService.localeDateFormat;
+  constructor(localeHelperService: LocaleHelperService) {
+    this.cldrLocaleDateFormat = localeHelperService.localeDateFormat;
     this.initializeLocaleDisplayFormat();
   }
 

--- a/projects/angular/src/forms/datepicker/providers/datepicker-enabled.service.ts
+++ b/projects/angular/src/forms/datepicker/providers/datepicker-enabled.service.ts
@@ -17,7 +17,7 @@ export class DatepickerEnabledService {
   private _innerWidth: number;
 
   constructor(@Inject(DOCUMENT) private _document: any) {
-    if (this._document) {
+    if (_document) {
       this._isUserAgentMobile = MOBILE_USERAGENT_REGEX.test(_document.defaultView.navigator.userAgent);
       this._innerWidth = _document.defaultView.innerWidth;
     }

--- a/projects/angular/src/forms/password/password-container.ts
+++ b/projects/angular/src/forms/password/password-container.ts
@@ -98,7 +98,7 @@ export class ClrPasswordContainer extends ClrAbstractContainer {
 
     /* The unsubscribe is handle inside the ClrAbstractContainer */
     this.subscriptions.push(
-      this.focusService.focusChange.subscribe(state => {
+      focusService.focusChange.subscribe(state => {
         this.focus = state;
       })
     );

--- a/projects/angular/src/forms/password/password.ts
+++ b/projects/angular/src/forms/password/password.ts
@@ -43,16 +43,16 @@ export class ClrPassword extends WrappedFormControl<ClrPasswordContainer> implem
     @Optional() private focusService: FocusService,
     @Optional()
     @Inject(TOGGLE_SERVICE)
-    private toggleService: BehaviorSubject<boolean>
+    toggleService: BehaviorSubject<boolean>
   ) {
     super(vcr, ClrPasswordContainer, injector, control, renderer, el);
 
-    if (!this.focusService) {
+    if (!focusService) {
       throw new Error('clrPassword requires being wrapped in <clr-password-container>');
     }
 
     this.subscriptions.push(
-      this.toggleService.subscribe(toggle => {
+      toggleService.subscribe(toggle => {
         renderer.setProperty(el.nativeElement, 'type', toggle ? 'text' : 'password');
       })
     );

--- a/projects/angular/src/layout/nav/header.ts
+++ b/projects/angular/src/layout/nav/header.ts
@@ -52,14 +52,14 @@ export class ClrHeader implements OnDestroy {
     private responsiveNavService: ResponsiveNavigationService,
     public commonStrings: ClrCommonStringsService
   ) {
-    this._subscription = this.responsiveNavService.registeredNavs.subscribe({
+    this._subscription = responsiveNavService.registeredNavs.subscribe({
       next: (navLevelList: number[]) => {
         this.initializeNavTriggers(navLevelList);
       },
     });
 
     this._subscription.add(
-      this.responsiveNavService.navControl
+      responsiveNavService.navControl
         .pipe(
           filter(
             ({ controlCode }) =>

--- a/projects/angular/src/layout/tabs/tab-link.directive.ts
+++ b/projects/angular/src/layout/tabs/tab-link.directive.ts
@@ -43,8 +43,8 @@ export class ClrTabLink {
     public ifActiveService: IfActiveService,
     @Inject(IF_ACTIVE_ID) readonly id: number,
     public el: ElementRef<HTMLElement>,
-    private cfr: ComponentFactoryResolver,
-    private viewContainerRef: ViewContainerRef,
+    cfr: ComponentFactoryResolver,
+    viewContainerRef: ViewContainerRef,
     private tabsService: TabsService,
     @Inject(TABS_ID) public tabsId: number
   ) {
@@ -55,9 +55,9 @@ export class ClrTabLink {
     // Tab links can be rendered in one of two places: in the main area or inside the overflow dropdown menu.
     // Here, we create a container so that its template can be used to create embeddedView on the fly.
     // See TabsService's renderView() method and how it's used in Tabs class for an example.
-    const factory = this.cfr.resolveComponentFactory(TemplateRefContainer);
-    this.templateRefContainer = this.viewContainerRef.createComponent(factory, undefined, undefined, [
-      [this.el.nativeElement],
+    const factory = cfr.resolveComponentFactory(TemplateRefContainer);
+    this.templateRefContainer = viewContainerRef.createComponent(factory, undefined, undefined, [
+      [el.nativeElement],
     ]).instance;
   }
 

--- a/projects/angular/src/layout/vertical-nav/vertical-nav-group.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav-group.ts
@@ -41,11 +41,11 @@ export class ClrVerticalNavGroup implements AfterContentInit, OnDestroy {
   constructor(
     private _itemExpand: IfExpandService,
     private _navGroupRegistrationService: VerticalNavGroupRegistrationService,
-    private _navGroupService: VerticalNavGroupService,
+    navGroupService: VerticalNavGroupService,
     private _navService: VerticalNavService,
     public commonStrings: ClrCommonStringsService
   ) {
-    this._navGroupRegistrationService.registerNavGroup();
+    _navGroupRegistrationService.registerNavGroup();
 
     // FIXME: This subscription handles a corner case
     // Vertical Nav collapse requires the animation to run first and then
@@ -54,10 +54,10 @@ export class ClrVerticalNavGroup implements AfterContentInit, OnDestroy {
     // and wait for it to complete. This subscription makes sure that the
     // animation states are correct for that edge case.
     this._subscriptions.push(
-      this._itemExpand.expandChange.subscribe(value => {
+      _itemExpand.expandChange.subscribe(value => {
         if (value && this.expandAnimationState === COLLAPSED_STATE) {
-          if (this._navService.collapsed) {
-            this._navService.collapsed = false;
+          if (_navService.collapsed) {
+            _navService.collapsed = false;
           }
           this.expandAnimationState = EXPANDED_STATE;
         } else if (!value && this.expandAnimationState === EXPANDED_STATE) {
@@ -69,7 +69,7 @@ export class ClrVerticalNavGroup implements AfterContentInit, OnDestroy {
     // 1. If the nav is collapsing, close the open nav group + save its state
     // 2. If the nav is expanding, expand the nav group if the previous state was expanded
     this._subscriptions.push(
-      this._navService.animateOnCollapsed.subscribe((goingToCollapse: boolean) => {
+      _navService.animateOnCollapsed.subscribe((goingToCollapse: boolean) => {
         if (goingToCollapse && this.expanded) {
           this.wasExpanded = true;
           this.expandAnimationState = COLLAPSED_STATE;
@@ -82,7 +82,7 @@ export class ClrVerticalNavGroup implements AfterContentInit, OnDestroy {
 
     // If a link is clicked, expand the nav group
     this._subscriptions.push(
-      this._navGroupService.expandChange.subscribe((expand: boolean) => {
+      navGroupService.expandChange.subscribe((expand: boolean) => {
         if (expand && !this.expanded) {
           this.expandGroup();
         }

--- a/projects/angular/src/layout/vertical-nav/vertical-nav-icon.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav-icon.ts
@@ -15,7 +15,7 @@ import { VerticalNavIconService } from './providers/vertical-nav-icon.service';
 })
 export class ClrVerticalNavIcon implements OnDestroy {
   constructor(private _verticalNavIconService: VerticalNavIconService) {
-    this._verticalNavIconService.registerIcon();
+    _verticalNavIconService.registerIcon();
   }
 
   ngOnDestroy() {

--- a/projects/angular/src/layout/vertical-nav/vertical-nav.ts
+++ b/projects/angular/src/layout/vertical-nav/vertical-nav.ts
@@ -35,7 +35,7 @@ export class ClrVerticalNav implements OnDestroy {
     private _navGroupRegistrationService: VerticalNavGroupRegistrationService,
     public commonStrings: ClrCommonStringsService
   ) {
-    this._sub = this._navService.collapsedChanged.subscribe(value => {
+    this._sub = _navService.collapsedChanged.subscribe(value => {
       this._collapsedChanged.emit(value);
     });
   }

--- a/projects/angular/src/modal/modal-body.ts
+++ b/projects/angular/src/modal/modal-body.ts
@@ -24,14 +24,14 @@ export class ClrModalBody implements OnDestroy {
   constructor(private readonly renderer: Renderer2, private readonly host: ElementRef<HTMLElement>, ngZone: NgZone) {
     ngZone.runOutsideAngular(() => {
       this.observer = new ResizeObserver(() => this.addOrRemoveTabIndex());
-      this.observer.observe(this.host.nativeElement);
+      this.observer.observe(host.nativeElement);
 
       this.unlisteners.push(
-        this.renderer.listen(this.host.nativeElement, 'mouseup', () => {
+        renderer.listen(host.nativeElement, 'mouseup', () => {
           // set the tabindex binding back when click is completed with mouseup
           this.addOrRemoveTabIndex();
         }),
-        this.renderer.listen(this.host.nativeElement, 'mousedown', () => {
+        renderer.listen(host.nativeElement, 'mousedown', () => {
           // tabindex = 0 binding should be removed
           // so it won't be focused when click starts with mousedown
           this.removeTabIndex();

--- a/projects/angular/src/popover/dropdown/dropdown.ts
+++ b/projects/angular/src/popover/dropdown/dropdown.ts
@@ -35,11 +35,11 @@ export class ClrDropdown implements OnDestroy {
     public parent: ClrDropdown,
     public toggleService: ClrPopoverToggleService,
     public focusHandler: DropdownFocusHandler,
-    private cdr: ChangeDetectorRef,
+    cdr: ChangeDetectorRef,
     dropdownService: RootDropdownService
   ) {
-    this.subscriptions.push(dropdownService.changes.subscribe(value => (this.toggleService.open = value)));
-    this.subscriptions.push(toggleService.openChange.subscribe(() => this.cdr.markForCheck()));
+    this.subscriptions.push(dropdownService.changes.subscribe(value => (toggleService.open = value)));
+    this.subscriptions.push(toggleService.openChange.subscribe(() => cdr.markForCheck()));
   }
 
   ngOnDestroy() {

--- a/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.service.ts
+++ b/projects/angular/src/popover/dropdown/providers/dropdown-focus-handler.service.ts
@@ -44,7 +44,7 @@ export class DropdownFocusHandler implements OnDestroy, FocusableItem {
   ) {
     this.resetChildren();
     this.moveToFirstItemWhenOpen();
-    if (!this.parent) {
+    if (!parent) {
       this.handleRootFocus();
     }
   }

--- a/projects/angular/src/popover/signpost/signpost-content.ts
+++ b/projects/angular/src/popover/signpost/signpost-content.ts
@@ -67,7 +67,7 @@ export class ClrSignpostContent extends AbstractPopover implements OnDestroy {
     @Inject(POPOVER_HOST_ANCHOR)
     parentHost: ElementRef<HTMLElement>,
     public commonStrings: ClrCommonStringsService,
-    private signpostIdService: SignpostIdService,
+    signpostIdService: SignpostIdService,
     private signpostFocusManager: SignpostFocusManager,
     @Inject(PLATFORM_ID) private platformId: any,
     @Inject(DOCUMENT) document: any
@@ -79,7 +79,7 @@ export class ClrSignpostContent extends AbstractPopover implements OnDestroy {
     // Defaults
     this.position = 'right-middle';
     this.closeOnOutsideClick = true;
-    this.signpostIdService.setId(this.signpostContentId);
+    signpostIdService.setId(this.signpostContentId);
 
     this.document = document;
   }

--- a/projects/angular/src/popover/tooltip/tooltip-trigger.ts
+++ b/projects/angular/src/popover/tooltip/tooltip-trigger.ts
@@ -27,11 +27,11 @@ export class ClrTooltipTrigger {
 
   constructor(
     private toggleService: ClrPopoverToggleService,
-    private tooltipIdService: TooltipIdService,
+    tooltipIdService: TooltipIdService,
     private tooltipMouseService: TooltipMouseService
   ) {
     // The aria-described by comes from the id of content. It
-    this.subs.push(this.tooltipIdService.id.subscribe(tooltipId => (this.ariaDescribedBy = tooltipId)));
+    this.subs.push(tooltipIdService.id.subscribe(tooltipId => (this.ariaDescribedBy = tooltipId)));
   }
 
   ngOnDestroy() {

--- a/projects/angular/src/utils/conditional/if-active.directive.ts
+++ b/projects/angular/src/utils/conditional/if-active.directive.ts
@@ -55,7 +55,7 @@ export class ClrIfActive implements OnDestroy {
   ) {
     this.checkAndUpdateView(ifActiveService.current);
 
-    this.subscription = this.ifActiveService.currentChange.subscribe(newCurrentId => {
+    this.subscription = ifActiveService.currentChange.subscribe(newCurrentId => {
       this.checkAndUpdateView(newCurrentId);
     });
   }

--- a/projects/angular/src/utils/conditional/if-expanded.directive.ts
+++ b/projects/angular/src/utils/conditional/if-expanded.directive.ts
@@ -45,7 +45,7 @@ export class ClrIfExpanded implements OnInit, OnDestroy {
     this._subscriptions.push(
       expand.expandChange.subscribe(() => {
         this.updateView();
-        this.expandedChange.emit(this.expand.expanded);
+        this.expandedChange.emit(expand.expanded);
       })
     );
   }

--- a/projects/angular/src/utils/conditional/if-open.directive.ts
+++ b/projects/angular/src/utils/conditional/if-open.directive.ts
@@ -43,7 +43,7 @@ export class ClrIfOpen implements OnDestroy {
     private template: TemplateRef<any>,
     private container: ViewContainerRef
   ) {
-    this.subscription = this.toggleService.openChange.subscribe(change => {
+    this.subscription = toggleService.openChange.subscribe(change => {
       this.updateView(change);
       this.openChange.emit(change);
     });

--- a/projects/angular/src/utils/focus/focus-on-view-init/focus-on-view-init.ts
+++ b/projects/angular/src/utils/focus/focus-on-view-init/focus-on-view-init.ts
@@ -41,7 +41,7 @@ export class ClrFocusOnViewInit implements AfterViewInit, OnDestroy {
     private renderer: Renderer2,
     ngZone: NgZone
   ) {
-    this._isEnabled = this.focusOnViewInit;
+    this._isEnabled = focusOnViewInit;
 
     // Angular compiler doesn't understand the type Document
     // when working out the metadata for injectable parameters,
@@ -55,8 +55,8 @@ export class ClrFocusOnViewInit implements AfterViewInit, OnDestroy {
         .subscribe(() => {
           if (!this.directFocus) {
             // manually set attributes and styles should be removed
-            this.renderer.removeAttribute(this.el.nativeElement, 'tabindex');
-            this.renderer.setStyle(this.el.nativeElement, 'outline', null);
+            renderer.removeAttribute(el.nativeElement, 'tabindex');
+            renderer.setStyle(el.nativeElement, 'outline', null);
           }
         })
     );

--- a/projects/angular/src/utils/popover/popover-open-close-button.ts
+++ b/projects/angular/src/utils/popover/popover-open-close-button.ts
@@ -23,7 +23,7 @@ export class ClrPopoverOpenCloseButton implements OnDestroy {
 
   constructor(private smartOpenService: ClrPopoverToggleService) {
     this.subscriptions.push(
-      this.smartOpenService.openChange.subscribe(change => {
+      smartOpenService.openChange.subscribe(change => {
         this.openCloseChange.next(change);
       })
     );

--- a/projects/angular/src/wizard/providers/wizard-navigation.service.ts
+++ b/projects/angular/src/wizard/providers/wizard-navigation.service.ts
@@ -190,7 +190,7 @@ export class WizardNavigationService implements OnDestroy {
    * @memberof WizardNavigationService
    */
   constructor(public pageCollection: PageCollectionService, public buttonService: ButtonHubService) {
-    this.previousButtonSubscription = this.buttonService.previousBtnClicked.subscribe(() => {
+    this.previousButtonSubscription = buttonService.previousBtnClicked.subscribe(() => {
       const currentPage = this.currentPage;
       if (this.currentPageIsFirst || currentPage.previousStepDisabled) {
         return;
@@ -201,25 +201,25 @@ export class WizardNavigationService implements OnDestroy {
       }
     });
 
-    this.nextButtonSubscription = this.buttonService.nextBtnClicked.subscribe(() => {
+    this.nextButtonSubscription = buttonService.nextBtnClicked.subscribe(() => {
       this.checkAndCommitCurrentPage('next');
     });
 
-    this.dangerButtonSubscription = this.buttonService.dangerBtnClicked.subscribe(() => {
+    this.dangerButtonSubscription = buttonService.dangerBtnClicked.subscribe(() => {
       this.checkAndCommitCurrentPage('danger');
     });
 
-    this.finishButtonSubscription = this.buttonService.finishBtnClicked.subscribe(() => {
+    this.finishButtonSubscription = buttonService.finishBtnClicked.subscribe(() => {
       this.checkAndCommitCurrentPage('finish');
     });
 
-    this.customButtonSubscription = this.buttonService.customBtnClicked.subscribe((type: string) => {
+    this.customButtonSubscription = buttonService.customBtnClicked.subscribe((type: string) => {
       if (!this.wizardStopNavigation) {
         this.currentPage.customButtonClicked.emit(type);
       }
     });
 
-    this.cancelButtonSubscription = this.buttonService.cancelBtnClicked.subscribe(() => {
+    this.cancelButtonSubscription = buttonService.cancelBtnClicked.subscribe(() => {
       if (this.wizardStopNavigation) {
         return;
       }
@@ -231,7 +231,7 @@ export class WizardNavigationService implements OnDestroy {
       }
     });
 
-    this.pagesResetSubscription = this.pageCollection.pagesReset.subscribe(() => {
+    this.pagesResetSubscription = pageCollection.pagesReset.subscribe(() => {
       this.setFirstPageCurrent();
     });
   }

--- a/projects/demo/src/app/datagrid/preserve-selection/preserve-selection.ts
+++ b/projects/demo/src/app/datagrid/preserve-selection/preserve-selection.ts
@@ -45,14 +45,10 @@ export class DatagridPreserveSelectionDemo {
   backUpUsers: User[] = [];
 
   constructor(private inventory: Inventory) {
-    this.inventory.size = this.total;
-    this.inventory.latency = 500;
-    this.inventory.reset();
-    this.users =
-      this.clientNoTrackByUsers =
-      this.clientTrackByIndexUsers =
-      this.clientTrackByIdUsers =
-        this.inventory.all;
+    inventory.size = this.total;
+    inventory.latency = 500;
+    inventory.reset();
+    this.users = this.clientNoTrackByUsers = this.clientTrackByIndexUsers = this.clientTrackByIdUsers = inventory.all;
   }
 
   trackByIndex: TrackByFunction<User> = index => index;

--- a/projects/demo/src/app/datagrid/selection-single/selection-single.ts
+++ b/projects/demo/src/app/datagrid/selection-single/selection-single.ts
@@ -34,10 +34,10 @@ export class DatagridSelectionSingleDemo {
   total: number;
 
   constructor(private inventory: Inventory) {
-    this.inventory.size = 100;
-    this.inventory.latency = 500;
-    this.inventory.reset();
-    this.users = this.trackByIndexUsers = this.trackByIdUsers = this.inventory.all;
+    inventory.size = 100;
+    inventory.latency = 500;
+    inventory.reset();
+    this.users = this.trackByIndexUsers = this.trackByIdUsers = inventory.all;
   }
 
   trackByIndex: TrackByFunction<User> = index => index;

--- a/projects/demo/src/app/datagrid/selection/selection.ts
+++ b/projects/demo/src/app/datagrid/selection/selection.ts
@@ -30,10 +30,10 @@ export class DatagridSelectionDemo {
   loading = true;
 
   constructor(private inventory: Inventory) {
-    this.inventory.size = this.total;
-    this.inventory.latency = 500;
-    this.inventory.reset();
-    this.clientNoTrackByUsers = this.clientTrackByIndexUsers = this.clientTrackByIdUsers = this.inventory.all;
+    inventory.size = this.total;
+    inventory.latency = 500;
+    inventory.reset();
+    this.clientNoTrackByUsers = this.clientTrackByIndexUsers = this.clientTrackByIdUsers = inventory.all;
   }
 
   trackByIndex: TrackByFunction<User> = index => index;

--- a/projects/demo/src/app/datagrid/server-driven/server-driven.ts
+++ b/projects/demo/src/app/datagrid/server-driven/server-driven.ts
@@ -24,7 +24,7 @@ export class DatagridServerDrivenDemo {
 
   constructor(private inventory: Inventory) {
     inventory.size = 103;
-    this.inventory.latency = 500;
+    inventory.latency = 500;
     inventory.reset();
   }
 

--- a/projects/demo/src/app/datagrid/virtual-scroll-client-side/virtual-scroll-client-side.ts
+++ b/projects/demo/src/app/datagrid/virtual-scroll-client-side/virtual-scroll-client-side.ts
@@ -46,14 +46,14 @@ export class DatagridVirtualScrollClientSideDemo implements OnInit, AfterViewChe
     public inventory: Inventory,
     private dynamicData: DynamicData,
     private cdr: ChangeDetectorRef,
-    private applicationRef: ApplicationRef
+    applicationRef: ApplicationRef
   ) {
     this.timeCD = new ChangeDetectionPerfRecord();
 
     this.rows = this.allRows;
 
-    const originalTick = this.applicationRef.tick;
-    this.applicationRef.tick = function () {
+    const originalTick = applicationRef.tick;
+    applicationRef.tick = function () {
       const before = window.performance.now();
       const retValue = originalTick.apply(this);
       const after = window.performance.now();

--- a/projects/demo/src/app/i18n-a11y/i18n-a11y.demo.ts
+++ b/projects/demo/src/app/i18n-a11y/i18n-a11y.demo.ts
@@ -23,7 +23,7 @@ export class I18nA11yDemo implements OnDestroy {
   test: ClrCommonStrings;
 
   constructor(private commonStrings: ClrCommonStringsService) {
-    this.commonStrings.localize(frenchTranslation);
+    commonStrings.localize(frenchTranslation);
   }
 
   // We want to reset the strings when leaving this demo.

--- a/projects/demo/src/app/popovers/dummy-menu.ts
+++ b/projects/demo/src/app/popovers/dummy-menu.ts
@@ -24,12 +24,12 @@ export class DummyMenu extends AbstractPopover {
     @Optional()
     @Inject(POPOVER_HOST_ANCHOR)
     parentHost: ElementRef<HTMLElement>,
-    private parent: DummyAnchor
+    parent: DummyAnchor
   ) {
     super(injector, parentHost);
     this.configurePopover();
-    if (this.parent && this.parent.ignore) {
-      this.ignoredElement = this.parent.ignore.nativeElement;
+    if (parent && parent.ignore) {
+      this.ignoredElement = parent.ignore.nativeElement;
     }
   }
 

--- a/projects/demo/src/app/vertical-nav/all-cases/vertical-all-cases.demo.ts
+++ b/projects/demo/src/app/vertical-nav/all-cases/vertical-all-cases.demo.ts
@@ -19,8 +19,8 @@ export class VerticalNavAllCases {
 
   private _collapse = false;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.cases = this.verticalNavCases.nonCollapsedMenus;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.cases = verticalNavCases.nonCollapsedMenus;
   }
 
   get collapse(): boolean {

--- a/projects/demo/src/app/vertical-nav/basic/vertical-nav-basic.ts
+++ b/projects/demo/src/app/vertical-nav/basic/vertical-nav-basic.ts
@@ -17,7 +17,7 @@ import { VerticalNavCases } from '../vertical-nav-cases';
 export class VerticalNavBasicDemo {
   case: any;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.basicMenu;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.basicMenu;
   }
 }

--- a/projects/demo/src/app/vertical-nav/collapsible/vertical-nav-collapsible.ts
+++ b/projects/demo/src/app/vertical-nav/collapsible/vertical-nav-collapsible.ts
@@ -20,8 +20,8 @@ export class VerticalNavCollapsibleDemo {
 
   private _collapse = true;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.basicMenu;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.basicMenu;
   }
 
   get collapse(): boolean {

--- a/projects/demo/src/app/vertical-nav/direct-icon/vertical-nav-icon.ts
+++ b/projects/demo/src/app/vertical-nav/direct-icon/vertical-nav-icon.ts
@@ -19,8 +19,8 @@ export class VerticalNavDirectIconDemo {
 
   private _collapse = false;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.iconMenu;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.iconMenu;
   }
 
   get collapse(): boolean {

--- a/projects/demo/src/app/vertical-nav/header-and-divider/vertical-nav-header-and-divider.ts
+++ b/projects/demo/src/app/vertical-nav/header-and-divider/vertical-nav-header-and-divider.ts
@@ -17,7 +17,7 @@ import { VerticalNavCases } from '../vertical-nav-cases';
 export class VerticalNavHeaderAndDividerDemo {
   case: any;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.basicMenu;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.basicMenu;
   }
 }

--- a/projects/demo/src/app/vertical-nav/highlights/vertical-nav-highlights.demo.ts
+++ b/projects/demo/src/app/vertical-nav/highlights/vertical-nav-highlights.demo.ts
@@ -17,7 +17,7 @@ import { VerticalNavCases } from '../vertical-nav-cases';
 export class VerticalNavHighlightsDemo {
   case: any;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.highlights;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.highlights;
   }
 }

--- a/projects/demo/src/app/vertical-nav/nested-icon-menus/vertical-nav-nested-icon-menus.ts
+++ b/projects/demo/src/app/vertical-nav/nested-icon-menus/vertical-nav-nested-icon-menus.ts
@@ -18,7 +18,7 @@ export class VerticalNavNestedIconMenusDemo {
   case: any;
   collapse = false;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.allNestedIconMenu;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.allNestedIconMenu;
   }
 }

--- a/projects/demo/src/app/vertical-nav/nested-menus/vertical-nav-nested-menus.ts
+++ b/projects/demo/src/app/vertical-nav/nested-menus/vertical-nav-nested-menus.ts
@@ -19,8 +19,8 @@ export class VerticalNavNestedMenusDemo {
 
   private _collapse = false;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.allNestedMenu;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.allNestedMenu;
   }
 
   get collapse(): boolean {

--- a/projects/demo/src/app/vertical-nav/partially-nested-icon-menu/vertical-nav-partial-nested-icon-menus.ts
+++ b/projects/demo/src/app/vertical-nav/partially-nested-icon-menu/vertical-nav-partial-nested-icon-menus.ts
@@ -19,8 +19,8 @@ export class VerticalNavPartiallyNestedIconMenusDemo {
 
   private _collapse = false;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.partiallyNestedIconMenu;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.partiallyNestedIconMenu;
   }
 
   get collapse(): boolean {

--- a/projects/demo/src/app/vertical-nav/partially-nested-menu/vertical-nav-partial-nested-menus.ts
+++ b/projects/demo/src/app/vertical-nav/partially-nested-menu/vertical-nav-partial-nested-menus.ts
@@ -19,8 +19,8 @@ export class VerticalNavPartiallyNestedMenusDemo {
 
   private _collapse = false;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.partiallyNestedMenu;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.partiallyNestedMenu;
   }
 
   get collapse(): boolean {

--- a/projects/demo/src/app/vertical-nav/routing/vertical-nav-routing.ts
+++ b/projects/demo/src/app/vertical-nav/routing/vertical-nav-routing.ts
@@ -20,8 +20,8 @@ export class VerticalNavRoutingDemo {
   groupExpand = true;
   navCollapsed = false;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.allNestedIconMenu;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.allNestedIconMenu;
   }
 
   updateGroupExpand(event: any) {

--- a/projects/demo/src/app/vertical-nav/unstructured-routes/unstructured-routes.ts
+++ b/projects/demo/src/app/vertical-nav/unstructured-routes/unstructured-routes.ts
@@ -20,8 +20,8 @@ export class UnstructuredRoutesDemo {
   groupExpand = true;
   navCollapsed = false;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.allNestedIconMenu;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.allNestedIconMenu;
   }
 
   updateGroupExpand(event: any) {

--- a/projects/demo/src/app/vertical-nav/without-expanded-directive/without-expanded-directive.ts
+++ b/projects/demo/src/app/vertical-nav/without-expanded-directive/without-expanded-directive.ts
@@ -20,8 +20,8 @@ export class WithoutExpandedDirectiveDemo {
   groupExpand = true;
   navCollapsed = false;
 
-  constructor(public verticalNavCases: VerticalNavCases) {
-    this.case = this.verticalNavCases.allNestedIconMenu;
+  constructor(verticalNavCases: VerticalNavCases) {
+    this.case = verticalNavCases.allNestedIconMenu;
   }
 
   updateGroupExpand(event: any) {


### PR DESCRIPTION
- remove unused parameter properties (manual)
- use parameter properties instead of a separate property (lint rule)
- remove unnecessary `this` when accessing parameter properties (lint rule for detecting unneded `this.`, manual removal of no-longer-needed properties)