### PR TITLE
fix(form-label): preserve id attribute if added from user

### DIFF
--- a/projects/angular/src/forms/common/label.ts
+++ b/projects/angular/src/forms/common/label.ts
@@ -28,9 +28,6 @@ import { NgControlService } from './providers/ng-control.service';
   selector: 'label',
 })
 export class ClrLabel implements OnInit, OnDestroy {
-  @Input('id') idInput: string;
-  @HostBinding('attr.id') idAttr: string;
-
   @Input('for') @HostBinding('attr.for') forAttr: string;
 
   @ContentChild(ClrSignpost, { read: ElementRef }) private signpost: ElementRef;
@@ -45,8 +42,17 @@ export class ClrLabel implements OnInit, OnDestroy {
     private el: ElementRef<HTMLLabelElement>
   ) {}
 
+  @HostBinding('attr.id')
+  get idAttr() {
+    return this.labelId;
+  }
+
   get labelText(): string {
     return this.el.nativeElement && this.el.nativeElement.textContent;
+  }
+
+  get labelId(): string {
+    return this.el.nativeElement.getAttribute('id') || this.controlIdService?.id + '-label';
   }
 
   ngOnInit() {
@@ -64,14 +70,9 @@ export class ClrLabel implements OnInit, OnDestroy {
     ) {
       this.renderer.addClass(this.el.nativeElement, 'clr-col-12');
       this.renderer.addClass(this.el.nativeElement, `clr-col-md-${this.layoutService.labelSize}`);
-    }
-    if (this.controlIdService && !this.forAttr) {
-      this.subscriptions.push(
-        this.controlIdService.idChange.subscribe(id => {
-          this.forAttr = id;
-          this.idAttr = this.idInput || `${id}-label`;
-        })
-      );
+      if (this.controlIdService && !this.forAttr) {
+        this.subscriptions.push(this.controlIdService.idChange.subscribe(id => (this.forAttr = id)));
+      }
     }
   }
 

--- a/projects/angular/src/forms/file-input/file-input-container.ts
+++ b/projects/angular/src/forms/file-input/file-input-container.ts
@@ -128,7 +128,7 @@ export class ClrFileInputContainer extends ClrAbstractContainer {
   }
 
   protected get browseButtonDescribedBy() {
-    return `${this.label?.forAttr} ${this.fileInput.elementRef.nativeElement.getAttribute('aria-describedby')}`;
+    return `${this.label.labelId} ${this.fileInput.elementRef.nativeElement.getAttribute('aria-describedby')}`;
   }
 
   protected override get successMessagePresent() {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

Preserve value of id attribute if it was added from the user. Currently we are removing whatever they put. This issue was created from https://github.com/vmware-clarity/ng-clarity/pull/1652

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

## What is the new behavior?

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
