### PR TITLE
chore(signpost): extract popover-pointer mixins for all 12 positions

### DIFF
--- a/projects/angular/popover/signpost/_mixins.signpost.scss
+++ b/projects/angular/popover/signpost/_mixins.signpost.scss
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+@use 'sass:map';
+@use '../../styles/mixins';
+@use 'variables.signpost' as signpost-variables;
+@use '../../styles/core/tokens/variables.tokens' as tokens;
+
+$_opp: mixins.$opp-directions;
+
+// CSS border-radius requires vertical-then-horizontal order.
+@function _corner-radius-prop($dir-a, $dir-b) {
+  @if $dir-a == top or $dir-a == bottom {
+    @return border-#{$dir-a}-#{$dir-b}-radius;
+  } @else {
+    @return border-#{$dir-b}-#{$dir-a}-radius;
+  }
+}
+
+// Shared `.popover-pointer` styles for all positions on a primary edge.
+@mixin popover-pointer-primary($primary, $pointer-size-negative, $before-props: ()) {
+  $opp-primary: map.get($_opp, $primary);
+  $is-vertical: $primary == top or $primary == bottom;
+
+  .popover-pointer {
+    border-#{$primary}: signpost-variables.$clr-signpost-pointer-border;
+    #{$opp-primary}: $pointer-size-negative;
+
+    &::before {
+      border-#{$primary}: signpost-variables.$clr-signpost-pointer-pseudo-border;
+
+      @if $is-vertical {
+        #{$opp-primary}: tokens.$cds-global-space-2;
+      }
+
+      @each $prop, $val in $before-props {
+        #{$prop}: #{$val};
+      }
+    }
+  }
+}
+
+// Per-position `.popover-pointer` and `.signpost-wrap` styles.
+//
+// $primary     – edge the pointer sits on (top | bottom | left | right)
+// $secondary   – position along that edge (start | middle | end)
+// $before-props – extra `::before` properties specific to this position
+@mixin popover-pointer-position($primary, $secondary, $before-props: ()) {
+  $opp-primary: map.get($_opp, $primary);
+  $is-vertical: $primary == top or $primary == bottom;
+  $cross-start: left;
+  $cross-end: right;
+
+  @if not $is-vertical {
+    $cross-start: top;
+    $cross-end: bottom;
+  }
+
+  @if $secondary == start {
+    .signpost-wrap {
+      #{_corner-radius-prop($opp-primary, $cross-end)}: 0;
+    }
+
+    .popover-pointer {
+      border-#{$cross-start}: signpost-variables.$clr-signpost-pointer-invisible-border;
+      #{$cross-end}: calc(-1 * tokens.$cds-global-space-1);
+
+      &::before {
+        border-#{$cross-start}: signpost-variables.$clr-signpost-pointer-invisible-border;
+
+        @each $prop, $val in $before-props {
+          #{$prop}: #{$val};
+        }
+      }
+    }
+  } @else if $secondary == middle {
+    .popover-pointer {
+      border-#{$cross-end}: signpost-variables.$clr-signpost-pointer-invisible-border;
+      #{$cross-start}: 50%;
+
+      &::before {
+        border-#{$cross-end}: signpost-variables.$clr-signpost-pointer-invisible-border;
+
+        @each $prop, $val in $before-props {
+          #{$prop}: #{$val};
+        }
+      }
+    }
+  } @else if $secondary == end {
+    .signpost-wrap {
+      #{_corner-radius-prop($opp-primary, $cross-start)}: 0;
+    }
+
+    .popover-pointer {
+      border-#{$cross-end}: signpost-variables.$clr-signpost-pointer-invisible-border;
+      #{$cross-start}: calc(-1 * tokens.$cds-global-space-1);
+
+      &::before {
+        border-#{$cross-end}: signpost-variables.$clr-signpost-pointer-invisible-border;
+
+        @each $prop, $val in $before-props {
+          #{$prop}: #{$val};
+        }
+      }
+    }
+  }
+}

--- a/projects/angular/popover/signpost/_signposts.clarity.scss
+++ b/projects/angular/popover/signpost/_signposts.clarity.scss
@@ -12,6 +12,7 @@
 @use 'variables.signpost' as signpost-variables;
 @use '../../styles/variables/variables.density' as density;
 @use '../../styles/core/tokens/variables.tokens' as tokens;
+@use 'mixins.signpost' as signpost-mixins;
 
 @include meta.load-css('properties.signpost');
 @include mixins.exports('signpost.clarity') {
@@ -140,275 +141,164 @@
     @include mixins.generate-typography-token('BODY-14-RG-CPT');
   }
 
+  // Top positions
   .clr-signpost-container.top-left,
   .clr-signpost-container.top-middle,
   .clr-signpost-container.top-right {
-    .popover-pointer {
-      border-top: signpost-variables.$clr-signpost-pointer-border;
-      bottom: $clr-signpost-pointer-size-negative;
-
-      &::before {
-        border-top: signpost-variables.$clr-signpost-pointer-pseudo-border;
-        bottom: tokens.$cds-global-space-2;
-      }
-    }
+    @include signpost-mixins.popover-pointer-primary(top, $clr-signpost-pointer-size-negative);
   }
 
   .clr-signpost-container.top-left {
-    .signpost-wrap {
-      border-bottom-right-radius: 0; // Turn off rounded corner here
-    }
-
-    .popover-pointer {
-      border-left: signpost-variables.$clr-signpost-pointer-invisible-border;
-      right: calc(-1 * tokens.$cds-global-space-1);
-
-      &::before {
-        border-left: signpost-variables.$clr-signpost-pointer-invisible-border;
-        right: tokens.$cds-global-space-1;
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      top,
+      start,
+      (
+        right: tokens.$cds-global-space-1,
+      )
+    );
   }
 
   .clr-signpost-container.top-middle {
-    .popover-pointer {
-      border-right: signpost-variables.$clr-signpost-pointer-invisible-border;
-      left: 50%;
-
-      &::before {
-        border-right: signpost-variables.$clr-signpost-pointer-invisible-border;
-        left: tokens.$cds-global-space-1;
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      top,
+      middle,
+      (
+        left: tokens.$cds-global-space-1,
+      )
+    );
   }
 
   .clr-signpost-container.top-right {
-    .signpost-wrap {
-      border-bottom-left-radius: 0; // Turn off rounded corner here
-    }
-
-    .popover-pointer {
-      border-right: signpost-variables.$clr-signpost-pointer-invisible-border;
-      left: calc(-1 * tokens.$cds-global-space-1);
-
-      &::before {
-        border-right: signpost-variables.$clr-signpost-pointer-invisible-border;
-        left: tokens.$cds-global-space-1;
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      top,
+      end,
+      (
+        left: tokens.$cds-global-space-1,
+      )
+    );
   }
-  // End top-*
 
-  /***
-    The signpost is below the icon top-{HORIZONTAL_POSITION}
-  */
-
+  // Bottom positions
   .clr-signpost-container.bottom-left,
   .clr-signpost-container.bottom-middle,
   .clr-signpost-container.bottom,
   .clr-signpost-container.bottom-right {
-    .popover-pointer {
-      border-bottom: signpost-variables.$clr-signpost-pointer-border;
-      top: $clr-signpost-pointer-size-negative;
-
-      &::before {
-        border-bottom: signpost-variables.$clr-signpost-pointer-pseudo-border;
-        top: tokens.$cds-global-space-2;
-      }
-    }
+    @include signpost-mixins.popover-pointer-primary(bottom, $clr-signpost-pointer-size-negative);
   }
 
   .clr-signpost-container.bottom-left {
-    .signpost-wrap {
-      border-top-right-radius: 0; // Turn off rounded corners here
-    }
-
-    .popover-pointer {
-      border-left: signpost-variables.$clr-signpost-pointer-invisible-border;
-      right: calc(-1 * tokens.$cds-global-space-1);
-
-      &::before {
-        border-left: signpost-variables.$clr-signpost-pointer-invisible-border;
-        right: tokens.$cds-global-space-1;
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      bottom,
+      start,
+      (
+        right: tokens.$cds-global-space-1,
+      )
+    );
   }
 
   .clr-signpost-container.bottom,
   .clr-signpost-container.bottom-middle {
-    .popover-pointer {
-      border-right: signpost-variables.$clr-signpost-pointer-invisible-border;
-      left: 50%;
-
-      &::before {
-        border-right: signpost-variables.$clr-signpost-pointer-invisible-border;
-        right: calc($clr-signpost-pointer-size-negative - tokens.$cds-global-space-1);
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      bottom,
+      middle,
+      (
+        right: calc($clr-signpost-pointer-size-negative - tokens.$cds-global-space-1),
+      )
+    );
   }
 
   .clr-signpost-container.bottom-right {
-    .signpost-wrap {
-      border-top-left-radius: 0; // Turn off rounded corners here
-    }
-
-    .popover-pointer {
-      border-right: signpost-variables.$clr-signpost-pointer-invisible-border;
-      left: calc(-1 * tokens.$cds-global-space-1);
-
-      &::before {
-        border-right: signpost-variables.$clr-signpost-pointer-invisible-border;
-        left: tokens.$cds-global-space-1;
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      bottom,
+      end,
+      (
+        left: tokens.$cds-global-space-1,
+      )
+    );
   }
-  // End bottom-*
 
-  /***
-     The signpost is on the left side of the icon left-{VERTICAL_POSITION}
-  */
-
+  // Left positions
   .clr-signpost-container.left-top,
   .clr-signpost-container.left-middle,
   .clr-signpost-container.left,
   .clr-signpost-container.left-bottom {
-    .popover-pointer {
-      border-left: signpost-variables.$clr-signpost-pointer-border;
-      right: $clr-signpost-pointer-size-negative;
-
-      &::before {
-        border-left: signpost-variables.$clr-signpost-pointer-pseudo-border;
-      }
-    }
+    @include signpost-mixins.popover-pointer-primary(left, $clr-signpost-pointer-size-negative);
   }
 
   .clr-signpost-container.left-top {
-    .signpost-wrap {
-      border-bottom-right-radius: 0; // Turn off rounded corners here
-    }
-
-    .popover-pointer {
-      border-top: signpost-variables.$clr-signpost-pointer-invisible-border;
-      bottom: calc(-1 * tokens.$cds-global-space-1);
-
-      &::before {
-        border-top: signpost-variables.$clr-signpost-pointer-invisible-border;
-        top: calc($clr-signpost-pointer-size-negative - tokens.$cds-global-space-1);
-        right: tokens.$cds-global-space-2;
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      left,
+      start,
+      (
+        top: calc($clr-signpost-pointer-size-negative - tokens.$cds-global-space-1),
+        right: tokens.$cds-global-space-2,
+      )
+    );
   }
 
   .clr-signpost-container.left-middle,
   .clr-signpost-container.left {
-    .popover-pointer {
-      border-bottom: signpost-variables.$clr-signpost-pointer-invisible-border;
-      top: 50%;
-
-      &::before {
-        border-bottom: signpost-variables.$clr-signpost-pointer-invisible-border;
-        top: tokens.$cds-global-space-1;
-        left: calc($clr-signpost-pointer-size-negative - tokens.$cds-global-space-2);
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      left,
+      middle,
+      (
+        top: tokens.$cds-global-space-1,
+        left: calc($clr-signpost-pointer-size-negative - tokens.$cds-global-space-2),
+      )
+    );
   }
 
   .clr-signpost-container.left-bottom {
-    .signpost-wrap {
-      border-top-right-radius: 0; // Turn off rounded corners here
-    }
-
-    .popover-pointer {
-      border-bottom: signpost-variables.$clr-signpost-pointer-invisible-border;
-      top: calc(-1 * tokens.$cds-global-space-1);
-
-      &::before {
-        border-bottom: signpost-variables.$clr-signpost-pointer-invisible-border;
-        top: tokens.$cds-global-space-1;
-        left: calc($clr-signpost-pointer-size-negative - tokens.$cds-global-space-2);
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      left,
+      end,
+      (
+        top: tokens.$cds-global-space-1,
+        left: calc($clr-signpost-pointer-size-negative - tokens.$cds-global-space-2),
+      )
+    );
   }
-  // End left-*
 
-  /***
-    The signpost is on the right side of the icon right-{VERTICAL_POSITION}
-  */
-
+  // Right positions
   .clr-signpost-container.right-top,
   .clr-signpost-container.right-middle,
   .clr-signpost-container.right-bottom {
-    .popover-pointer {
-      border-right: signpost-variables.$clr-signpost-pointer-border;
-      left: $clr-signpost-pointer-size-negative;
-
-      &::before {
-        border-right: signpost-variables.$clr-signpost-pointer-pseudo-border;
-        left: tokens.$cds-global-space-2;
-      }
-    }
+    @include signpost-mixins.popover-pointer-primary(
+      right,
+      $clr-signpost-pointer-size-negative,
+      (
+        left: tokens.$cds-global-space-2,
+      )
+    );
   }
 
   .clr-signpost-container.right-top {
-    .signpost-wrap {
-      border-bottom-left-radius: 0; // turn off rounded corner here
-    }
-
-    .popover-pointer {
-      border-top: signpost-variables.$clr-signpost-pointer-invisible-border;
-      bottom: calc(-1 * tokens.$cds-global-space-1);
-
-      &::before {
-        border-top: signpost-variables.$clr-signpost-pointer-invisible-border;
-        top: calc($clr-signpost-pointer-size-negative - tokens.$cds-global-space-1);
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      right,
+      start,
+      (
+        top: calc($clr-signpost-pointer-size-negative - tokens.$cds-global-space-1),
+      )
+    );
   }
 
   .clr-signpost-container.right-middle {
-    .popover-pointer {
-      border-bottom: signpost-variables.$clr-signpost-pointer-invisible-border;
-      top: 50%;
-
-      &::before {
-        border-bottom: signpost-variables.$clr-signpost-pointer-invisible-border;
-        top: tokens.$cds-global-space-1;
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      right,
+      middle,
+      (
+        top: tokens.$cds-global-space-1,
+      )
+    );
   }
 
   .clr-signpost-container.right-bottom {
-    .signpost-wrap {
-      border-top-left-radius: 0; // turn off rounded corner here
-    }
-
-    .popover-pointer {
-      border-bottom: signpost-variables.$clr-signpost-pointer-invisible-border;
-      top: calc(-1 * tokens.$cds-global-space-1);
-
-      &::before {
-        border-bottom: signpost-variables.$clr-signpost-pointer-invisible-border;
-        top: tokens.$cds-global-space-1;
-      }
-    }
+    @include signpost-mixins.popover-pointer-position(
+      right,
+      end,
+      (
+        top: tokens.$cds-global-space-1,
+      )
+    );
   }
-
-  /***
-    TODO: Create a general mix-in for the popover-pointer that can
-    1. Accomadate all 12 positions
-    2. Unification for the nomenclature between components
-        (if possible, I know they all use slightly different terms)
-    3. Be used across Tooltips, Signposts (Do we also want it for Dropdowns)
-    4. What's up with the namespacing here? Usually we use `clr-*` to denote
-        Clarity components but we aren't doing that in signposts. We should
-        consider it.
-  */
-
-  /* NOTE:
-    signposts need precise pixels for some measurements due to the design
-    Hence the 1px and 2px values you'll see.
-
-    I've tested the calcs while resizing the base font-size for the rem
-    measurements and they appear to hold up well.
-  */
 }


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [x] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: CDE-3054

The signpost component has ~250 lines of repetitive SCSS for popover-pointer positioning across all 12 positions (top-left, top-middle, top-right, bottom-left, bottom-middle, bottom-right, left-top, left-middle, left-bottom, right-top, right-middle, right-bottom). A TODO comment in the file explicitly requests creating a shared mixin for this.

## What is the new behavior?

- Created `_mixins.signpost.scss` with two reusable mixins:
  - `popover-pointer-primary` — handles shared border and position styles for each primary edge group (top/bottom/left/right)
  - `popover-pointer-position` — handles per-position cross-axis placement, corner-radius removal, and `::before` pseudo-element positioning
- Refactored `_signposts.clarity.scss` to use these mixins, reducing repetition while producing identical CSS output
- Removed the TODO comment (resolved by this PR)

The compiled CSS output is **byte-for-byte identical** (excluding removed comment blocks) — verified by diffing the compiled output before and after the refactor.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

No breaking change. The generated CSS is identical; only the SCSS source structure has changed.

## Other information

The TODO also mentioned unifying nomenclature across tooltips/signposts/dropdowns and adding `clr-*` namespacing to signpost classes. These are separate concerns that would be breaking changes with wider scope, and are not addressed in this PR.

Made with [Cursor](https://cursor.com)