### PR TITLE
chore: minor cleanup for visual snapshot screenshot options

### DIFF
--- a/tests/screenshot-options.ts
+++ b/tests/screenshot-options.ts
@@ -5,8 +5,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-type ScreenshotOptionsT = {
-  [key: string]: { fullPageScreenshot?: boolean; viewport?: { width: number; height: number } };
+type ScreenshotOptions = {
+  [componentOrStoryName: string]: { fullPageScreenshot?: boolean; viewport?: { width: number; height: number } };
 };
 
 /**
@@ -23,7 +23,7 @@ type ScreenshotOptionsT = {
  *
  * If a component name is used, all stories under that component name will use the options specified.
  */
-export const ScreenshotOptions: ScreenshotOptionsT = {
+export const screenshotOptions: ScreenshotOptions = {
   dropdown: {
     fullPageScreenshot: true,
   },

--- a/tests/visual-snapshots.spec.ts
+++ b/tests/visual-snapshots.spec.ts
@@ -10,7 +10,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 
 import { Story } from './helpers/story.interface';
-import { ScreenshotOptions } from './screenshot-options';
+import { screenshotOptions } from './screenshot-options';
 
 const browser = process.env['CLARITY_VRT_BROWSER'];
 const theme = process.env['CLARITY_VRT_THEME'];
@@ -39,6 +39,7 @@ for (const { storyId, component } of stories) {
       globals: `theme:${theme};density:${density}`,
       viewMode: 'story',
     });
+
     const viewport = getPageViewPort(component, storyName);
     if (viewport) {
       page.setViewportSize(viewport);
@@ -58,13 +59,13 @@ for (const { storyId, component } of stories) {
   });
 }
 
-const takeFullPageScreenshot = (component, storyName) => {
-  return ScreenshotOptions[component]?.fullPageScreenshot || ScreenshotOptions[storyName]?.fullPageScreenshot;
-};
+function takeFullPageScreenshot(component: string, storyName: string) {
+  return screenshotOptions[component]?.fullPageScreenshot || screenshotOptions[storyName]?.fullPageScreenshot;
+}
 
-const getPageViewPort = (component, storyName) => {
-  return ScreenshotOptions[component]?.viewport || ScreenshotOptions[storyName]?.viewport;
-};
+function getPageViewPort(component: string, storyName: string) {
+  return screenshotOptions[component]?.viewport || screenshotOptions[storyName]?.viewport;
+}
 
 const unusedScreenshotsFilePath = path.join('.', 'tests', 'snapshots', `used-screenshot-paths-${matrixKey}.txt`);
 fs.writeFileSync(unusedScreenshotsFilePath, usedScreenshotPaths.join('\n'));


### PR DESCRIPTION
- use `function` for options functions
- add missing parameter type annotations
- rename "screenshot options" constant to camel case per convention
- rename "screenshot options" interface to remove `T` suffix
- rename "screenshot options" interface key with descriptive name