### PR TITLE
fix(file-input): prevent validation error when `accept` is empty string

### DIFF
--- a/projects/angular/src/forms/file-input/file-input-validator.spec.ts
+++ b/projects/angular/src/forms/file-input/file-input-validator.spec.ts
@@ -13,6 +13,8 @@ import { ClrFormsModule } from '../forms.module';
 import { clearFiles, selectFiles } from './file-input.helpers';
 
 interface TestComponent {
+  accept: string;
+
   get control(): FormControl<FileList>;
 }
 
@@ -23,11 +25,11 @@ interface TestComponent {
         <label>File</label>
         <input
           type="file"
-          accept=".txt,text/plain"
           formControlName="files"
           clrFileInput
           [clrMinFileSize]="100"
           [clrMaxFileSize]="500"
+          [accept]="accept"
           multiple
           required
         />
@@ -42,6 +44,8 @@ interface TestComponent {
   `,
 })
 class ReactiveTest implements TestComponent {
+  accept = '.txt,text/plain';
+
   readonly form = new FormGroup({
     files: new FormControl<FileList>(undefined),
   });
@@ -58,12 +62,12 @@ class ReactiveTest implements TestComponent {
       <input
         #ngModel="ngModel"
         type="file"
-        accept=".txt,text/plain"
         name="files"
         [(ngModel)]="files"
         clrFileInput
         [clrMinFileSize]="100"
         [clrMaxFileSize]="500"
+        [accept]="accept"
         required
         multiple
       />
@@ -78,6 +82,7 @@ class ReactiveTest implements TestComponent {
 })
 class TemplateDrivenTest implements TestComponent {
   files: FileList;
+  accept = '.txt,text/plain';
 
   @ViewChild('ngModel') private readonly ngModel: NgModel;
 
@@ -138,6 +143,16 @@ function fileInputValidatorSpec(testComponent: Type<TestComponent>) {
     fixture.detectChanges();
 
     expect(getErrorMessages(nativeElement)).toBe('File type not accepted');
+  });
+
+  it('should not show the file type error when `accept` is an empty string', () => {
+    fixture.componentInstance.accept = '';
+    fixture.detectChanges();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'image.png')]);
+    fixture.detectChanges();
+
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
   });
 
   it('should show the file size error when the file is too small', () => {

--- a/projects/angular/src/forms/file-input/file-input-validator.ts
+++ b/projects/angular/src/forms/file-input/file-input-validator.ts
@@ -29,7 +29,7 @@ export class ClrFileInputValidator implements Validator {
       errors.required = true;
     }
 
-    const accept = fileInputElement.accept?.split(',').map(type => type.trim());
+    const accept = fileInputElement.accept ? fileInputElement.accept.split(',').map(type => type.trim()) : null;
 
     if (files?.length > 0 && (accept?.length || this.minFileSize || this.maxFileSize)) {
       for (let i = 0; i < files.length; i++) {

--- a/projects/angular/src/forms/file-input/file-input-validator.ts
+++ b/projects/angular/src/forms/file-input/file-input-validator.ts
@@ -31,12 +31,12 @@ export class ClrFileInputValidator implements Validator {
 
     const accept = fileInputElement.accept ? fileInputElement.accept.split(',').map(type => type.trim()) : null;
 
-    if (files?.length > 0 && (accept?.length || this.minFileSize || this.maxFileSize)) {
+    if (files?.length > 0 && (accept || this.minFileSize || this.maxFileSize)) {
       for (let i = 0; i < files.length; i++) {
         const file = files.item(i);
 
         // accept validation (native attribute)
-        if (accept?.length) {
+        if (accept) {
           const [fileExtension] = file.name.match(/\..+$/);
 
           if (!accept.includes(file.type) && !accept.includes(fileExtension)) {


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

File accept error is set when `accept=""`.

## What is the new behavior?

File accept error is not set when `accept=""`.

## Does this PR introduce a breaking change?

No.