### PR TITLE
Fixed width problem (no visible lines after scrolling) with datagrids

### DIFF
--- a/projects/angular/src/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/src/data/datagrid/_datagrid.clarity.scss
@@ -372,7 +372,7 @@
     display: flex;
     flex: 1 1 auto;
     min-height: 100%;
-    width: 100%;
+    width: auto;
   }
 
   .datagrid-table {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

When horizontally scrolling in a datagrid, the lines between the cells did not appear on the newly scrolled place, they remained where the first sight was. The div itself did not move when scrolling.

Issue Number: N/A

## What is the new behavior?

Fixed this issue with seeting width to auto  --> div adapts when scrolling.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
