### PR TITLE
chore: pin to `netlify-cli@20.1.1` to prevent error

### DIFF
--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -46,4 +46,4 @@ jobs:
         timeout-minutes: 5
         env:
           NETLIFY_AUTH_TOKEN: ${{secrets.NETLIFY_AUTH_TOKEN}}
-        run: npx netlify-cli deploy --site storybook-clarity-design --alias ${{steps.get-pr-event.outputs.pullRequestNumber}}
+        run: npx netlify-cli@20.1.1 deploy --site storybook-clarity-design --alias ${{steps.get-pr-event.outputs.pullRequestNumber}}

--- a/.github/workflows/release-preview.yml
+++ b/.github/workflows/release-preview.yml
@@ -33,4 +33,4 @@ jobs:
         timeout-minutes: 5
         env:
           NETLIFY_AUTH_TOKEN: ${{secrets.NETLIFY_AUTH_TOKEN}}
-        run: npx netlify-cli deploy --site storybook-clarity-design
+        run: npx netlify-cli@20.1.1 deploy --site storybook-clarity-design

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -35,4 +35,4 @@ jobs:
         timeout-minutes: 5
         env:
           NETLIFY_AUTH_TOKEN: ${{secrets.NETLIFY_AUTH_TOKEN}}
-        run: npx netlify-cli deploy --site storybook-clarity-design $([[ $GITHUB_REF_NAME == "main" ]] && echo "--prod")
+        run: npx netlify-cli@20.1.1 deploy --site storybook-clarity-design $([[ $GITHUB_REF_NAME == "main" ]] && echo "--prod")


### PR DESCRIPTION
This prevents the following error:

```
Failed retrieving site data for site storybook-clarity-design: Not Found. Double-check your login status with 'netlify status' or contact support with details of your error.
```

I am not sure why this is happening with v21.