### PR TITLE
Revert "fix(modal): remove typography styles from title base selector"

### DIFF
--- a/projects/angular/src/modal/_modal.clarity.scss
+++ b/projects/angular/src/modal/_modal.clarity.scss
@@ -195,6 +195,7 @@
     .modal-title,
     .side-panel-title {
       color: modal-variables.$clr-modal-title-color;
+      @include mixins.generate-typography-token('SECTION-20-STD');
       margin: 0;
     }
 


### PR DESCRIPTION
Reverts vmware-clarity/ng-clarity#1957