### PR TITLE
fix(datagrid): selection with shift to emit correct value (#2086) (backport to next)

### DIFF
--- a/projects/angular/src/data/datagrid/datagrid-row.ts
+++ b/projects/angular/src/data/datagrid/datagrid-row.ts
@@ -367,9 +367,7 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
       const newSelection = new Set(
         this.selection.current.concat(items.slice(Math.min(startIx, endIx), Math.max(startIx, endIx) + 1))
       );
-      this.selection.clearSelection();
-      this.selection.current.push(...newSelection);
-      this.selection.checkForChanges();
+      this.selection.current = [...newSelection];
     } else {
       // page number has changed or
       // no Shift was pressed or

--- a/projects/angular/src/data/datagrid/datagrid.spec.ts
+++ b/projects/angular/src/data/datagrid/datagrid.spec.ts
@@ -1173,7 +1173,8 @@ export default function (): void {
           expect(selection.current).toEqual([1, 3]);
         });
 
-        it('updates selection range when Shift key pressed', function () {
+        it('updates selection range when Shift key pressed', async function () {
+          const selectedChange = spyOn(context.clarityDirective.selectedChanged, 'emit').and.callThrough();
           checkboxes[1].click();
           expect(selection.current).toEqual([1]);
           expect(selection.shiftPressed).toBeFalse();
@@ -1181,7 +1182,9 @@ export default function (): void {
           expect(selection.shiftPressed).toBeTrue();
           checkboxes[3].click();
           document.body.dispatchEvent(new KeyboardEvent('keyup', { key: 'Shift' }));
+          await delay();
           expect(selection.shiftPressed).toBeFalse();
+          expect(selectedChange).toHaveBeenCalledWith([1, 2, 3]);
           expect(selection.current).toEqual([1, 2, 3]);
         });
 

--- a/projects/demo/src/app/datagrid/selection/selection.html
+++ b/projects/demo/src/app/datagrid/selection/selection.html
@@ -48,7 +48,11 @@
   </div>
 </div>
 
-<clr-datagrid [(clrDgSelected)]="clientNoTrackBySelected" [clrDgItemsIdentityFn]="identityFn">
+<clr-datagrid
+  [(clrDgSelected)]="clientNoTrackBySelected"
+  (clrDgSelectedChange)="selectedChange($event)"
+  [clrDgItemsIdentityFn]="identityFn"
+>
   <clr-dg-column>User ID</clr-dg-column>
   <clr-dg-column>Name</clr-dg-column>
   <clr-dg-column>Creation date</clr-dg-column>

--- a/projects/demo/src/app/datagrid/selection/selection.ts
+++ b/projects/demo/src/app/datagrid/selection/selection.ts
@@ -73,4 +73,8 @@ export class DatagridSelectionDemo {
     this.clientTrackByIdSelected = selectedUsers;
     this.serverTrackByIdSelected = selectedUsers;
   }
+
+  selectedChange(event: any) {
+    console.log(event);
+  }
 }


### PR DESCRIPTION
Backport of #2086 

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

Selection with shift key emits empty array.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-2987

Emits selected items.

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->