### PR TITLE
fix(datagrid): use custom value accessor for single selection (#2083) (backport to next)

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -20,7 +20,6 @@ import { CdkVirtualForOf } from '@angular/cdk/scrolling';
 import { CdkVirtualForOfContext } from '@angular/cdk/scrolling';
 import { ChangeDetectorRef } from '@angular/core';
 import { ControlValueAccessor } from '@angular/forms';
-import { DefaultValueAccessor } from '@angular/forms';
 import { Directionality } from '@angular/cdk/bidi';
 import { DoCheck } from '@angular/core';
 import { DragDrop } from '@angular/cdk/drag-drop';
@@ -5789,10 +5788,20 @@ export class ÇlrDatagridSelectionCellDirective {
 }
 
 // @public (undocumented)
-export class ÇlrDatagridSingleSelectionValueAccessor extends DefaultValueAccessor {
+export class ÇlrDatagridSingleSelectionValueAccessor implements ControlValueAccessor {
     constructor(renderer: Renderer2, elementRef: ElementRef<HTMLInputElement>);
     // (undocumented)
     clrDgIdentityFn: (value: any) => unknown;
+    // (undocumented)
+    onChange: (value: any) => void;
+    // (undocumented)
+    onTouched: () => void;
+    // (undocumented)
+    registerOnChange(fn: (value: any) => void): void;
+    // (undocumented)
+    registerOnTouched(fn: () => void): void;
+    // (undocumented)
+    setDisabledState(isDisabled: boolean): void;
     // (undocumented)
     value: any;
     // (undocumented)

--- a/projects/angular/src/data/datagrid/datagrid-single-selection.directive.ts
+++ b/projects/angular/src/data/datagrid/datagrid-single-selection.directive.ts
@@ -6,7 +6,7 @@
  */
 
 import { Directive, ElementRef, forwardRef, Input, Renderer2 } from '@angular/core';
-import { DefaultValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
+import { ControlValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
 
 @Directive({
   selector: 'input[type=radio][clrDgSingleSelectionRadio]',
@@ -22,21 +22,35 @@ import { DefaultValueAccessor, NG_VALUE_ACCESSOR } from '@angular/forms';
     '(blur)': 'onTouched()',
   },
 })
-export class ClrDatagridSingleSelectionValueAccessor extends DefaultValueAccessor {
-  @Input() value: any;
+export class ClrDatagridSingleSelectionValueAccessor implements ControlValueAccessor {
+  @Input() value;
   @Input() clrDgIdentityFn!: (value: any) => unknown;
 
-  private model: any;
+  private state: any;
 
   constructor(
     private renderer: Renderer2,
     private elementRef: ElementRef<HTMLInputElement>
-  ) {
-    super(renderer, elementRef, null);
+  ) {}
+
+  onChange: (value: any) => void = () => {};
+
+  onTouched: () => void = () => {};
+
+  registerOnChange(fn: (value: any) => void): void {
+    this.onChange = fn;
   }
 
-  override writeValue(value: any): void {
-    this.model = value;
+  registerOnTouched(fn: () => void): void {
+    this.onTouched = fn;
+  }
+
+  setDisabledState(isDisabled: boolean): void {
+    this.renderer.setProperty(this.elementRef.nativeElement, 'disabled', isDisabled);
+  }
+
+  writeValue(value: any): void {
+    this.state = value;
     this.updateChecked();
   }
 
@@ -48,8 +62,8 @@ export class ClrDatagridSingleSelectionValueAccessor extends DefaultValueAccesso
   }
 
   private updateChecked(): void {
-    const model = this.keyOf(this.model);
+    const state = this.keyOf(this.state);
     const value = this.keyOf(this.value);
-    this.renderer.setProperty(this.elementRef.nativeElement, 'checked', model === value);
+    this.renderer.setProperty(this.elementRef.nativeElement, 'checked', state === value);
   }
 }


### PR DESCRIPTION
Backport #2083

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

What kind of change does this PR introduce?

Due to using Angular DefaultValueAccessor the radio button is throwing change event with the initial value 'on' and then the actual value on click. Adding all overrides to fix that misses the point of extending it so we just implement the correct interface.

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: N/A

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->