### PR TITLE
feat(accordion): remove heading enabled flag

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -894,10 +894,6 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
     // (undocumented)
     getPanelStateClasses(panel: AccordionPanelModel): string;
     // (undocumented)
-    headingEnabled: boolean;
-    // (undocumented)
-    get headingLevel(): HeadingLevel;
-    // (undocumented)
     get id(): string;
     set id(value: string);
     // (undocumented)
@@ -921,7 +917,7 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
     // (undocumented)
     togglePanel(): void;
     // (undocumented)
-    static ɵcmp: i0.ɵɵComponentDeclaration<ClrAccordionPanel, "clr-accordion-panel", never, { "disabled": { "alias": "clrAccordionPanelDisabled"; "required": false; }; "panelOpen": { "alias": "clrAccordionPanelOpen"; "required": false; }; "headingEnabled": { "alias": "clrAccordionPanelHeadingEnabled"; "required": false; }; "explicitHeadingLevel": { "alias": "clrAccordionPanelHeadingLevel"; "required": false; }; }, { "panelOpenChange": "clrAccordionPanelOpenChange"; }, ["accordionDescription"], ["clr-accordion-title, clr-step-title", "clr-accordion-description, clr-step-description", "*"], false, never>;
+    static ɵcmp: i0.ɵɵComponentDeclaration<ClrAccordionPanel, "clr-accordion-panel", never, { "disabled": { "alias": "clrAccordionPanelDisabled"; "required": false; }; "panelOpen": { "alias": "clrAccordionPanelOpen"; "required": false; }; "explicitHeadingLevel": { "alias": "clrAccordionPanelHeadingLevel"; "required": false; }; }, { "panelOpenChange": "clrAccordionPanelOpenChange"; }, ["accordionDescription"], ["clr-accordion-title, clr-step-title", "clr-accordion-description, clr-step-description", "*"], false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<ClrAccordionPanel, [{ optional: true; skipSelf: true; }, null, null, null, null]>;
 }

--- a/projects/angular/src/accordion/accordion-panel.html
+++ b/projects/angular/src/accordion/accordion-panel.html
@@ -2,8 +2,8 @@
 <div [ngClass]="getPanelStateClasses(panel)">
   <div
     class="clr-accordion-header"
-    [attr.role]="headingEnabled || explicitHeadingLevel ? 'heading' : null"
-    [attr.aria-level]="headingEnabled || explicitHeadingLevel ? headingLevel : null"
+    [attr.role]="explicitHeadingLevel ? 'heading' : null"
+    [attr.aria-level]="explicitHeadingLevel ? explicitHeadingLevel : null"
   >
     <button
       type="button"

--- a/projects/angular/src/accordion/accordion-panel.spec.ts
+++ b/projects/angular/src/accordion/accordion-panel.spec.ts
@@ -50,15 +50,11 @@ class TestComponent {
 @Component({
   template: `
     <clr-accordion>
-      <clr-accordion-panel [clrAccordionPanelOpen]="true" [clrAccordionPanelHeadingEnabled]="true">
+      <clr-accordion-panel [clrAccordionPanelOpen]="true">
         <clr-accordion-title>title 1</clr-accordion-title>
         <clr-accordion-content>
           <clr-accordion>
-            <clr-accordion-panel
-              id="nested-accordion-panel"
-              [clrAccordionPanelOpen]="true"
-              [clrAccordionPanelHeadingEnabled]="true"
-            >
+            <clr-accordion-panel id="nested-accordion-panel" [clrAccordionPanelOpen]="true">
               <clr-accordion-title>nested title</clr-accordion-title>
               <clr-accordion-content>nested panel</clr-accordion-content>
             </clr-accordion-panel>
@@ -311,31 +307,19 @@ describe('ClrAccordionPanel', () => {
       expect(panelHeading.getAttribute('aria-level')).toBe('5');
     });
 
-    it('when [clrAccordionPanelHeadingEnabled] is not set at all, heading role should not be present', () => {
-      const fixture = TestBed.createComponent(TestNoBindingComponent);
-      fixture.detectChanges();
-
-      const accordionPanel: HTMLElement = fixture.debugElement.query(By.directive(ClrAccordionPanel)).nativeElement;
-      const panelHeading = accordionPanel.querySelector('[role="heading"]');
-
-      expect(panelHeading).toBeNull();
-    });
-
-    it('default heading aria-level should be present in nested accordion', () => {
+    it('default heading aria-level should NOT be present in accordion', () => {
       const fixture = TestBed.createComponent(TestNestedAccordionComponent);
       fixture.detectChanges();
 
       const accordionPanel: HTMLElement = fixture.debugElement.query(By.directive(ClrAccordionPanel)).nativeElement;
       const panelHeading = accordionPanel.querySelector('[role="heading"]');
 
-      expect(panelHeading).not.toBeNull();
-      expect(panelHeading.getAttribute('aria-level')).toBe('3');
+      expect(panelHeading).toBeNull();
 
       const nestedAccordionPanel = accordionPanel.querySelector('#nested-accordion-panel');
       const nestedPanelHeading = nestedAccordionPanel.querySelector('[role="heading"]');
 
-      expect(nestedPanelHeading).not.toBeNull();
-      expect(nestedPanelHeading.getAttribute('aria-level')).toBe('4');
+      expect(nestedPanelHeading).toBeNull();
     });
   });
 });

--- a/projects/angular/src/accordion/accordion-panel.ts
+++ b/projects/angular/src/accordion/accordion-panel.ts
@@ -46,7 +46,6 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
   @Input('clrAccordionPanelDisabled') @HostBinding('class.clr-accordion-panel-disabled') disabled = false;
   @Input('clrAccordionPanelOpen') panelOpen = false;
 
-  @Input('clrAccordionPanelHeadingEnabled') headingEnabled = false;
   /**
    * Level of the accordion/stepper heading from 1 to 6.
    */
@@ -78,14 +77,6 @@ export class ClrAccordionPanel implements OnInit, OnChanges {
 
   get panelNumber() {
     return this._panelIndex + 1;
-  }
-
-  get headingLevel() {
-    if (this.explicitHeadingLevel) {
-      return this.explicitHeadingLevel;
-    }
-
-    return this.parent ? 4 : 3;
   }
 
   ngOnInit() {

--- a/projects/demo/src/app/accordion/accordion.demo.html
+++ b/projects/demo/src/app/accordion/accordion.demo.html
@@ -71,7 +71,7 @@
 <h2>Angular - nested accordion</h2>
 
 <clr-accordion>
-  <clr-accordion-panel [clrAccordionPanelOpen]="true" [clrAccordionPanelHeadingEnabled]="true">
+  <clr-accordion-panel [clrAccordionPanelOpen]="true" [clrAccordionPanelHeadingLevel]="4">
     <clr-accordion-title>Parent Title 1</clr-accordion-title>
     <clr-accordion-content>
       <clr-accordion>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
`clrAccordionPanelHeadingEnabled` feature flag enables default `heading` values 3 and 4 nested accordions.

Issue Number: CDE-2505

## What is the new behavior?
`clrAccordionPanelHeadingEnabled` feature flag is removed.
All heading values must have explicit content assigned through `clrAccordionPanelHeadingLevel` input.

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

## Other information

BREAKING  CHANGE:
`clrAccordionPanelHeadingEnabled` feature flag is removed.
All heading values must have explicit content assigned through `clrAccordionPanelHeadingLevel` input.
