### PR TITLE
fix(datagrid): remove expand cell from calculations

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -1489,6 +1489,10 @@
       .datagrid-row {
         display: table-row;
 
+        clr-expandable-animation {
+          display: none;
+        }
+
         .datagrid-cell {
           // This is a hack b/c styles were not applied out of the box when moving columns into the
           // calculation container element


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Expandable rows first cell with the trigger it's rendered when calculations are happening and it's creating wrong widths for columns.
![Screenshot 2024-10-04 at 16 42 58](https://github.com/user-attachments/assets/5e359770-5488-47a9-9ec7-4e63ed1e75ae)

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: #1487

## What is the new behavior?
That cell is excluded from calculations and they are correct.
![Screenshot 2024-10-04 at 16 43 47](https://github.com/user-attachments/assets/c7e0c6d2-19f7-4dd4-a8de-21fe79fe436c)


## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
