### PR TITLE
fix(vertical-nav): revert group titles to 14px instead of 16px

### DIFF
--- a/projects/angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
+++ b/projects/angular/src/layout/vertical-nav/_vertical-nav.clarity.scss
@@ -341,12 +341,7 @@
       .nav-content > .nav-link,
       .nav-group .nav-group-text,
       .nav-group .nav-group-trigger {
-        @include mixins.generate-typography-token(
-          'SUBSECTION-16-SB',
-          (
-            font-weight: vertical-nav-variables.$clr-vertical-nav-item-top-level-font-weight,
-          )
-        );
+        font-weight: vertical-nav-variables.$clr-vertical-nav-item-top-level-font-weight;
       }
 
       .nav-group-children .nav-link {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Current group titles are 16px due to mistake in specification while implementing density layouts.


<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-2939

## What is the new behavior?

Group titles are back to 14px.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
