### PR TITLE
fix(buttons): warning active state

### DIFF
--- a/projects/ui/src/temp-overrides.scss
+++ b/projects/ui/src/temp-overrides.scss
@@ -49,7 +49,8 @@
     --cds-alias-object-interaction-info-selected: #{tokens.$cds-global-color-blue-900};
     --cds-alias-object-interaction-info-active: #{tokens.$cds-alias-object-interaction-info-click};
     --cds-alias-object-interaction-success-active: #{tokens.$cds-alias-object-interaction-success-click};
-    --cds-alias-object-interaction-warning-active: #{tokens.$cds-alias-object-interaction-warning-click};
+    --cds-alias-object-interaction-warning-click: #{tokens.$cds-global-color-ochre-700};
+    --cds-alias-object-interaction-warning-active: #{tokens.$cds-global-color-ochre-700};
     --cds-alias-object-interaction-danger-active: #{tokens.$cds-alias-object-interaction-danger-click};
     --cds-alias-object-interaction-neutral-active: #{tokens.$cds-alias-object-interaction-neutral-click};
     --cds-alias-object-interaction-inverse-active: #{tokens.$cds-alias-object-interaction-inverse-click};


### PR DESCRIPTION
(port of #2171 to main)

## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
Active state of the warning button is using green color `--cds-global-color-green-900`.

Issue Number: CDE-3022

## What is the new behavior?
Active state of the warning button is using ochrecolor `--cds-global-color-ochre-700`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
