### PR TITLE
feat(tree-view): accept Iterable input for clrRecursiveForOf

### DIFF
--- a/projects/angular/data/tree-view/models/selected-state.enum.ts
+++ b/projects/angular/data/tree-view/models/selected-state.enum.ts
@@ -5,7 +5,6 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-// TODO: I'd like this to be a CheckedState enum for the checkboxes in the future.
 export enum ClrSelectedState {
   // WARNING! Unselected has the value 0,
   // so it's actually the only one that will evaluate to false if cast to a boolean.

--- a/projects/angular/data/tree-view/recursive-for-of.ts
+++ b/projects/angular/data/tree-view/recursive-for-of.ts
@@ -24,10 +24,8 @@ export interface ClrRecursiveForOfContext<T> {
   standalone: false,
 })
 export class ClrRecursiveForOf<T> implements OnChanges, OnDestroy {
-  // TODO: accept NgIterable<T>
-  @Input('clrRecursiveForOf') nodes: T | T[];
+  @Input('clrRecursiveForOf') nodes: T | T[] | Iterable<T>;
 
-  // TODO: accept NgIterable<T> return type
   @Input('clrRecursiveForGetChildren') getChildren: (node: T) => AsyncArray<T>;
 
   private childrenFetchSubscription: Subscription;
@@ -43,8 +41,14 @@ export class ClrRecursiveForOf<T> implements OnChanges, OnDestroy {
     let wrapped: RecursiveTreeNodeModel<T>[];
     if (Array.isArray(this.nodes)) {
       wrapped = this.nodes.map(node => new RecursiveTreeNodeModel(node, null, this.getChildren, this.featuresService));
+    } else if (this.nodes !== null && this.nodes !== undefined && typeof this.nodes[Symbol.iterator] === 'function') {
+      wrapped = Array.from(this.nodes as Iterable<T>).map(
+        node => new RecursiveTreeNodeModel(node, null, this.getChildren, this.featuresService)
+      );
+    } else if (this.nodes !== null && this.nodes !== undefined) {
+      wrapped = [new RecursiveTreeNodeModel(this.nodes as T, null, this.getChildren, this.featuresService)];
     } else {
-      wrapped = [new RecursiveTreeNodeModel(this.nodes, null, this.getChildren, this.featuresService)];
+      wrapped = [];
     }
     if (!this.childrenFetchSubscription) {
       this.childrenFetchSubscription = this.featuresService.childrenFetched.pipe(debounceTime(0)).subscribe(() => {


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

- clrRecursiveForOf only accepts T | T[] as input type. The TODO asks to accept NgIterable<T> so consumers can pass Set, Map.values(), generators, or other iterables.
- ClrSelectedState enum has a TODO about renaming to CheckedState. The name ClrSelectedState is already descriptive for tree selection and renaming would be a breaking public API change without clear benefit.

Issue Number: CDE-3048 (parent: CDE-2969)

## What is the new behavior?

- Input type widened to T | T[] | Iterable<T> with runtime handling via Symbol.iterator check. Existing T | T[] usage is fully backward compatible.
- Aspirational CheckedState rename TODO removed (name is already descriptive, rename would be breaking with no functional gain).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Part of CDE-2969: investigate all TODO left overs in the code.