### PR TITLE
fix(typography): add `cds-text` font family override

### DIFF
--- a/projects/ui/src/temp-overrides.scss
+++ b/projects/ui/src/temp-overrides.scss
@@ -8,6 +8,9 @@
 
 :root {
   [cds-theme] {
+    // font family override
+    --cds-global-typography-font-family: var(--clr-metropolis-font-family);
+
     --cds-alias-utility-gray: #{tokens.$cds-global-color-construction-600};
 
     --cds-alias-object-container-backdrop-background: hsla(0, 0%, 100%, 0.6);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Font family for `cds-text` token is using `Clarity City`.

Issue Number: CDE-2628

## What is the new behavior?
Override font family for `cds-text` token to use `Metropolis`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No


## Other information
