### PR TITLE
fix(button-group): overflow button with lower padding on btn-icon group

### DIFF
--- a/projects/angular/src/button/button-group/_button-group.clarity.scss
+++ b/projects/angular/src/button/button-group/_button-group.clarity.scss
@@ -146,6 +146,10 @@
       .btn {
         min-width: 0;
       }
+
+      .btn-group-overflow .dropdown-toggle {
+        padding: buttons-variables.$clr-btn-appearance-form-padding;
+      }
     }
 
     //Icons and their corresponding title


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Overflow button is keeping it's 24px padding even in btn-icon only button group.

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

Issue Number: CDE-2991
Follow up of #2091.

## What is the new behavior?

Overflow button is with the same padding as the icons for btn-icon only button group.

## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information
