### PR TITLE
fix(file-input): validate accept entries using suffix matching

### DIFF
--- a/projects/angular/src/forms/file-input/file-input-validator.spec.ts
+++ b/projects/angular/src/forms/file-input/file-input-validator.spec.ts
@@ -170,6 +170,135 @@ function fileInputValidatorSpec(testComponent: Type<TestComponent>) {
 
     expect(getErrorMessages(nativeElement)).toBe('File size too large');
   });
+
+  it('accept: ".gz" should accept both readme.gz and archive.tar.gz (suffix match)', () => {
+    fixture.componentInstance.accept = '.gz';
+    fixture.detectChanges();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'readme.gz')]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'archive.tar.gz')]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+  });
+
+  it('accept: ".tar.gz" should accept archive.tar.gz and reject readme.gz', () => {
+    fixture.componentInstance.accept = '.tar.gz';
+    fixture.detectChanges();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'archive.tar.gz')]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'readme.gz')]);
+    fixture.detectChanges();
+    expect(getErrorMessages(nativeElement)).toBe('File type not accepted');
+  });
+
+  it('accept: ".gz,.tar.gz" should accept both variants', () => {
+    fixture.componentInstance.accept = '.gz,.tar.gz';
+    fixture.detectChanges();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'readme.gz')]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'archive.tar.gz')]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+  });
+
+  it('accept: "application/gzip" should accept by MIME even if extension differs', () => {
+    fixture.componentInstance.accept = 'application/gzip';
+    fixture.detectChanges();
+
+    // Simulate a gzip file with correct MIME
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'anything.any', { type: 'application/gzip' })]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+  });
+
+  it('accept: "image/*" should accept image/png and reject text/plain', () => {
+    fixture.componentInstance.accept = 'image/*';
+    fixture.detectChanges();
+
+    // valid: image/png
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'pic.png', { type: 'image/png' })]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+
+    // invalid: text/plain
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'note.txt', { type: 'text/plain' })]);
+    fixture.detectChanges();
+    expect(getErrorMessages(nativeElement)).toBe('File type not accepted');
+  });
+
+  it('should be case-insensitive for extensions', () => {
+    fixture.componentInstance.accept = '.gz,.tar.gz';
+    fixture.detectChanges();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'README.GZ')]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'ARCHIVE.TAR.GZ')]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+  });
+
+  it('dotfile with no further dot should be treated as no extension', () => {
+    fixture.componentInstance.accept = '.txt';
+    fixture.detectChanges();
+
+    // ".gitignore" should NOT match ".txt"
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], '.gitignore')]);
+    fixture.detectChanges();
+    expect(getErrorMessages(nativeElement)).toBe('File type not accepted');
+  });
+
+  it('no extension should be rejected when an extension is required', () => {
+    fixture.componentInstance.accept = '.txt';
+    fixture.detectChanges();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'readme')]); // no extension
+    fixture.detectChanges();
+    expect(getErrorMessages(nativeElement)).toBe('File type not accepted');
+  });
+
+  it('multi-part custom: accept ".module.css" should accept style.module.css and reject style.css', () => {
+    fixture.componentInstance.accept = '.module.css';
+    fixture.detectChanges();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'style.module.css')]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'style.css')]);
+    fixture.detectChanges();
+    expect(getErrorMessages(nativeElement)).toBe('File type not accepted');
+  });
+
+  it('MIME exact should override extension when present', () => {
+    fixture.componentInstance.accept = '.txt,text/plain';
+    fixture.detectChanges();
+
+    // Wrong extension but correct MIME -> accepted
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'data.bin', { type: 'text/plain' })]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+  });
+
+  it('empty MIME type falls back to extension checks only', () => {
+    fixture.componentInstance.accept = '.gz';
+    fixture.detectChanges();
+
+    // No MIME provided, should be accepted by extension
+    selectFiles(fileInputElement, [new File(['+'.repeat(100)], 'readme.gz', { type: '' })]);
+    fixture.detectChanges();
+    expect(nativeElement.querySelector('clr-control-error')).toBeNull();
+  });
 }
 
 function getErrorMessages(nativeElement: HTMLElement) {

--- a/projects/angular/src/forms/file-input/file-input-validator.ts
+++ b/projects/angular/src/forms/file-input/file-input-validator.ts
@@ -39,12 +39,15 @@ export class ClrFileInputValidator implements Validator {
         const file = files.item(i);
 
         // accept validation (native attribute)
-        if (accept) {
-          const [fileExtension] = file.name.match(/\..+$/);
-
-          if (!accept.includes(file.type) && !accept.includes(fileExtension)) {
+        if (accept && accept.length) {
+          if (!this.validateAccept(file, accept)) {
             errors.accept = errors.accept || [];
-            errors.accept.push({ name: file.name, accept, type: file.type, extension: fileExtension });
+            errors.accept.push({
+              name: file.name,
+              accept,
+              type: file.type || '',
+              extension: this.getSuffixByDepth(file.name, 2), // last up to 2 parts for reporting
+            });
           }
         }
 
@@ -63,5 +66,46 @@ export class ClrFileInputValidator implements Validator {
     }
 
     return Object.keys(errors).length ? errors : null;
+  }
+
+  private getSuffixByDepth(filename: string, depth: number): string {
+    const match = filename.toLowerCase().match(new RegExp(`(\\.[^.]+){1,${depth}}$`, 'i'));
+    return match ? match[0] : '';
+  }
+
+  private validateAccept(file: File, acceptList: string[]): boolean {
+    const name = file.name.toLowerCase();
+    const type = (file.type || '').toLowerCase();
+
+    for (const entryRaw of acceptList) {
+      const entry = entryRaw.trim().toLowerCase();
+      if (!entry) {
+        continue;
+      }
+
+      // Extension check
+      if (entry.startsWith('.')) {
+        const depth = (entry.match(/\./g) || []).length;
+        if (this.getSuffixByDepth(name, depth) === entry) {
+          return true;
+        }
+        continue;
+      }
+
+      // MIME check
+      if (entry.includes('/')) {
+        if (entry.endsWith('/*')) {
+          const prefix = entry.slice(0, entry.length - 1); // keep trailing slash
+          if (type.startsWith(prefix)) {
+            return true;
+          }
+        } else if (type === entry) {
+          return true;
+        }
+        continue;
+      }
+    }
+
+    return false;
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Currently the file input validators have a regex that take all dots from the file name and taking it as the extension, for example: "file-name.0.0.1.zip" would return extension to be ".0.01.zip" while we have `accept=".zip"` and that would fail.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-2971

## What is the new behavior?

Use suffix matching by each entry in accept so we can compare `.zip` to the file name and dynamically take only the last part of the file name.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
