### PR TITLE
chore(datagrid): make "server-driven, trackBy item" demo work

### DIFF
--- a/projects/demo/src/app/datagrid/preserve-selection/preserve-selection.html
+++ b/projects/demo/src/app/datagrid/preserve-selection/preserve-selection.html
@@ -179,6 +179,7 @@
   (clrDgRefresh)="refresh($event)"
   [clrDgLoading]="loading"
   [clrDgPreserveSelection]="preserveFilteringServerTrackBy"
+  [clrDgItemsTrackBy]="trackItemById"
 >
   <clr-dg-column>User ID</clr-dg-column>
   <clr-dg-column [clrDgField]="'name'" [(clrFilterValue)]="nameFilterServerTrackBy">Name</clr-dg-column>

--- a/projects/demo/src/app/datagrid/preserve-selection/preserve-selection.ts
+++ b/projects/demo/src/app/datagrid/preserve-selection/preserve-selection.ts
@@ -6,7 +6,7 @@
  */
 
 import { Component, TrackByFunction } from '@angular/core';
-import { ClrDatagridStateInterface } from '@clr/angular';
+import { ClrDatagridItemsTrackByFunction, ClrDatagridStateInterface } from '@clr/angular';
 
 import { Inventory } from '../inventory/inventory';
 import { User } from '../inventory/user';
@@ -53,6 +53,7 @@ export class DatagridPreserveSelectionDemo {
 
   trackByIndex: TrackByFunction<User> = index => index;
   trackById: TrackByFunction<User> = (_index, item) => item.id;
+  trackItemById: ClrDatagridItemsTrackByFunction<User> = item => item.id;
 
   async refresh(state: ClrDatagridStateInterface) {
     this.loading = true;


### PR DESCRIPTION
I missed this demo in 8fe236acdd40401d7ecaf0e014587bace1d14fea (#539) and a5694637356de642090ecf5f78bca96372fb8615 (#1144).