### PR TITLE
fix(datagrid): pre-select before data is loaded (#2081) (backport to next)

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -1264,7 +1264,7 @@ export class ClrControlSuccess extends ClrAbstractControl {
 }
 
 // @public (undocumented)
-export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, OnDestroy {
+export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, OnDestroy, DoCheck {
     // Warning: (ae-forgotten-export) The symbol "DatagridRenderOrganizer" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "StateProvider" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "DisplayModeService" needs to be exported by the entry point index.d.ts
@@ -1335,6 +1335,8 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
     // (undocumented)
     ngAfterContentInit(): void;
     ngAfterViewInit(): void;
+    // (undocumented)
+    ngDoCheck(): void;
     // (undocumented)
     ngOnDestroy(): void;
     placeholder: ClrDatagridPlaceholder<T>;

--- a/projects/angular/src/data/datagrid/datagrid-row.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.ts
@@ -369,6 +369,7 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
       );
       this.selection.clearSelection();
       this.selection.current.push(...newSelection);
+      this.selection.checkForChanges();
     } else {
       // page number has changed or
       // no Shift was pressed or

--- a/projects/angular/src/data/datagrid/datagrid.ts
+++ b/projects/angular/src/data/datagrid/datagrid.ts
@@ -11,6 +11,7 @@ import {
   Component,
   ContentChild,
   ContentChildren,
+  DoCheck,
   DOCUMENT,
   ElementRef,
   EventEmitter,
@@ -83,7 +84,7 @@ import { uniqueIdFactory } from '../../utils/id-generator/id-generator.service';
   },
   standalone: false,
 })
-export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, OnDestroy {
+export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, OnDestroy, DoCheck {
   @Input('clrLoadingMoreItems') loadingMoreItems: boolean;
 
   @Input() clrDgSingleSelectionAriaLabel: string = this.commonStrings.keys.singleSelectionAriaLabel;
@@ -425,6 +426,12 @@ export class ClrDatagrid<T = any> implements AfterContentInit, AfterViewInit, On
         })
       );
     });
+  }
+
+  ngDoCheck() {
+    // we track for changes on selection.current because it can happen with pushing items
+    // instead of overriding the variable
+    this.selection.checkForChanges();
   }
 
   ngOnDestroy() {

--- a/projects/angular/src/data/datagrid/providers/selection.spec.ts
+++ b/projects/angular/src/data/datagrid/providers/selection.spec.ts
@@ -5,6 +5,8 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { IterableDiffers } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
 import { delay } from 'projects/angular/src/utils/testing/helpers.spec';
 import { Subject } from 'rxjs';
 
@@ -38,7 +40,17 @@ export default function (): void {
         itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
         itemsInstance.smartenUp();
         itemsInstance.all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        selectionInstance = new Selection(itemsInstance, filtersInstance);
+
+        TestBed.configureTestingModule({
+          providers: [
+            IterableDiffers,
+            { provide: Items, useValue: itemsInstance },
+            { provide: FiltersProvider, useValue: filtersInstance },
+            Selection,
+          ],
+        });
+
+        selectionInstance = TestBed.inject(Selection);
       });
 
       afterEach(function () {
@@ -384,7 +396,17 @@ export default function (): void {
         itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
         itemsInstance.smartenUp();
         itemsInstance.all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        selectionInstance = new Selection(itemsInstance, filtersInstance);
+
+        TestBed.configureTestingModule({
+          providers: [
+            IterableDiffers,
+            { provide: Items, useValue: itemsInstance },
+            { provide: FiltersProvider, useValue: filtersInstance },
+            Selection,
+          ],
+        });
+
+        selectionInstance = TestBed.inject(Selection);
         selectionInstance.preserveSelection = true;
       });
 
@@ -478,7 +500,17 @@ export default function (): void {
         itemsInstance.smartenUp();
         itemsInstance.all = items;
         pageInstance.size = 3;
-        selectionInstance = new Selection(itemsInstance, filtersInstance);
+
+        TestBed.configureTestingModule({
+          providers: [
+            IterableDiffers,
+            { provide: Items, useValue: itemsInstance },
+            { provide: FiltersProvider, useValue: filtersInstance },
+            Selection,
+          ],
+        });
+
+        selectionInstance = TestBed.inject(Selection);
       });
 
       afterEach(function () {
@@ -580,7 +612,16 @@ export default function (): void {
         sortInstance = new Sort(stateDebouncer);
         itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
 
-        selectionInstance = new Selection(itemsInstance, filtersInstance);
+        TestBed.configureTestingModule({
+          providers: [
+            IterableDiffers,
+            { provide: Items, useValue: itemsInstance },
+            { provide: FiltersProvider, useValue: filtersInstance },
+            Selection,
+          ],
+        });
+
+        selectionInstance = TestBed.inject(Selection);
       });
 
       afterEach(function () {
@@ -705,7 +746,17 @@ export default function (): void {
         itemsInstance = new Items(filtersInstance, sortInstance, pageInstance);
         itemsInstance.smartenUp();
         itemsInstance.all = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
-        selectionInstance = new Selection(itemsInstance, filtersInstance);
+
+        TestBed.configureTestingModule({
+          providers: [
+            IterableDiffers,
+            { provide: Items, useValue: itemsInstance },
+            { provide: FiltersProvider, useValue: filtersInstance },
+            Selection,
+          ],
+        });
+
+        selectionInstance = TestBed.inject(Selection);
       });
 
       afterEach(function () {

--- a/projects/angular/src/data/datagrid/providers/selection.ts
+++ b/projects/angular/src/data/datagrid/providers/selection.ts
@@ -5,12 +5,12 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { Injectable } from '@angular/core';
+import { Injectable, IterableDiffer, IterableDiffers, TrackByFunction } from '@angular/core';
 import { Observable, Subject, Subscription } from 'rxjs';
 import { debounceTime, delay } from 'rxjs/operators';
 
 import { FiltersProvider } from './filters';
-import { Items } from './items';
+import { ClrDatagridItemsIdentityFunction, Items } from './items';
 import { SelectionType } from '../enums/selection-type';
 
 let nbSelection = 0;
@@ -33,9 +33,8 @@ export class Selection<T = any> {
   /** @deprecated since 2.0, remove in 3.0 */
   rowSelectionMode = false;
 
-  private prevSelectionRefs: T[] = []; // Refs of selected items
-  private prevSingleSelectionRef: T; // Ref of single selected item
   private lockedRefs: T[] = []; // Ref of locked items
+  private _currentSelectionRefs: T[] = [];
   private valueCollector = new Subject<T[]>();
   private _selectionType: SelectionType = SelectionType.None;
 
@@ -59,11 +58,20 @@ export class Selection<T = any> {
    */
   private subscriptions: Subscription[] = [];
 
+  /**
+   * Differ to track changes of multi selection.
+   */
+  private _differ!: IterableDiffer<T>;
+  private identifyBy: ClrDatagridItemsIdentityFunction<T>;
+
   constructor(
     private _items: Items<T>,
-    filters: FiltersProvider<T>
+    filters: FiltersProvider<T>,
+    differs: IterableDiffers
   ) {
     this.id = 'clr-dg-selection' + nbSelection++;
+    this.identifyBy = _items.identifyBy;
+    this._differ = differs.find(this._current || []).create<T>(this.identifyBy as TrackByFunction<T>);
 
     this.subscriptions.push(
       filters.change.subscribe(() => {
@@ -88,15 +96,10 @@ export class Selection<T = any> {
             let newSingle: any;
             let selectionUpdated = false;
 
-            // if the currentSingle has been set before data was loaded, we look up and save the ref from current data set
-            if (this.currentSingle && !this.prevSingleSelectionRef) {
-              this.prevSingleSelectionRef = _items.identifyBy(this.currentSingle);
-            }
-
             updatedItems.forEach(item => {
               const ref = _items.identifyBy(item);
               // If one of the updated items is the previously selectedSingle, set it as the new one
-              if (this.prevSingleSelectionRef === ref) {
+              if (this.currentSingleSelectionRef === ref) {
                 newSingle = item;
                 selectionUpdated = true;
               }
@@ -123,14 +126,6 @@ export class Selection<T = any> {
             let leftOver: any[] = this.current.slice();
             let selectionUpdated = false;
 
-            // if the current has been set before data was loaded, we look up and save the ref from current data set
-            if (this.current.length > 0 && this.prevSelectionRefs.length !== this.current.length) {
-              this.prevSelectionRefs = [];
-              this.current.forEach(item => {
-                this.prevSelectionRefs.push(_items.identifyBy(item));
-              });
-            }
-
             // Duplicate loop, when the issue is issue#2342 is revisited keep in mind that
             // we need to go over every updated item and check to see if there are valid to be
             // locked or not and update it. When only add items that are found in the lockedRefs back.
@@ -150,7 +145,7 @@ export class Selection<T = any> {
               updatedItems.forEach(item => {
                 const ref = _items.identifyBy(item);
                 // Look in current selected refs array if item is selected, and update actual value
-                const selectedIndex = this.prevSelectionRefs.indexOf(ref);
+                const selectedIndex = this.currentSelectionRefs.indexOf(ref);
                 if (selectedIndex > -1) {
                   leftOver[selectedIndex] = item;
                   selectionUpdated = true;
@@ -205,6 +200,7 @@ export class Selection<T = any> {
   }
   set current(value: T[]) {
     this.updateCurrent(value, true);
+    this.updateCurrentSelectionRefs();
   }
 
   get currentSingle(): T {
@@ -215,9 +211,6 @@ export class Selection<T = any> {
       return;
     }
     this._currentSingle = value;
-    if (this._items.all && this._items.identifyBy && value) {
-      this.prevSingleSelectionRef = this._items.identifyBy(value);
-    }
     this.emitChange();
   }
 
@@ -232,7 +225,7 @@ export class Selection<T = any> {
 
   // Refs of currently selected items
   private get currentSelectionRefs(): T[] {
-    return this._current?.map(item => this._items.identifyBy(item)) || [];
+    return this._currentSelectionRefs;
   }
 
   // Ref of currently selected item
@@ -240,10 +233,20 @@ export class Selection<T = any> {
     return this._currentSingle && this._items.identifyBy(this._currentSingle);
   }
 
+  checkForChanges(): void {
+    const changes = this._differ.diff(this._current);
+    // @TODO move the identifyBy from items to selection as it's used only here and is not needed in items
+    if (this.identifyBy !== this._items.identifyBy) {
+      this.identifyBy = this._items.identifyBy;
+    }
+    if (changes) {
+      this.updateCurrentSelectionRefs();
+    }
+  }
+
   clearSelection(): void {
     this._current = [];
-    this.prevSelectionRefs = [];
-    this.prevSingleSelectionRef = null;
+    this._currentSelectionRefs = [];
     this._currentSingle = null;
     this.emitChange();
   }
@@ -391,8 +394,6 @@ export class Selection<T = any> {
    */
   private selectItem(item: T): void {
     this.current = this.current.concat(item);
-    // Push selected ref onto array
-    this.prevSelectionRefs.push(this._items.identifyBy(item));
   }
 
   /**
@@ -400,9 +401,9 @@ export class Selection<T = any> {
    */
   private deselectItem(indexOfItem: number): void {
     this.current = this.current.slice(0, indexOfItem).concat(this.current.slice(indexOfItem + 1));
-    if (indexOfItem < this.prevSelectionRefs.length) {
+    if (indexOfItem < this.currentSelectionRefs.length) {
       // Keep selected refs array in sync
-      const removedItems = this.prevSelectionRefs.splice(indexOfItem, 1);
+      const removedItems = this.currentSelectionRefs[indexOfItem];
       // locked reference is no longer needed (if any)
       this.lockedRefs = this.lockedRefs.filter(locked => locked !== removedItems[0]);
     }
@@ -421,5 +422,9 @@ export class Selection<T = any> {
     } else if (this._selectionType === SelectionType.Multi) {
       this._change.next(this.current);
     }
+  }
+
+  private updateCurrentSelectionRefs() {
+    this._currentSelectionRefs = this._current?.map(item => this._items.identifyBy(item)) || [];
   }
 }


### PR DESCRIPTION
Backport of #2081

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

If selected items are assigned before data is loaded they are not selected because trackBy needs to be set before selected items.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

Selected items are loaded even if set before data is loaded and order of track by doesn't matter.

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->