### PR TITLE
chore: use `NETLIFY_SITE_NAME` secret instead hard-coding the site name

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -46,4 +46,4 @@ jobs:
         timeout-minutes: 5
         env:
           NETLIFY_AUTH_TOKEN: ${{secrets.NETLIFY_AUTH_TOKEN}}
-        run: npx netlify-cli deploy --site storybook-clarity-design --alias ${{steps.get-pr-event.outputs.pullRequestNumber}}
+        run: npx netlify-cli deploy --site ${{secrets.NETLIFY_SITE_NAME}} --alias ${{steps.get-pr-event.outputs.pullRequestNumber}}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -33,4 +33,4 @@ jobs:
         timeout-minutes: 5
         env:
           NETLIFY_AUTH_TOKEN: ${{secrets.NETLIFY_AUTH_TOKEN}}
-        run: npx netlify-cli deploy --site storybook-clarity-design
+        run: npx netlify-cli deploy --site ${{secrets.NETLIFY_SITE_NAME}}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,4 @@ jobs:
         timeout-minutes: 5
         env:
           NETLIFY_AUTH_TOKEN: ${{secrets.NETLIFY_AUTH_TOKEN}}
-        run: npx netlify-cli deploy --site storybook-clarity-design $([[ $GITHUB_REF_NAME == "main" ]] && echo "--prod")
+        run: npx netlify-cli deploy --site ${{secrets.NETLIFY_SITE_NAME}} $([[ $GITHUB_REF_NAME == "main" ]] && echo "--prod")


### PR DESCRIPTION
This change makes the actions consistent. The secret was already used in the "PR Comment Bot" workflow.