### PR TITLE
fix(badge): rename color input from `clrBadgeColor` to `clrColor`

### DIFF
--- a/.storybook/stories/badge/badge.storybook.component.ts
+++ b/.storybook/stories/badge/badge.storybook.component.ts
@@ -19,7 +19,7 @@ import { ClrBadge } from '@clr/angular';
           <a href="#" class="badge" [ngClass]="badgeClass(status)">{{ context }}</a>
         }
       } @else {
-        <clr-badge [clrBadgeColor]="status">{{ context }}</clr-badge>
+        <clr-badge [clrColor]="status">{{ context }}</clr-badge>
       }
     }
   `,

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -552,7 +552,7 @@ export class ClrBadge {
     // (undocumented)
     get colorClass(): string;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrBadge, "clr-badge", never, { "color": { "alias": "clrBadgeColor"; "required": false; }; }, {}, never, ["*"], true, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrBadge, "clr-badge", never, { "color": { "alias": "clrColor"; "required": false; }; }, {}, never, ["*"], true, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrBadge, never>;
 }

--- a/projects/angular/src/emphasis/badge/badge.spec.ts
+++ b/projects/angular/src/emphasis/badge/badge.spec.ts
@@ -11,7 +11,7 @@ import { ComponentFixture, TestBed } from '@angular/core/testing';
 import { ClrBadge, ClrBadgeColors } from './badge';
 
 @Component({
-  template: ` <clr-badge [clrBadgeColor]="color">{{ content }}</clr-badge> `,
+  template: ` <clr-badge [clrColor]="color">{{ content }}</clr-badge> `,
   standalone: false,
 })
 class TestComponent {

--- a/projects/angular/src/emphasis/badge/badge.ts
+++ b/projects/angular/src/emphasis/badge/badge.ts
@@ -5,7 +5,6 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { NgClass } from '@angular/common';
 import { Component, Input } from '@angular/core';
 
 export enum ClrBadgeColors {
@@ -23,11 +22,14 @@ export enum ClrBadgeColors {
 
 @Component({
   selector: 'clr-badge',
-  template: `<span class="badge" [ngClass]="colorClass"><ng-content></ng-content></span>`,
-  imports: [NgClass],
+  template: `<ng-content></ng-content>`,
+  host: {
+    class: 'badge',
+    '[class]': 'colorClass',
+  },
 })
 export class ClrBadge {
-  @Input('clrBadgeColor') color: ClrBadgeColors | string = ClrBadgeColors.Empty;
+  @Input('clrColor') color: ClrBadgeColors | string = ClrBadgeColors.Empty;
 
   get colorClass() {
     return this.color ? `badge-${this.color}` : '';

--- a/projects/demo/src/app/badges/badge-colors.demo.html
+++ b/projects/demo/src/app/badges/badge-colors.demo.html
@@ -9,16 +9,16 @@
 <div class="clr-example">
   <div>
     <clr-badge>11</clr-badge>
-    <clr-badge [clrBadgeColor]="ClrBadgeColors.Purple">15</clr-badge>
-    <clr-badge [clrBadgeColor]="ClrBadgeColors.Blue">2</clr-badge>
-    <clr-badge [clrBadgeColor]="ClrBadgeColors.Orange">3</clr-badge>
-    <clr-badge [clrBadgeColor]="ClrBadgeColors.LightBlue">12</clr-badge>
-    <clr-badge [clrBadgeColor]="'1'">90</clr-badge>
-    <clr-badge [clrBadgeColor]="'2'">51</clr-badge>
-    <clr-badge [clrBadgeColor]="'3'">25</clr-badge>
-    <clr-badge [clrBadgeColor]="'4'">32</clr-badge>
-    <clr-badge [clrBadgeColor]="'5'">57</clr-badge>
-    <clr-badge [clrBadgeColor]="'gray'">12</clr-badge>
+    <clr-badge [clrColor]="ClrBadgeColors.Purple">15</clr-badge>
+    <clr-badge [clrColor]="ClrBadgeColors.Blue">2</clr-badge>
+    <clr-badge [clrColor]="ClrBadgeColors.Orange">3</clr-badge>
+    <clr-badge [clrColor]="ClrBadgeColors.LightBlue">12</clr-badge>
+    <clr-badge [clrColor]="'1'">90</clr-badge>
+    <clr-badge [clrColor]="'2'">51</clr-badge>
+    <clr-badge [clrColor]="'3'">25</clr-badge>
+    <clr-badge [clrColor]="'4'">32</clr-badge>
+    <clr-badge [clrColor]="'5'">57</clr-badge>
+    <clr-badge [clrColor]="'gray'">12</clr-badge>
   </div>
 </div>
 

--- a/projects/demo/src/app/badges/badge-statuses.demo.html
+++ b/projects/demo/src/app/badges/badge-statuses.demo.html
@@ -7,10 +7,10 @@
 
 <h2>Angular Badges</h2>
 <div class="clr-example">
-  <clr-badge [clrBadgeColor]="ClrBadgeColors.Info">2</clr-badge>
-  <clr-badge [clrBadgeColor]="ClrBadgeColors.Success">3</clr-badge>
-  <clr-badge [clrBadgeColor]="ClrBadgeColors.Warning">12</clr-badge>
-  <clr-badge [clrBadgeColor]="ClrBadgeColors.Danger">15</clr-badge>
+  <clr-badge [clrColor]="ClrBadgeColors.Info">2</clr-badge>
+  <clr-badge [clrColor]="ClrBadgeColors.Success">3</clr-badge>
+  <clr-badge [clrColor]="ClrBadgeColors.Warning">12</clr-badge>
+  <clr-badge [clrColor]="ClrBadgeColors.Danger">15</clr-badge>
 </div>
 
 <h2>CSS Badges</h2>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: CDE-2972, follow up of #2018 

## What is the new behavior?
- Property `clrBadgeColor` now is `clrColor`.
- Inner `span` is removed and CSS class are put on `host` level.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
