### PR TITLE
fix(datagrid): focus handling on actionable element click

### DIFF
--- a/projects/angular/src/data/datagrid/utils/key-navigation-grid.controller.ts
+++ b/projects/angular/src/data/datagrid/utils/key-navigation-grid.controller.ts
@@ -21,12 +21,12 @@ const actionableItemSelectors = [
   'iframe',
   'object',
   'embed',
-  '*[contenteditable=true]',
+  '[contenteditable=true]',
   '[role=button]:not([disabled])',
 ];
 
 export function getTabableItems(el: HTMLElement) {
-  const tabableItemSelectors = [...actionableItemSelectors, '*[tabindex="0"]:not([disabled])'];
+  const tabableItemSelectors = [...actionableItemSelectors, '[tabindex="0"]:not([disabled])'];
   const tabableSelector = tabableItemSelectors.join(',');
   return Array.from(el.querySelectorAll(tabableSelector)) as HTMLElement[];
 }
@@ -197,7 +197,7 @@ export class KeyNavigationGridController implements OnDestroy {
     const item =
       activeCell.getAttribute('role') !== 'columnheader' && actionableItems[0] ? actionableItems[0] : activeCell;
 
-    if (!(this.skipItemFocus || keepFocus)) {
+    if (!this.skipItemFocus && !keepFocus) {
       item.focus();
     }
   }

--- a/projects/angular/src/data/datagrid/utils/key-navigation-grid.controller.ts
+++ b/projects/angular/src/data/datagrid/utils/key-navigation-grid.controller.ts
@@ -11,7 +11,7 @@ import { debounceTime, takeUntil } from 'rxjs/operators';
 
 import { Keys } from '../../../utils/enums/keys.enum';
 
-const actionableItems = [
+const actionableItemSelectors = [
   'a[href]',
   'area[href]',
   'input:not([disabled])',
@@ -26,13 +26,13 @@ const actionableItems = [
 ];
 
 export function getTabableItems(el: HTMLElement) {
-  const tabableItems = [...actionableItems, '*[tabindex="0"]:not([disabled])'];
-  const tabableSelector = tabableItems.join(',');
+  const tabableItemSelectors = [...actionableItemSelectors, '*[tabindex="0"]:not([disabled])'];
+  const tabableSelector = tabableItemSelectors.join(',');
   return Array.from(el.querySelectorAll(tabableSelector)) as HTMLElement[];
 }
 
 function isActionableItem(el: HTMLElement) {
-  const actionableSelector = actionableItems.join(',');
+  const actionableSelector = actionableItemSelectors.join(',');
   return el.matches(actionableSelector);
 }
 
@@ -100,7 +100,7 @@ export class KeyNavigationGridController implements OnDestroy {
                 )
               : null;
             if (activeCell) {
-              this.setActiveCell(activeCell, isActionableItem(e.target as HTMLElement));
+              this.setActiveCell(activeCell, { keepFocus: isActionableItem(e.target as HTMLElement) });
             }
           }
         });
@@ -183,7 +183,7 @@ export class KeyNavigationGridController implements OnDestroy {
     return this._activeCell;
   }
 
-  setActiveCell(activeCell: HTMLElement, actionableItem = false) {
+  setActiveCell(activeCell: HTMLElement, { keepFocus } = { keepFocus: false }) {
     const prior = this.cells ? Array.from(this.cells).find(c => c.getAttribute('tabindex') === '0') : null;
 
     if (prior) {
@@ -197,7 +197,7 @@ export class KeyNavigationGridController implements OnDestroy {
     const item =
       activeCell.getAttribute('role') !== 'columnheader' && actionableItems[0] ? actionableItems[0] : activeCell;
 
-    if (!this.skipItemFocus && !actionableItem) {
+    if (!(this.skipItemFocus || keepFocus)) {
       item.focus();
     }
   }

--- a/projects/angular/src/data/datagrid/utils/key-navigation-grid.controller.ts
+++ b/projects/angular/src/data/datagrid/utils/key-navigation-grid.controller.ts
@@ -11,22 +11,29 @@ import { debounceTime, takeUntil } from 'rxjs/operators';
 
 import { Keys } from '../../../utils/enums/keys.enum';
 
+const actionableItems = [
+  'a[href]',
+  'area[href]',
+  'input:not([disabled])',
+  'button:not([disabled])',
+  'select:not([disabled])',
+  'textarea:not([disabled])',
+  'iframe',
+  'object',
+  'embed',
+  '*[contenteditable=true]',
+  '[role=button]:not([disabled])',
+];
+
 export function getTabableItems(el: HTMLElement) {
-  const tabableSelector = [
-    'a[href]',
-    'area[href]',
-    'input:not([disabled])',
-    'button:not([disabled])',
-    'select:not([disabled])',
-    'textarea:not([disabled])',
-    'iframe',
-    'object',
-    'embed',
-    '*[tabindex]:not([disabled])',
-    '*[contenteditable=true]',
-    '[role=button]:not([disabled])',
-  ].join(',');
+  const tabableItems = [...actionableItems, '*[tabindex="0"]:not([disabled])'];
+  const tabableSelector = tabableItems.join(',');
   return Array.from(el.querySelectorAll(tabableSelector)) as HTMLElement[];
+}
+
+function isActionableItem(el: HTMLElement) {
+  const actionableSelector = actionableItems.join(',');
+  return el.matches(actionableSelector);
 }
 
 export interface KeyNavigationGridConfig {
@@ -93,7 +100,7 @@ export class KeyNavigationGridController implements OnDestroy {
                 )
               : null;
             if (activeCell) {
-              this.setActiveCell(activeCell);
+              this.setActiveCell(activeCell, isActionableItem(e.target as HTMLElement));
             }
           }
         });
@@ -176,7 +183,7 @@ export class KeyNavigationGridController implements OnDestroy {
     return this._activeCell;
   }
 
-  setActiveCell(activeCell: HTMLElement) {
+  setActiveCell(activeCell: HTMLElement, actionableItem = false) {
     const prior = this.cells ? Array.from(this.cells).find(c => c.getAttribute('tabindex') === '0') : null;
 
     if (prior) {
@@ -186,10 +193,11 @@ export class KeyNavigationGridController implements OnDestroy {
     activeCell.setAttribute('tabindex', '0');
     this._activeCell = activeCell;
 
-    const items = getTabableItems(activeCell);
-    const item = activeCell.getAttribute('role') !== 'columnheader' && items[0] ? items[0] : activeCell;
+    const actionableItems = getTabableItems(activeCell);
+    const item =
+      activeCell.getAttribute('role') !== 'columnheader' && actionableItems[0] ? actionableItems[0] : activeCell;
 
-    if (!this.skipItemFocus) {
+    if (!this.skipItemFocus && !actionableItem) {
       item.focus();
     }
   }

--- a/projects/demo/src/app/datagrid/expandable-rows/expandable-rows.html
+++ b/projects/demo/src/app/datagrid/expandable-rows/expandable-rows.html
@@ -75,13 +75,18 @@
       <clr-dg-row-detail *clrIfExpanded [clrDgReplace]="replace">
         <ng-template [clrFakeLoader]="slowLoad" clrLoading>
           <ng-template [ngIf]="detail === 'default'">
-            Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin in neque in ante placerat mattis id sed quam.
-            Proin rhoncus lacus et tempor dignissim. Vivamus sem quam, pellentesque aliquet suscipit eget, pellentesque
-            sed arcu. Vivamus in dui lectus. Suspendisse cursus est ac nisl imperdiet viverra. Aenean sagittis nibh
-            lacus, in eleifend urna ultrices et. Mauris porttitor nisi nec velit pharetra porttitor. Vestibulum
-            vulputate sollicitudin dolor ut tincidunt. Phasellus vitae blandit felis. Nullam posuere ipsum tincidunt
-            velit pellentesque rhoncus. Morbi faucibus ut ipsum at malesuada. Nam vestibulum felis sit amet metus
-            finibus hendrerit. Fusce faucibus odio eget ex vulputate rhoncus. Fusce nec aliquam leo, at suscipit diam.
+            <input type="checkbox" id="top-input" />
+            <div>
+              Lorem ipsum dolor sit amet, consectetur adipiscing elit. Proin in neque in ante placerat mattis id sed
+              quam. Proin rhoncus lacus et tempor dignissim. Vivamus sem quam, pellentesque aliquet suscipit eget,
+              pellentesque sed arcu. Vivamus in dui lectus. Suspendisse cursus est ac nisl imperdiet viverra. Aenean
+              sagittis nibh lacus, in eleifend urna ultrices et. Mauris porttitor nisi nec velit pharetra porttitor.
+              Vestibulum vulputate sollicitudin dolor ut tincidunt. Phasellus vitae blandit felis. Nullam posuere ipsum
+              tincidunt velit pellentesque rhoncus. Morbi faucibus ut ipsum at malesuada. Nam vestibulum felis sit amet
+              metus finibus hendrerit. Fusce faucibus odio eget ex vulputate rhoncus. Fusce nec aliquam leo, at suscipit
+              diam.
+            </div>
+            <input type="checkbox" id="bottom-input" />
           </ng-template>
 
           <ng-template [ngIf]="detail === 'columns'">


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When multiple actionable items exist in cell, clicking on any of them, or the cell itself, would forcefully focus the first actionable item.

Issue Number: CDE-2404

## What is the new behavior?

Focusing on actionable items in a cell leaves the focus on the clicked item.
Refocusing when clicking on non-actionable content is preserved.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
