### PR TITLE
fix(badge): nesting inside alert color issue

### DIFF
--- a/projects/angular/src/emphasis/alert/_alert.clarity.scss
+++ b/projects/angular/src/emphasis/alert/_alert.clarity.scss
@@ -19,7 +19,7 @@
   background: alert-variables.getAlertColor($alertType, bg-color);
   color: alert-variables.getAlertColor($alertType, color);
 
-  & .alert-items .alert-item a {
+  & .alert-items .alert-item a:not(.badge) {
     color: alert-variables.getAlertColor($alertType, color);
 
     cds-icon,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The color of the link badge nested in alert is wrong
<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-2682

## What is the new behavior?
Keep the color no matter if it is nested or not.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
Tests are added in https://github.com/vmware-clarity/ng-clarity/pull/1771