### PR TITLE
fix(wizard): remove header actions from `role="heading"` element

### DIFF
--- a/projects/angular/src/wizard/_wizard.clarity.scss
+++ b/projects/angular/src/wizard/_wizard.clarity.scss
@@ -94,7 +94,6 @@
     }
 
     .modal-header-actions-wrapper {
-      flex: 1 0 auto;
       height: wizard-variables.$clr-wizard-default-space;
       padding-left: tokens.$cds-global-space-6;
       padding-right: tokens.$cds-global-space-3;

--- a/projects/angular/src/wizard/wizard.html
+++ b/projects/angular/src/wizard/wizard.html
@@ -46,15 +46,14 @@
             <span tabindex="-1" #pageTitle class="modal-title-text">
               <ng-template [ngTemplateOutlet]="navService.currentPageTitle"></ng-template>
             </span>
-
-            <div class="modal-header-actions-wrapper" *ngIf="headerActionService.displayHeaderActionsWrapper">
-              <div *ngIf="headerActionService.showWizardHeaderActions">
-                <ng-content select="clr-wizard-header-action"></ng-content>
-              </div>
-              <div *ngIf="headerActionService.currentPageHasHeaderActions">
-                <ng-template [ngTemplateOutlet]="navService.currentPage.headerActions"></ng-template>
-              </div>
-            </div>
+          </div>
+        </div>
+        <div class="modal-header-actions-wrapper" *ngIf="headerActionService.displayHeaderActionsWrapper">
+          <div *ngIf="headerActionService.showWizardHeaderActions">
+            <ng-content select="clr-wizard-header-action"></ng-content>
+          </div>
+          <div *ngIf="headerActionService.currentPageHasHeaderActions">
+            <ng-template [ngTemplateOutlet]="navService.currentPage.headerActions"></ng-template>
           </div>
         </div>
         <button


### PR DESCRIPTION
## PR Checklist

- [N/A] Tests for the changes have been added (for bug fixes / features)
- [N/A] Docs have been added / updated (for bug fixes / features)
- [N/A] If applicable, have a visual design approval

## PR Type

Bugfix

## What is the current behavior?

The wizard header action buttons are in nested inside the step title `role="heading"` element which is invalid semantics.

Issue Number: N/A

## What is the new behavior?

The wizard header action buttons are in not nested inside the step title `role="heading"` element.

## Does this PR introduce a breaking change?

No.