### PR TITLE
chore: prevent code injection in visual snapshot commit message

### DIFF
--- a/.github/workflows/pr-visual-snapshot-update-bot.yml
+++ b/.github/workflows/pr-visual-snapshot-update-bot.yml
@@ -65,8 +65,11 @@ jobs:
           git config user.name "GitHub"
           git config user.email "noreply@github.com"
 
+          # set environment variable for sourceHeadBranch
+          sourceHeadBranch=${{steps.get-pr-event.outputs.sourceHeadBranch}}
+
           # commit changes
-          git commit --message 'chore: update visual snapshots for `${{steps.get-pr-event.outputs.sourceHeadBranch}}`'
+          git commit --message "chore: update visual snapshots for '$sourceHeadBranch'"
 
           # push changes
           git push $repositoryUrl HEAD:refs/heads/$updateBranchName --force

--- a/.github/workflows/pr-visual-snapshot-update-bot.yml
+++ b/.github/workflows/pr-visual-snapshot-update-bot.yml
@@ -60,13 +60,11 @@ jobs:
         run: |
           repositoryUrl=${{github.server_url}}/${{github.repository}}.git
           updateBranchName=visual-snapshot-update/pr-${{steps.get-pr-event.outputs.pullRequestNumber}}
+          sourceHeadBranch=${{steps.get-pr-event.outputs.sourceHeadBranch}}
 
           # configure git
           git config user.name "GitHub"
           git config user.email "noreply@github.com"
-
-          # set environment variable for sourceHeadBranch
-          sourceHeadBranch=${{steps.get-pr-event.outputs.sourceHeadBranch}}
 
           # commit changes
           git commit --message "chore: update visual snapshots for '$sourceHeadBranch'"


### PR DESCRIPTION
Fixes [https://github.com/vmware-clarity/ng-clarity/security/code-scanning/22](https://github.com/vmware-clarity/ng-clarity/security/code-scanning/22)

To fix the code injection issue, we should set the untrusted input value to an intermediate environment variable and then use the environment variable using the native shell syntax. This approach ensures that the input is handled safely and reduces the risk of code injection.

1. Define an environment variable for `sourceHeadBranch` before using it in the shell command.
2. Use the environment variable in the shell command instead of directly embedding the untrusted input.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
