### PR TITLE
fix(datagrid): disable grid classes for page size label

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1813,7 +1813,7 @@ export interface ClrDatagridNumericFilterInterface<T> {
 export class ClrDatagridPageSize {
     constructor(page: Page);
     // (undocumented)
-    label: ClrLabel;
+    set label(label: ClrLabel);
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1813,6 +1813,8 @@ export interface ClrDatagridNumericFilterInterface<T> {
 export class ClrDatagridPageSize {
     constructor(page: Page);
     // (undocumented)
+    label: ClrLabel;
+    // (undocumented)
     ngOnInit(): void;
     // (undocumented)
     page: Page;

--- a/projects/angular/src/data/datagrid/datagrid-page-size.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid-page-size.spec.ts
@@ -49,6 +49,19 @@ export default function (): void {
           expect(select.options[0].innerText).toMatch('0');
         });
       });
+      describe('Inside Form Test', function () {
+        let context: TestContext<ClrDatagridPageSize, FormTest>;
+
+        beforeEach(function () {
+          context = this.create(ClrDatagridPageSize, FormTest, [Page, StateDebouncer]);
+        });
+
+        it('label should not have col classes when inside a form', function () {
+          const label = context.clarityElement.querySelector('label') as HTMLElement;
+          expect(label).not.toBeNull();
+          expect(label.className.includes('clr-col')).toBeFalse();
+        });
+      });
 
       describe('Full Test', function () {
         let context: TestContext<ClrDatagridPageSize, FullTest>;
@@ -112,6 +125,15 @@ export default function (): void {
   template: `<clr-dg-page-size>Hello world</clr-dg-page-size>`,
 })
 class SimpleTest {}
+
+@Component({
+  template: `
+    <form clrForm>
+      <clr-dg-page-size>Hello world</clr-dg-page-size>
+    </form>
+  `,
+})
+class FormTest {}
 
 @Component({
   template: `

--- a/projects/angular/src/data/datagrid/datagrid-page-size.ts
+++ b/projects/angular/src/data/datagrid/datagrid-page-size.ts
@@ -25,14 +25,17 @@ import { Page } from './providers/page';
 export class ClrDatagridPageSize {
   @Input('clrPageSizeOptions') pageSizeOptions: number[];
   @Input('clrPageSizeOptionsId') pageSizeOptionsId = uniqueIdFactory();
-  @ViewChild(ClrLabel, { static: true }) label: ClrLabel;
 
   constructor(public page: Page) {}
 
-  ngOnInit() {
-    if (this.label) {
-      this.label.disableGrid();
+  @ViewChild(ClrLabel, { static: true })
+  set label(label: ClrLabel) {
+    if (label) {
+      label.disableGrid();
     }
+  }
+
+  ngOnInit() {
     if (!this.pageSizeOptions || this.pageSizeOptions.length === 0) {
       this.pageSizeOptions = [this.page.size];
     }

--- a/projects/angular/src/data/datagrid/datagrid-page-size.ts
+++ b/projects/angular/src/data/datagrid/datagrid-page-size.ts
@@ -5,8 +5,9 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Component, Input } from '@angular/core';
+import { Component, Input, ViewChild } from '@angular/core';
 
+import { ClrLabel } from '../../forms';
 import { uniqueIdFactory } from '../../utils/id-generator/id-generator.service';
 import { Page } from './providers/page';
 
@@ -24,10 +25,14 @@ import { Page } from './providers/page';
 export class ClrDatagridPageSize {
   @Input('clrPageSizeOptions') pageSizeOptions: number[];
   @Input('clrPageSizeOptionsId') pageSizeOptionsId = uniqueIdFactory();
+  @ViewChild(ClrLabel, { static: true }) label: ClrLabel;
 
   constructor(public page: Page) {}
 
   ngOnInit() {
+    if (this.label) {
+      this.label.disableGrid();
+    }
     if (!this.pageSizeOptions || this.pageSizeOptions.length === 0) {
       this.pageSizeOptions = [this.page.size];
     }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Page size label gets smacked to the select when datagrid is inside `clrForm`

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-2979

## What is the new behavior?

Disable grid for page size label

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
