### PR TITLE
chore(datagrid): use correct lifecycle hook for column filter label

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1509,7 +1509,7 @@ export class ClrDatagridDetailHeader implements AfterViewInit {
 // Warning: (ae-forgotten-export) The symbol "CustomFilter" needs to be exported by the entry point index.d.ts
 //
 // @public
-export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements CustomFilter, OnChanges, OnDestroy {
+export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>> implements CustomFilter, DoCheck, OnDestroy {
     constructor(_filters: FiltersProvider<T>, commonStrings: ClrCommonStringsService, smartToggleService: ClrPopoverToggleService, platformId: any, elementRef: ElementRef<HTMLElement>, keyNavigation: KeyNavigationGridController);
     get active(): boolean;
     // (undocumented)
@@ -1523,7 +1523,7 @@ export class ClrDatagridFilter<T = any> extends DatagridFilterRegistrar<T, ClrDa
     // (undocumented)
     set customFilter(filter: ClrDatagridFilterInterface<T> | RegisteredFilter<T, ClrDatagridFilterInterface<T>>);
     // (undocumented)
-    ngOnChanges(): void;
+    ngDoCheck(): void;
     // (undocumented)
     ngOnDestroy(): void;
     // (undocumented)
@@ -3642,8 +3642,7 @@ export class ClrSignpostContent extends AbstractPopover implements OnDestroy {
     // (undocumented)
     signpostContentId: string;
     // (undocumented)
-  
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrSignpostContent, "clr-signpost-content", never, {  "signpostCloseAriaLabel": "clrSignpostCloseAriaLabel"; "position": "clrPosition"; }, {}, never, ["clr-signpost-title", "*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrSignpostContent, "clr-signpost-content", never, { "signpostCloseAriaLabel": "clrSignpostCloseAriaLabel"; "position": "clrPosition"; }, {}, never, ["clr-signpost-title", "*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrSignpostContent, [null, { optional: true; }, null, null, null, null, null]>;
 }

--- a/projects/angular/src/data/datagrid/datagrid-filter.ts
+++ b/projects/angular/src/data/datagrid/datagrid-filter.ts
@@ -8,11 +8,11 @@
 import { isPlatformBrowser } from '@angular/common';
 import {
   Component,
+  DoCheck,
   ElementRef,
   EventEmitter,
   Inject,
   Input,
-  OnChanges,
   OnDestroy,
   Optional,
   Output,
@@ -83,7 +83,7 @@ import { KeyNavigationGridController } from './utils/key-navigation-grid.control
 })
 export class ClrDatagridFilter<T = any>
   extends DatagridFilterRegistrar<T, ClrDatagridFilterInterface<T>>
-  implements CustomFilter, OnChanges, OnDestroy
+  implements CustomFilter, DoCheck, OnDestroy
 {
   @Output('clrDgFilterOpenChange') openChange = new EventEmitter<boolean>(false);
 
@@ -153,10 +153,8 @@ export class ClrDatagridFilter<T = any>
     return !!this.filter && this.filter.isActive();
   }
 
-  ngOnChanges() {
-    setTimeout(() => {
-      this.setToggleButtonAriaLabel();
-    });
+  ngDoCheck() {
+    this.setToggleButtonAriaLabel();
   }
 
   override ngOnDestroy(): void {


### PR DESCRIPTION
Using `ngDoCheck` removes the need for the `setTimeout` and avoids changing a binding immediately after a change detection cycle.