### PR TITLE
chore: make visual regression threshold more strict

### DIFF
--- a/tests/visual-snapshots.spec.ts
+++ b/tests/visual-snapshots.spec.ts
@@ -55,7 +55,7 @@ for (const { storyId, component } of stories) {
         fullPage,
         animations: 'disabled',
         caret: 'hide',
-        threshold: 0.01,
+        threshold: 0.008,
       });
     });
   }


### PR DESCRIPTION
Visual regression threshold needs to be stricter because some very slight color changes are not calculated.

related to #1799 