### PR TITLE
fix(datagrid): align action items focus/hover/selected with dropdown

### DIFF
--- a/projects/angular/src/data/datagrid/STYLES.md
+++ b/projects/angular/src/data/datagrid/STYLES.md
@@ -2,58 +2,58 @@
 
 ## CSS Properties
 
-| Property Name                                        | Description                                                              |
-| ---------------------------------------------------- | ------------------------------------------------------------------------ |
-| --clr-datagrid-font-color                            | Not used.                                                                |
-| --clr-datagrid-default-border-color                  | Default border color for datagrid detail pane.                           |
-| --clr-datagrid-icon-color                            | Default color for expandable, detail caret icons and action toggle icon. |
-| --clr-datagrid-row-hover-color                       | Background color for datagrid row on hover and active action items.      |
-| --clr-datagrid-row-hover-font-color                  | Font color for active action items.                                      |
-| --clr-datagrid-action-toggle-color                   | Datagrid action toggle icon color when active.                           |
-| --clr-datagrid-pagination-btn-color                  | Color for pagination buttons.                                            |
-| --clr-datagrid-pagination-btn-disabled-color         | Color for disabled pagination buttons.                                   |
-| --clr-datagrid-pagination-btn-disabled-opacity       | Opacity for disabled pagination buttons.                                 |
-| --clr-datagrid-pagination-input-border-color         | Border color for the pagination input field.                             |
-| --clr-datagrid-pagination-input-border-focus-color   | Border color for the pagination input field when focused.                |
-| --clr-datagrid-popover-bg-color                      | Background color for popovers within the datagrid.                       |
-| --clr-datagrid-popover-border-color                  | Border color for popovers within the datagrid.                           |
-| --clr-datagrid-action-popover-hover-color            | Background color of action items on hover and focus.                     |
-| --clr-datagrid-row-selected                          | Font color for selected rows.                                            |
-| --clr-datagrid-row-selected-background-color         | Background color for selected rows.                                      |
-| --clr-datagrid-row-selected-active-background-color  | Background color for active on selected rows.                            |
-| --clr-datagrid-row-selected-hover-background-color   | Background color for hover on selected rows.                             |
-| --clr-datagrid-column-switch-header-font-color       | Font color for column switch header button icons.                        |
-| --clr-datagrid-column-switch-header-font-hover-color | Font color for column switch button icons on hover.                      |
-| --clr-datagrid-detail-caret-icon-open-bg-color       | Background color for opened detail caret button.                         |
-| --clr-datagrid-detail-caret-icon-open-icon-color     | Color of opened detail caret icon.                                       |
-| --clr-datagrid-placeholder-color                     | Font color for empty datagrid placeholder.                               |
-| --clr-datagrid-placeholder-font-size                 | Font size for empty datagrid placeholder.                                |
-| --clr-datagrid-loading-background                    | Background color for the loading state of the datagrid.                  |
-| --clr-datagrid-column-toggle-border-color            | Border color for column toggle buttons.                                  |
-| --clr-datagrid-column-toggle-fill-color              | Background color for column toggle buttons.                              |
-| --clr-datagrid-column-toggle-text-color              | Text color for column toggle buttons.                                    |
-| --clr-datagrid-column-toggle-border-hover-color      | Border color for column toggle buttons when hovered.                     |
-| --clr-datagrid-column-toggle-fill-hover-color        | Background color for column toggle buttons when hovered.                 |
-| --clr-datagrid-column-toggle-text-hover-color        | Text color for column toggle buttons when hovered.                       |
-| --clr-datagrid-column-toggle-border-active-color     | Border color for active column toggle buttons.                           |
-| --clr-datagrid-column-toggle-fill-active-color       | Background color for active column toggle buttons.                       |
-| --clr-datagrid-column-toggle-text-active-color       | Text color for active column toggle buttons.                             |
-| --clr-datagrid-popovers-box-shadow-color             | Not used.                                                                |
-| --clr-datagrid-popover-font-color                    | Font color for popovers.                                                 |
-| --clr-datagrid-detail-pane-content-padding           | Padding for detail panel content                                         |
-| --clr-datagrid-detail-pane-close-icon-size           | Width and Height for detail close icon                                   |
-| --clr-datagrid-detail-body-text-color                | Font color for detail body                                               |
-| --clr-datagrid-detail-header-title-color             | Font color for detail header title                                       |
-| --clr-datagrid-detail-pane-bg-color                  | Background color for detail panel                                        |
-| --clr-datagrid-detail-pane-border-color              | Border color for detail panel                                            |
-| --clr-datagrid-placeholder-font-weight               | Font weight for placeholder                                              |
-| --clr-datagrid-placeholder-line-height               | Line height for placeholder                                              |
-| --clr-datagrid-placeholder-letter-spacing            | Letter spacing for placeholder                                           |
-| --clr-datagrid-placeholder-background-color          | Background color for placeholder                                         |
-| --clr-datagrid-column-separator-height               | Height for column separator                                              |
-| --clr-datagrid-filter-toggle-size                    | Width and Height for filter toggle button                                |
-| --clr-datagrid-row-active-color                      | Background color for active state on rows                                |
-| --clr-datagrid-fixed-column-size                     | Size for fixed columns inside datagrid                                   |
+| Property Name                                        | Description                                                                  |
+| ---------------------------------------------------- | ---------------------------------------------------------------------------- |
+| --clr-datagrid-font-color                            | Not used.                                                                    |
+| --clr-datagrid-default-border-color                  | Default border color for datagrid detail pane.                               |
+| --clr-datagrid-icon-color                            | Default color for expandable, detail caret icons and action toggle icon.     |
+| --clr-datagrid-row-hover-color                       | Background color for datagrid row on hover and active action items.          |
+| --clr-datagrid-row-hover-font-color                  | Font color for active action items. (unused, remove in v18)                  |
+| --clr-datagrid-action-toggle-color                   | Datagrid action toggle icon color when active.                               |
+| --clr-datagrid-pagination-btn-color                  | Color for pagination buttons.                                                |
+| --clr-datagrid-pagination-btn-disabled-color         | Color for disabled pagination buttons.                                       |
+| --clr-datagrid-pagination-btn-disabled-opacity       | Opacity for disabled pagination buttons.                                     |
+| --clr-datagrid-pagination-input-border-color         | Border color for the pagination input field.                                 |
+| --clr-datagrid-pagination-input-border-focus-color   | Border color for the pagination input field when focused.                    |
+| --clr-datagrid-popover-bg-color                      | Background color for popovers within the datagrid.                           |
+| --clr-datagrid-popover-border-color                  | Border color for popovers within the datagrid.                               |
+| --clr-datagrid-action-popover-hover-color            | Background color of action items on hover and focus. (unused, remove in v18) |
+| --clr-datagrid-row-selected                          | Font color for selected rows.                                                |
+| --clr-datagrid-row-selected-background-color         | Background color for selected rows.                                          |
+| --clr-datagrid-row-selected-active-background-color  | Background color for active on selected rows.                                |
+| --clr-datagrid-row-selected-hover-background-color   | Background color for hover on selected rows.                                 |
+| --clr-datagrid-column-switch-header-font-color       | Font color for column switch header button icons.                            |
+| --clr-datagrid-column-switch-header-font-hover-color | Font color for column switch button icons on hover.                          |
+| --clr-datagrid-detail-caret-icon-open-bg-color       | Background color for opened detail caret button.                             |
+| --clr-datagrid-detail-caret-icon-open-icon-color     | Color of opened detail caret icon.                                           |
+| --clr-datagrid-placeholder-color                     | Font color for empty datagrid placeholder.                                   |
+| --clr-datagrid-placeholder-font-size                 | Font size for empty datagrid placeholder.                                    |
+| --clr-datagrid-loading-background                    | Background color for the loading state of the datagrid.                      |
+| --clr-datagrid-column-toggle-border-color            | Border color for column toggle buttons.                                      |
+| --clr-datagrid-column-toggle-fill-color              | Background color for column toggle buttons.                                  |
+| --clr-datagrid-column-toggle-text-color              | Text color for column toggle buttons.                                        |
+| --clr-datagrid-column-toggle-border-hover-color      | Border color for column toggle buttons when hovered.                         |
+| --clr-datagrid-column-toggle-fill-hover-color        | Background color for column toggle buttons when hovered.                     |
+| --clr-datagrid-column-toggle-text-hover-color        | Text color for column toggle buttons when hovered.                           |
+| --clr-datagrid-column-toggle-border-active-color     | Border color for active column toggle buttons.                               |
+| --clr-datagrid-column-toggle-fill-active-color       | Background color for active column toggle buttons.                           |
+| --clr-datagrid-column-toggle-text-active-color       | Text color for active column toggle buttons.                                 |
+| --clr-datagrid-popovers-box-shadow-color             | Not used.                                                                    |
+| --clr-datagrid-popover-font-color                    | Font color for popovers.                                                     |
+| --clr-datagrid-detail-pane-content-padding           | Padding for detail panel content                                             |
+| --clr-datagrid-detail-pane-close-icon-size           | Width and Height for detail close icon                                       |
+| --clr-datagrid-detail-body-text-color                | Font color for detail body                                                   |
+| --clr-datagrid-detail-header-title-color             | Font color for detail header title                                           |
+| --clr-datagrid-detail-pane-bg-color                  | Background color for detail panel                                            |
+| --clr-datagrid-detail-pane-border-color              | Border color for detail panel                                                |
+| --clr-datagrid-placeholder-font-weight               | Font weight for placeholder                                                  |
+| --clr-datagrid-placeholder-line-height               | Line height for placeholder                                                  |
+| --clr-datagrid-placeholder-letter-spacing            | Letter spacing for placeholder                                               |
+| --clr-datagrid-placeholder-background-color          | Background color for placeholder                                             |
+| --clr-datagrid-column-separator-height               | Height for column separator                                                  |
+| --clr-datagrid-filter-toggle-size                    | Width and Height for filter toggle button                                    |
+| --clr-datagrid-row-active-color                      | Background color for active state on rows                                    |
+| --clr-datagrid-fixed-column-size                     | Size for fixed columns inside datagrid                                       |
 
 ## CSS Classes
 

--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -10,6 +10,7 @@
 @use '../../image/icons.clarity';
 @use '../../utils/mixins';
 @use '../../utils/variables/variables';
+@use '../../popover/dropdown/menu-mixins.clarity';
 @use '../../button/variables.buttons' as button-variables;
 @use '../../forms/styles/variables.forms' as forms-variables;
 @use '../../modal/variables.modal' as modal-variables;
@@ -69,55 +70,7 @@
   }
 
   .action-item {
-    color: datagrid-variables.$clr-datagrid-popover-font-color;
-    @include mixins.generate-typography-token('SECONDARY-13-RG-EXP');
-
-    background: transparent;
-    border: 0;
-    cursor: pointer;
-    display: block;
-    margin: 0;
-    padding: 0 tokens.$cds-global-space-9 0 tokens.$cds-global-space-7;
-    text-align: left;
-    width: 100%;
-
-    &:hover,
-    &:focus {
-      text-decoration: none;
-      background-color: datagrid-variables.$clr-datagrid-action-popover-hover-color;
-    }
-
-    &.active {
-      background-color: datagrid-variables.$clr-datagrid-row-hover-color;
-      color: datagrid-variables.$clr-datagrid-row-hover-font-color;
-    }
-
-    &:focus {
-      outline: 0;
-    }
-
-    &.disabled,
-    &:disabled {
-      cursor: not-allowed;
-      opacity: 0.4;
-      user-select: none;
-
-      &:hover {
-        background: none;
-      }
-
-      &:active,
-      &:focus {
-        background: none;
-        box-shadow: none;
-      }
-    }
-
-    cds-icon,
-    clr-icon {
-      vertical-align: middle;
-      transform: translate3d(0px, calc(-1 * tokens.$cds-global-space-1), 0);
-    }
+    @include menu-mixins.generate-dropdown-item();
   }
 }
 

--- a/projects/angular/src/data/datagrid/_properties.datagrid.scss
+++ b/projects/angular/src/data/datagrid/_properties.datagrid.scss
@@ -19,6 +19,7 @@
     --clr-datagrid-icon-color: #{tokens.$cds-alias-object-interaction-color};
     --clr-datagrid-row-hover-color: #{tokens.$cds-alias-object-interaction-background-hover};
     --clr-datagrid-row-active-color: #{tokens.$cds-alias-object-interaction-background-active};
+    /* unused, remove in v18 */
     --clr-datagrid-row-hover-font-color: #{tokens.$cds-alias-typography-color-500};
     --clr-datagrid-action-toggle-color: #{tokens.$cds-alias-object-interaction-color-active};
     --clr-datagrid-pagination-btn-color: #{tokens.$cds-alias-object-interaction-color};
@@ -28,6 +29,7 @@
     --clr-datagrid-popover-bg-color: #{tokens.$cds-alias-object-container-background};
     --clr-datagrid-popover-border-color: #{tokens.$cds-alias-object-border-color};
     --clr-datagrid-popover-font-color: #{tokens.$cds-alias-typography-color-400};
+    /* unused, remove in v18 */
     --clr-datagrid-action-popover-hover-color: #{tokens.$cds-alias-object-interaction-background-hover};
     --clr-datagrid-row-selected: #{tokens.$cds-alias-typography-color-500};
     --clr-datagrid-row-selected-background-color: #{tokens.$cds-alias-object-interaction-background-selected};

--- a/projects/angular/src/data/datagrid/_variables.datagrid.scss
+++ b/projects/angular/src/data/datagrid/_variables.datagrid.scss
@@ -13,6 +13,7 @@ $clr-datagrid-default-border-color: var(--clr-datagrid-default-border-color) !de
 $clr-datagrid-icon-color: var(--clr-datagrid-icon-color) !default;
 $clr-datagrid-row-hover-color: var(--clr-datagrid-row-hover-color) !default;
 $clr-datagrid-row-active-color: var(--clr-datagrid-row-active-color) !default;
+/* unused, remove in v18 */
 $clr-datagrid-row-hover-font-color: var(--clr-datagrid-row-hover-font-color) !default;
 $clr-datagrid-action-toggle-color: var(--clr-datagrid-action-toggle-color) !default;
 $clr-datagrid-pagination-btn-color: var(--clr-datagrid-pagination-btn-color) !default;
@@ -22,6 +23,7 @@ $clr-datagrid-pagination-input-border-focus-color: var(--clr-datagrid-pagination
 $clr-datagrid-popover-bg-color: var(--clr-datagrid-popover-bg-color) !default;
 $clr-datagrid-popover-border-color: var(--clr-datagrid-popover-border-color) !default;
 $clr-datagrid-popover-font-color: var(--clr-datagrid-popover-font-color) !default;
+/* unused, remove in v18 */
 $clr-datagrid-action-popover-hover-color: var(--clr-datagrid-action-popover-hover-color) !default;
 $clr-datagrid-row-selected: var(--clr-datagrid-row-selected) !default;
 $clr-datagrid-row-selected-background-color: var(--clr-datagrid-row-selected-background-color) !default;


### PR DESCRIPTION
Use the same styles as dropdown items for datagrid action items. This results in focus being indicated with an outline instead of focus and hover using the same background color.

CDE-2565