### PR TITLE
fix(datagrid): virtual scroll subscriptions not initialized on after view init

### DIFF
--- a/projects/angular/src/data/datagrid/datagrid.ts
+++ b/projects/angular/src/data/datagrid/datagrid.ts
@@ -402,6 +402,10 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
       })
     );
 
+    if (this.virtualScroll) {
+      this.toggleVirtualScrollSubscriptions();
+    }
+
     // We need to preserve shift state, so it can be used on selection change, regardless of the input event
     // that triggered the change. This helps us to easily resolve the k/b only case together with the mouse selection case.
     this.zone.runOutsideAngular(() => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Virtual scroll initialize it's subscriptions in datagrid only on change.

Issue Number: CDE-2954

## What is the new behavior?
Virtual scroll will initialize it's subscriptions on after view init as well.


## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
