### PR TITLE
feat(login): remove unused tooltip-validation styles

### DIFF
--- a/projects/angular/layout/_login.clarity.scss
+++ b/projects/angular/layout/_login.clarity.scss
@@ -114,7 +114,6 @@
         padding-top: density.$clr-base-vertical-offset-3xl;
         width: 100%;
 
-        // @TODO Are these used? Some are documented on the website but not actually used. Some are neither documented nor used.
         .auth-source,
         .username,
         .password,
@@ -156,18 +155,6 @@
               }
             }
           }
-        }
-
-        // @TODO Is this used? It's not documented on the website or used in the demo app.
-        .tooltip-validation {
-          margin-top: density.$clr-base-vertical-offset-s;
-        }
-
-        // @TODO Is this used? It's not documented on the website or used in the demo app.
-        .tooltip-validation .username,
-        .tooltip-validation .password {
-          width: 100%;
-          margin-top: 0; //Since the top margin is now handled by the tooltip itself
         }
 
         .error {


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Login SCSS (_login.clarity.scss) contains three TODO comments:
1. Questioning if .auth-source, .username, .password, .checkbox, .clr-form-control selectors are used - they ARE used, they provide spacing for login form fields and .username/.password are documented on the website.
2. .tooltip-validation class and .tooltip-validation .username/.password - searched the entire codebase (projects/ tree) and these selectors are not used in any template, demo, or documentation page. The styles are dead code.

Issue Number: CDE-3050 (parent: CDE-2969)

## What is the new behavior?

- Removed .tooltip-validation and .tooltip-validation .username/.password CSS rules since they are confirmed unused across the entire codebase
- Removed the TODO questioning .auth-source/.username/.password usage after confirming they are actively used for login form field spacing

## Does this PR introduce a breaking change?

- [x] Yes
- [ ] No

BREAKING CHANGE: .tooltip-validation CSS class removed from login styles. Consumers using this class for custom login form tooltip styling need to provide their own styles.

## Other information

Part of CDE-2969: investigate all TODO left overs in the code.