### PR TITLE
fix(datagrid): virtual scroll empty space after last row

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -147,6 +147,10 @@
     overflow: auto;
     flex: 1 1 auto;
     margin-top: tokens.$cds-global-space-6;
+
+    &.cdk-virtual-scrollable .datagrid-rows {
+      flex-grow: 0;
+    }
   }
 
   .datagrid-container {
@@ -421,10 +425,6 @@
       display: flex;
       flex-direction: column;
       flex: 1 1 auto;
-
-      &.virtual-scroller {
-        flex-grow: 0;
-      }
     }
 
     .datagrid-body {

--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -420,7 +420,7 @@
     .datagrid-rows {
       display: flex;
       flex-direction: column;
-      flex: 1 1 auto;
+      flex: 0 1 auto;
     }
 
     .datagrid-body {

--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -420,7 +420,11 @@
     .datagrid-rows {
       display: flex;
       flex-direction: column;
-      flex: 0 1 auto;
+      flex: 1 1 auto;
+
+      &.virtual-scroller {
+        flex-grow: 0;
+      }
     }
 
     .datagrid-body {

--- a/projects/angular/src/data/datagrid/datagrid.html
+++ b/projects/angular/src/data/datagrid/datagrid.html
@@ -75,7 +75,7 @@
             </div>
           </div>
 
-          <div role="presentation" class="datagrid-rows">
+          <div role="presentation" class="datagrid-rows" [class.virtual-scroller]="hasVirtualScroller">
             <clr-dg-row class="datagrid-row-loading" *ngIf="loadingMoreItems">
               <clr-dg-cell>
                 <clr-spinner clrMedium></clr-spinner>

--- a/projects/angular/src/data/datagrid/datagrid.html
+++ b/projects/angular/src/data/datagrid/datagrid.html
@@ -75,7 +75,7 @@
             </div>
           </div>
 
-          <div role="presentation" class="datagrid-rows" [class.virtual-scroller]="hasVirtualScroller">
+          <div role="presentation" class="datagrid-rows">
             <clr-dg-row class="datagrid-row-loading" *ngIf="loadingMoreItems">
               <clr-dg-cell>
                 <clr-spinner clrMedium></clr-spinner>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
When using virtual scroller empty space is available after the last row.

Issue Number: CDE-2313

## What is the new behavior?
When using virtual scroller there is no empty space after the last row.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
