### PR TITLE
chore(ci): create new preview build branches for workflow dispatch

### DIFF
--- a/scripts/update-preview-build-branches.sh
+++ b/scripts/update-preview-build-branches.sh
@@ -7,27 +7,27 @@ git fetch origin preview-build/$GIT_BRANCH/clr-ui
 git fetch origin preview-build/$GIT_BRANCH/clr-angular
 
 # add worktrees
-git worktree add --track -b preview-build/$GIT_BRANCH/clr-ui preview-build/$GIT_BRANCH/clr-ui origin/preview-build/$GIT_BRANCH/clr-ui
-git worktree add --track -b preview-build/$GIT_BRANCH/clr-angular preview-build/$GIT_BRANCH/clr-angular origin/preview-build/$GIT_BRANCH/clr-angular
+git worktree add --track -b preview-build-clr-ui preview-build-clr-ui origin/preview-build/$GIT_BRANCH/clr-ui || git worktree add --orphan preview-build-clr-ui
+git worktree add --track -b preview-build-clr-angular preview-build-clr-angular origin/preview-build/$GIT_BRANCH/clr-angular || git worktree add --orphan preview-build-clr-angular
 
 # delete old files
-rm -rf ./preview-build/$GIT_BRANCH/clr-ui/*
-rm -rf ./preview-build/$GIT_BRANCH/clr-angular/*
+rm -rf ./preview-build-clr-ui/*
+rm -rf ./preview-build-clr-angular/*
 
 # copy new files
-cp -r ./dist/clr-ui/* ./preview-build/$GIT_BRANCH/clr-ui
-cp -r ./dist/clr-angular/* ./preview-build/$GIT_BRANCH/clr-angular
+cp -r ./dist/clr-ui/* ./preview-build-clr-ui
+cp -r ./dist/clr-angular/* ./preview-build-clr-angular
 
 # push @clr/ui
-pushd ./preview-build/$GIT_BRANCH/clr-ui
+pushd ./preview-build-clr-ui
 git add .
 git commit -m "update build for commit $GIT_COMMIT_SHA"
-git push origin preview-build/$GIT_BRANCH/clr-ui:preview-build/$GIT_BRANCH/clr-ui
+git push origin preview-build-clr-ui:refs/heads/preview-build/$GIT_BRANCH/clr-ui
 popd
 
 # push @clr/angular
-pushd ./preview-build/$GIT_BRANCH/clr-angular
+pushd ./preview-build-clr-angular
 git add .
 git commit -m "update build for commit $GIT_COMMIT_SHA"
-git push origin preview-build/$GIT_BRANCH/clr-angular:preview-build/$GIT_BRANCH/clr-angular
+git push origin preview-build-clr-angular:refs/heads/preview-build/$GIT_BRANCH/clr-angular
 popd


### PR DESCRIPTION
I needed to change the local folder and branch name so that it doesn't use slashes because `git worktree add --orphan [branch]` does not work with slashes in the branch name.