### PR TITLE
feat(modal): merge modal-header--accessible, remove font token overrides, decouple animation

### DIFF
--- a/projects/angular/modal/STYLES.md
+++ b/projects/angular/modal/STYLES.md
@@ -2,23 +2,18 @@
 
 ## CSS Custom Properties
 
-| CSS Custom Property              | Description                              |
-| -------------------------------- | ---------------------------------------- |
-| --clr-modal-close-color          | Fill color of modal close icon           |
-| --clr-modal-bg-color             | Background color of modal                |
-| --clr-modal-backdrop-color       | Color of modal backdrop                  |
-| --clr-modal-border-radius        | Border radius of a modal                 |
-| --clr-modal-title-color          | Font color of modal title                |
-| --clr-modal-title-font-family    | Font family of modal title               |
-| --clr-modal-title-font-weight    | Font weight of modal title               |
-| --clr-modal-title-font-size      | Font size for modal title                |
-| --clr-modal-title-line-height    | Line height for modal title              |
-| --clr-modal-title-letter-spacing | Letter spacing for modal title           |
-| --clr-modal-sm-width             | Width of the modal on small layout       |
-| --clr-modal-md-width             | Width of the modal on medium layout      |
-| --clr-modal-lg-width             | Width of the modal on large layout       |
-| --clr-modal-xl-width             | Width of the modal on extra large layout |
-| --clr-modal-content-box-shadow   | Shadow of modal content                  |
+| CSS Custom Property            | Description                              |
+| ------------------------------ | ---------------------------------------- |
+| --clr-modal-close-color        | Fill color of modal close icon           |
+| --clr-modal-bg-color           | Background color of modal                |
+| --clr-modal-backdrop-color     | Color of modal backdrop                  |
+| --clr-modal-border-radius      | Border radius of a modal                 |
+| --clr-modal-title-color        | Font color of modal title                |
+| --clr-modal-sm-width           | Width of the modal on small layout       |
+| --clr-modal-md-width           | Width of the modal on medium layout      |
+| --clr-modal-lg-width           | Width of the modal on large layout       |
+| --clr-modal-xl-width           | Width of the modal on extra large layout |
+| --clr-modal-content-box-shadow | Shadow of modal content                  |
 
 ## CSS Classes
 

--- a/projects/angular/modal/_modal.clarity.scss
+++ b/projects/angular/modal/_modal.clarity.scss
@@ -171,22 +171,14 @@
   }
 
   .modal-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-start;
     border-bottom: none;
     padding: modal-variables.$clr-modal-vertical-space modal-variables.$clr-modal-horizontal-space 0;
 
     & + .modal-footer {
       padding-top: modal-variables.$clr-modal-vertical-gap;
-    }
-
-    // TODO: This class is used only in the clr-modal template.
-    // It should be merged this with `.modal-header` in a major version
-    // because this would be breaking for the static modals.
-    &--accessible {
-      @extend .modal-header;
-
-      display: flex;
-      justify-content: space-between;
-      align-items: flex-start;
     }
 
     .modal-title,
@@ -195,19 +187,7 @@
       margin: 0;
 
       &:not([cds-text]) {
-        //cds-text do not have color, margin
-        font-family: modal-variables.$clr-modal-title-font-family; //TODO remove line and PI tokens in GA 17+
-        //TODO remove API tokens overrides in GA 17+
-
-        @include mixins.generate-typography-token(
-          'SECTION-20-STD',
-          (
-            font-size: modal-variables.$clr-modal-title-font-size,
-            font-weight: modal-variables.$clr-modal-title-font-weight,
-            line-height: modal-variables.$clr-modal-title-line-height,
-            letter-spacing: modal-variables.$clr-modal-title-letter-spacing,
-          )
-        );
+        @include mixins.generate-typography-token('SECTION-20-STD');
       }
     }
 

--- a/projects/angular/modal/_properties.modal.scss
+++ b/projects/angular/modal/_properties.modal.scss
@@ -5,10 +5,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-@use 'sass:color';
 @use '../styles/mixins';
-@use '../styles/variables/variables';
-@use './variables.modal' as modal-variables;
 @use '../styles/variables/variables.density' as density;
 @use '../styles/core/tokens/variables.tokens' as tokens;
 
@@ -19,15 +16,10 @@
     --clr-modal-md-width: #{mixins.baselinePx(576)};
     --clr-modal-lg-width: #{mixins.baselinePx(864)};
     --clr-modal-xl-width: #{mixins.baselinePx(1152)};
-    --clr-modal-title-font-family: #{variables.$clr-font};
-    --clr-modal-title-font-weight: #{tokens.$cds-alias-typography-section-font-weight};
-    --clr-modal-title-letter-spacing: #{mixins.baselinePx(-0.2)};
 
     &,
     & [clr-density] {
       --clr-modal-border-radius: #{density.$clr-base-border-radius-s};
-      --clr-modal-title-font-size: #{density.$clr-base-typography-font-size-section};
-      --clr-modal-title-line-height: #{density.$clr-base-typography-line-height-24};
     }
 
     &,

--- a/projects/angular/modal/_variables.modal.scss
+++ b/projects/angular/modal/_variables.modal.scss
@@ -31,8 +31,3 @@ $clr-modal-xl-width: var(--clr-modal-xl-width) !default;
 
 // Usage: ../modal/_modal.clarity.scss
 $clr-modal-title-color: var(--clr-modal-title-color) !default;
-$clr-modal-title-font-size: var(--clr-modal-title-font-size) !default;
-$clr-modal-title-font-family: var(--clr-modal-title-font-family) !default;
-$clr-modal-title-font-weight: var(--clr-modal-title-font-weight) !default;
-$clr-modal-title-line-height: var(--clr-modal-title-line-height) !default;
-$clr-modal-title-letter-spacing: var(--clr-modal-title-letter-spacing) !default;

--- a/projects/angular/modal/modal.html
+++ b/projects/angular/modal/modal.html
@@ -12,7 +12,6 @@
     cdkTrapFocus
     [cdkTrapFocusAutoCapture]="true"
     [@fadeMove]="fadeMove"
-    (@fadeMove.done)="fadeDone($event)"
     class="modal-dialog"
     [class.modal-sm]="size == 'sm'"
     [class.modal-lg]="size == 'lg'"
@@ -27,7 +26,7 @@
     <div class="modal-content-wrapper">
       @if (!modalContentTemplate) {
       <div class="modal-content">
-        <div class="modal-header--accessible">
+        <div class="modal-header">
           <ng-content select=".leading-button"></ng-content>
           <div class="modal-title-wrapper" #title [id]="modalId" cdkFocusInitial tabindex="-1">
             <ng-content select=".modal-title"></ng-content>

--- a/projects/angular/modal/modal.spec.ts
+++ b/projects/angular/modal/modal.spec.ts
@@ -339,7 +339,7 @@ describe('Modal', () => {
   });
 
   it('renders the title before the close button', async () => {
-    const modalHeader = compiled.querySelector('.modal-header--accessible');
+    const modalHeader = compiled.querySelector('.modal-header');
     expect(modalHeader.children.length).toBeGreaterThanOrEqual(2);
 
     const maybeTitleWrapper = modalHeader.children[0];

--- a/projects/angular/modal/modal.ts
+++ b/projects/angular/modal/modal.ts
@@ -5,7 +5,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-import { animate, AnimationEvent, style, transition, trigger } from '@angular/animations';
+import { animate, style, transition, trigger } from '@angular/animations';
 import {
   Component,
   ContentChild,
@@ -147,14 +147,8 @@ export class ClrModal implements OnChanges, OnDestroy {
       return;
     }
     this._open = false;
-  }
-
-  fadeDone(e: AnimationEvent) {
-    if (e.toState === 'void') {
-      // TODO: Investigate if we can decouple from animation events
-      this._openChanged.emit(false);
-      this.modalStackService.trackModalClose(this);
-    }
+    this._openChanged.emit(false);
+    this.modalStackService.trackModalClose(this);
   }
 
   scrollTop() {

--- a/projects/angular/modal/side-panel.spec.ts
+++ b/projects/angular/modal/side-panel.spec.ts
@@ -236,7 +236,7 @@ describe('Side Panel', () => {
   });
 
   it('renders the title before the close button', async () => {
-    const modalHeader = compiled.querySelector('.modal-header--accessible');
+    const modalHeader = compiled.querySelector('.modal-header');
     expect(modalHeader.children.length).toBeGreaterThanOrEqual(2);
 
     const maybeTitleWrapper = modalHeader.children[0];

--- a/projects/angular/wizard/wizard.html
+++ b/projects/angular/wizard/wizard.html
@@ -14,7 +14,7 @@
     </div>
 
     <div class="modal-content">
-      <div class="modal-header--accessible">
+      <div class="modal-header">
         <div class="modal-title-wrapper" #title cdkFocusInitial tabindex="-1">
           <div
             class="modal-title"


### PR DESCRIPTION
## PR Checklist

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

- [ ] Bugfix
- [x] Feature
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes

## What is the current behavior?

- `.modal-header--accessible` is a separate BEM modifier class that
  duplicates `.modal-header` styles via `@extend` and is only used in
  the clr-modal component template
- Modal title uses PI (Preview Integration) token overrides for
  font-family, font-size, font-weight, line-height, letter-spacing
  that should have been removed in GA 17
- Close event emission and modal stack tracking are coupled to the
  fadeMove animation done callback

Issue Number: CDE-3043 (parent: CDE-2969)

## What is the new behavior?

- `.modal-header` now includes flex layout directly; the
  `--accessible` variant is removed from SCSS and templates
- Title typography uses the `SECTION-20-STD` token without overrides;
  5 CSS custom properties removed
- `_openChanged` and `trackModalClose` are called directly in
  `close()`, decoupled from animation events

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: `.modal-header--accessible` removed (use
`.modal-header`). CSS custom properties `--clr-modal-title-font-*`
and `--clr-modal-title-letter-spacing` removed.

## Other information

Part of CDE-2969: investigate all TODO left overs in the code.

Made with [Cursor](https://cursor.com)