### PR TITLE
chore(ci): prevent other branches cancelling preview build workflow

### DIFF
--- a/.github/workflows/update-preview-build-branches.yml
+++ b/.github/workflows/update-preview-build-branches.yml
@@ -9,7 +9,7 @@ on:
 permissions:
   contents: write
 concurrency:
-  group: update-preview-build-branches
+  group: update-preview-build-branches-${{github.ref_name}}
   cancel-in-progress: true
 jobs:
   update-preview-build-branches:


### PR DESCRIPTION
This fixes a mistake I made in #1737 (ae5e764304aa468ca0c8c1ee2ddf9e72e33de916).