### PR TITLE
chore(popover): add website documentation for popover utility

### DIFF
--- a/projects/website/src/app/documentation/demos/popover/popover-basic.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover-basic.demo.html
@@ -1,0 +1,29 @@
+<!--
+  ~ Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+  ~ The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+<div class="clr-example">
+  <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+    <cds-icon shape="home"></cds-icon> Open Popover
+  </button>
+  <div
+    class="popover-panel"
+    role="dialog"
+    cdkTrapFocus
+    *clrPopoverContent="open; at: 'bottom-left'; outsideClickToClose: true; scrollToClose: false"
+  >
+    <h4 cds-text="section">Server Details</h4>
+    <p cds-text="body" class="clr-mt-8px">
+      <b>Host:</b> prod-web-01.example.com<br />
+      <b>Status:</b> Running<br />
+      <b>Uptime:</b> 14 days
+    </p>
+    <button class="btn btn-sm btn-outline clr-mt-8px" clrPopoverCloseButton>
+      Close <cds-icon shape="times"></cds-icon>
+    </button>
+  </div>
+</div>
+<app-stackblitz-example name="popover basic" [componentTemplate]="example" [componentClass]="exampleTs">
+</app-stackblitz-example>

--- a/projects/website/src/app/documentation/demos/popover/popover-basic.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover-basic.demo.html
@@ -5,7 +5,7 @@
   ~ The full license information can be found in LICENSE in the root directory of this project.
   -->
 <div class="clr-example">
-  <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+  <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverOrigin>
     <cds-icon shape="home"></cds-icon> Open Popover
   </button>
   <div

--- a/projects/website/src/app/documentation/demos/popover/popover-basic.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover-basic.ts
@@ -1,0 +1,79 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, ViewEncapsulation } from '@angular/core';
+import { ClrIcon, ClrPopoverContent, ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+
+import { StackblitzExampleComponent } from '../../../shared/stackblitz-example/stackblitz-example.component';
+
+const EXAMPLE = `
+<button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+  <cds-icon shape="home"></cds-icon>
+  Open Popover
+</button>
+<div
+  class="popover-panel"
+  role="dialog"
+  cdkTrapFocus
+  *clrPopoverContent="open; at: 'bottom-left'; outsideClickToClose: true; scrollToClose: false"
+>
+  <h4 style="margin-top: 0">Server Details</h4>
+  <p>
+    <b>Host:</b>
+    prod-web-01.example.com
+    <br />
+    <b>Status:</b>
+    Running
+    <br />
+    <b>Uptime:</b>
+    14 days
+  </p>
+  <button class="btn btn-sm btn-outline" clrPopoverCloseButton>
+    Close
+    <cds-icon shape="times"></cds-icon>
+  </button>
+</div>
+`;
+
+const EXAMPLE_TS = `
+import { Component } from '@angular/core';
+import {
+  ClarityIcons,
+  ClrPopoverService,
+  homeIcon,
+  timesIcon,
+  ÇlrClrPopoverModuleNext,
+} from '@clr/angular';
+
+@Component({
+  selector: 'app-popover-example',
+  templateUrl: './popover-example.component.html',
+  providers: [ClrPopoverService],
+  imports: [ÇlrClrPopoverModuleNext],
+})
+export class PopoverExampleComponent {
+  open = false;
+
+  constructor() {
+    ClarityIcons.addIcons(homeIcon, timesIcon);
+  }
+}
+`;
+
+@Component({
+  selector: 'clr-popover-basic-demo',
+  templateUrl: './popover-basic.demo.html',
+  styleUrl: './popover.demo.scss',
+  encapsulation: ViewEncapsulation.None,
+  providers: [ClrPopoverService],
+  imports: [ClrPopoverContent, ClrIcon, ÇlrClrPopoverModuleNext, StackblitzExampleComponent],
+})
+export class PopoverBasicDemo {
+  open = false;
+  example = EXAMPLE;
+  exampleTs = EXAMPLE_TS;
+}

--- a/projects/website/src/app/documentation/demos/popover/popover-basic.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover-basic.ts
@@ -6,12 +6,12 @@
  */
 
 import { Component, ViewEncapsulation } from '@angular/core';
-import { ClrIcon, ClrPopoverContent, ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+import { ClrIcon, ClrPopoverContent, ClrPopoverModuleNext, ClrPopoverService } from '@clr/angular';
 
 import { StackblitzExampleComponent } from '../../../shared/stackblitz-example/stackblitz-example.component';
 
 const EXAMPLE = `
-<button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+<button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverOrigin>
   <cds-icon shape="home"></cds-icon>
   Open Popover
 </button>
@@ -46,14 +46,14 @@ import {
   ClrPopoverService,
   homeIcon,
   timesIcon,
-  ÇlrClrPopoverModuleNext,
+  ClrPopoverModuleNext,
 } from '@clr/angular';
 
 @Component({
   selector: 'app-popover-example',
   templateUrl: './popover-example.component.html',
   providers: [ClrPopoverService],
-  imports: [ÇlrClrPopoverModuleNext],
+  imports: [ClrPopoverModuleNext],
 })
 export class PopoverExampleComponent {
   open = false;
@@ -70,7 +70,7 @@ export class PopoverExampleComponent {
   styleUrl: './popover.demo.scss',
   encapsulation: ViewEncapsulation.None,
   providers: [ClrPopoverService],
-  imports: [ClrPopoverContent, ClrIcon, ÇlrClrPopoverModuleNext, StackblitzExampleComponent],
+  imports: [ClrPopoverContent, ClrIcon, ClrPopoverModuleNext, StackblitzExampleComponent],
 })
 export class PopoverBasicDemo {
   open = false;

--- a/projects/website/src/app/documentation/demos/popover/popover-context-menu.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover-context-menu.demo.html
@@ -1,0 +1,39 @@
+<!--
+  ~ Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+  ~ The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+<div>
+  <p cds-text="body" class="clr-mt-16px">
+    Right-click inside the dashed area to open a popover at the cursor position. The popover uses
+    <code cds-text="code">openAtPoint()</code> to position itself at the exact click coordinates instead of an element.
+  </p>
+  <div class="clr-example">
+    <div class="context-menu-area" (contextmenu)="onContextMenu($event)">
+      <span cds-text="body">Right-click here to open context menu</span>
+    </div>
+    <div
+      class="popover-panel"
+      role="dialog"
+      cdkTrapFocus
+      *clrPopoverContent="open; at: 'bottom-left'; outsideClickToClose: true"
+    >
+      <h4 cds-text="section" style="margin-top: 0">Context Menu</h4>
+      <p cds-text="body" class="clr-mt-8px">
+        Opened at point (<code cds-text="code">{{ clickX }}, {{ clickY }}</code>).
+      </p>
+      <div class="clr-mt-8px" cds-layout="horizontal gap:sm">
+        <button class="btn btn-sm btn-outline" type="button" clrPopoverCloseButton>
+          Close <cds-icon shape="times"></cds-icon>
+        </button>
+      </div>
+    </div>
+  </div>
+
+  <app-stackblitz-example
+    name="popover context menu"
+    [componentTemplate]="html"
+    [componentClass]="code"
+  ></app-stackblitz-example>
+</div>

--- a/projects/website/src/app/documentation/demos/popover/popover-context-menu.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover-context-menu.ts
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, ViewEncapsulation } from '@angular/core';
+import { ClrIcon, ClrPopoverContent, ClrPopoverModuleNext, ClrPopoverService } from '@clr/angular';
+
+import { StackblitzExampleComponent } from '../../../shared/stackblitz-example/stackblitz-example.component';
+
+const HTML = `
+<div class="context-menu-area" (contextmenu)="onContextMenu($event)">
+  <span>Right-click here to open context menu</span>
+</div>
+<div role="dialog" cdkTrapFocus *clrPopoverContent="open; at: 'bottom-left'; outsideClickToClose: true">
+  <h4 style="margin-top: 0">Context Menu</h4>
+  <p>Opened at point ({{ clickX }}, {{ clickY }}).</p>
+  <button class="btn btn-sm btn-outline" clrPopoverCloseButton>Close</button>
+</div>
+`;
+
+const CODE = `
+import { Component } from '@angular/core';
+import { ClrPopoverService, ClrPopoverModuleNext } from '@clr/angular';
+
+@Component({
+  selector: 'app-popover-context-menu',
+  templateUrl: './popover-context-menu.component.html',
+  providers: [ClrPopoverService],
+  imports: [ClrPopoverModuleNext],
+})
+export class PopoverContextMenuComponent {
+  open = false;
+  clickX = 0;
+  clickY = 0;
+
+  constructor(private popoverService: ClrPopoverService) {}
+
+  onContextMenu(event: MouseEvent) {
+    event.preventDefault();
+    this.clickX = event.clientX;
+    this.clickY = event.clientY;
+    this.popoverService.openAtPoint({ x: event.clientX, y: event.clientY });
+  }
+}
+`;
+
+@Component({
+  selector: 'clr-popover-context-menu-demo',
+  templateUrl: './popover-context-menu.demo.html',
+  styleUrl: './popover.demo.scss',
+  encapsulation: ViewEncapsulation.None,
+  providers: [ClrPopoverService],
+  styles: [
+    `
+      .context-menu-area {
+        border: 2px dashed var(--cds-alias-object-border-color);
+        padding: var(--cds-global-space-9);
+        min-height: 120px;
+        display: flex;
+        align-items: center;
+        justify-content: center;
+        cursor: context-menu;
+      }
+    `,
+  ],
+  imports: [ClrPopoverContent, ClrIcon, ClrPopoverModuleNext, StackblitzExampleComponent],
+})
+export class PopoverContextMenuDemo {
+  open = false;
+  clickX = 0;
+  clickY = 0;
+
+  html = HTML;
+  code = CODE;
+
+  constructor(private popoverService: ClrPopoverService) {}
+
+  onContextMenu(event: MouseEvent) {
+    event.preventDefault();
+    this.clickX = event.clientX;
+    this.clickY = event.clientY;
+    this.popoverService.openAtPoint({ x: event.clientX, y: event.clientY });
+  }
+}

--- a/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.demo.html
@@ -6,9 +6,13 @@
   -->
 <div>
   <p cds-text="body" class="clr-mt-16px">
+    The <code cds-text="code">availablePositions</code> array defines fallback positions that are tried
+    <strong>in order</strong> when the preferred position does not fit the viewport. The CDK checks each position
+    sequentially and uses the first one that fits.
+  </p>
+  <p cds-text="body" class="clr-mt-8px">
     Resize the browser or scroll the page so the button is near the edge. The popover prefers
-    <code cds-text="code">top-right</code>, but when there is not enough space above, it falls back to
-    <code cds-text="code">bottom-right</code>, then <code cds-text="code">right-middle</code>.
+    <code cds-text="code">top-right</code>, but falls back through bottom, top, left, and right positions.
   </p>
   <div class="clr-example popover-centered-area">
     <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
@@ -29,10 +33,13 @@
       <h4 cds-text="section" style="margin-top: 0">Fallback Positions</h4>
       <p cds-text="body" class="clr-mt-8px">
         Preferred: <code cds-text="code">top-right</code><br />
-        Fallbacks: <code cds-text="code">bottom-right</code>, <code cds-text="code">right-middle</code>
+        Fallbacks (in order): <code cds-text="code">bottom-middle</code>, <code cds-text="code">bottom-left</code>,
+        <code cds-text="code">bottom-right</code>, <code cds-text="code">top-middle</code>,
+        <code cds-text="code">left-middle</code>,
+        <code cds-text="code">right-middle</code>
       </p>
       <p cds-text="body" class="clr-mt-8px">
-        Move the button near the top edge of the viewport to see the overlay reposition automatically.
+        Move the button near an edge of the viewport to see the overlay reposition automatically.
       </p>
       <button class="btn btn-sm btn-outline clr-mt-8px" clrPopoverCloseButton>
         Close <cds-icon shape="times"></cds-icon>

--- a/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.demo.html
@@ -15,7 +15,7 @@
     <code cds-text="code">top-right</code>, but falls back through bottom, top, left, and right positions.
   </p>
   <div class="clr-example popover-centered-area">
-    <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+    <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverOrigin>
       <cds-icon shape="home"></cds-icon> Open (prefers top-right)
     </button>
     <div

--- a/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.demo.html
@@ -1,0 +1,48 @@
+<!--
+  ~ Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+  ~ The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+<div>
+  <p cds-text="body" class="clr-mt-16px">
+    Resize the browser or scroll the page so the button is near the edge. The popover prefers
+    <code cds-text="code">top-right</code>, but when there is not enough space above, it falls back to
+    <code cds-text="code">bottom-right</code>, then <code cds-text="code">right-middle</code>.
+  </p>
+  <div class="clr-example popover-centered-area">
+    <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+      <cds-icon shape="home"></cds-icon> Open (prefers top-right)
+    </button>
+    <div
+      class="popover-panel"
+      role="dialog"
+      cdkTrapFocus
+      *clrPopoverContent="
+        open;
+        at: 'top-right';
+        availablePositions: fallbackPositions;
+        outsideClickToClose: true;
+        scrollToClose: false
+      "
+    >
+      <h4 cds-text="section" style="margin-top: 0">Fallback Positions</h4>
+      <p cds-text="body" class="clr-mt-8px">
+        Preferred: <code cds-text="code">top-right</code><br />
+        Fallbacks: <code cds-text="code">bottom-right</code>, <code cds-text="code">right-middle</code>
+      </p>
+      <p cds-text="body" class="clr-mt-8px">
+        Move the button near the top edge of the viewport to see the overlay reposition automatically.
+      </p>
+      <button class="btn btn-sm btn-outline clr-mt-8px" clrPopoverCloseButton>
+        Close <cds-icon shape="times"></cds-icon>
+      </button>
+    </div>
+  </div>
+
+  <app-stackblitz-example
+    name="popover fallback positions"
+    [componentTemplate]="html"
+    [componentClass]="code"
+  ></app-stackblitz-example>
+</div>

--- a/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.ts
@@ -29,11 +29,7 @@ const HTML = `
   <p>
     The CDK tries
     <code>top-right</code>
-    first, then falls back to
-    <code>bottom-right</code>
-    or
-    <code>right-middle</code>
-    .
+    first, then checks each fallback in order until one fits the viewport.
   </p>
   <button class="btn btn-sm btn-outline" clrPopoverCloseButton>Close</button>
 </div>
@@ -53,9 +49,14 @@ import { ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
 export class PopoverFallbackComponent {
   open = false;
 
+  // Positions are tried in order — the first one that fits the viewport wins.
   fallbackPositions: ConnectedPosition[] = [
-    { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top' },
-    { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center' },
+    { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top' }, // bottom-middle
+    { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top' }, // bottom-left
+    { originX: 'end', originY: 'bottom', overlayX: 'end', overlayY: 'top' }, // bottom-right
+    { originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom' }, // top-middle
+    { originX: 'start', originY: 'center', overlayX: 'end', overlayY: 'center' }, // left-middle
+    { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center' }, // right-middle
   ];
 }
 `;
@@ -72,8 +73,12 @@ export class PopoverFallbackPositionsDemo {
   open = false;
 
   fallbackPositions: ConnectedPosition[] = [
-    { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top' },
-    { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center' },
+    { originX: 'center', originY: 'bottom', overlayX: 'center', overlayY: 'top' }, // bottom-middle
+    { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top' }, // bottom-left
+    { originX: 'end', originY: 'bottom', overlayX: 'end', overlayY: 'top' }, // bottom-right
+    { originX: 'center', originY: 'top', overlayX: 'center', overlayY: 'bottom' }, // top-middle
+    { originX: 'start', originY: 'center', overlayX: 'end', overlayY: 'center' }, // left-middle
+    { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center' }, // right-middle
   ];
 
   html = HTML;

--- a/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.ts
@@ -1,0 +1,81 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ConnectedPosition } from '@angular/cdk/overlay';
+import { Component, ViewEncapsulation } from '@angular/core';
+import { ClrIcon, ClrPopoverContent, ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+
+import { StackblitzExampleComponent } from '../../../shared/stackblitz-example/stackblitz-example.component';
+
+const HTML = `
+<button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+  Open (prefers top-right)
+</button>
+<div
+  role="dialog"
+  cdkTrapFocus
+  *clrPopoverContent="
+    open;
+    at: 'top-right';
+    availablePositions: fallbackPositions;
+    outsideClickToClose: true
+  "
+>
+  <h4 style="margin-top: 0">Fallback Positions</h4>
+  <p>
+    The CDK tries
+    <code>top-right</code>
+    first, then falls back to
+    <code>bottom-right</code>
+    or
+    <code>right-middle</code>
+    .
+  </p>
+  <button class="btn btn-sm btn-outline" clrPopoverCloseButton>Close</button>
+</div>
+`;
+
+const CODE = `
+import { ConnectedPosition } from '@angular/cdk/overlay';
+import { Component } from '@angular/core';
+import { ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+
+@Component({
+  selector: 'app-popover-fallback',
+  templateUrl: './popover-fallback.component.html',
+  providers: [ClrPopoverService],
+  imports: [ÇlrClrPopoverModuleNext],
+})
+export class PopoverFallbackComponent {
+  open = false;
+
+  fallbackPositions: ConnectedPosition[] = [
+    { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top' },
+    { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center' },
+  ];
+}
+`;
+
+@Component({
+  selector: 'clr-popover-fallback-positions-demo',
+  templateUrl: './popover-fallback-positions.demo.html',
+  styleUrl: './popover.demo.scss',
+  encapsulation: ViewEncapsulation.None,
+  providers: [ClrPopoverService],
+  imports: [ClrPopoverContent, ClrIcon, ÇlrClrPopoverModuleNext, StackblitzExampleComponent],
+})
+export class PopoverFallbackPositionsDemo {
+  open = false;
+
+  fallbackPositions: ConnectedPosition[] = [
+    { originX: 'start', originY: 'bottom', overlayX: 'start', overlayY: 'top' },
+    { originX: 'end', originY: 'center', overlayX: 'start', overlayY: 'center' },
+  ];
+
+  html = HTML;
+  code = CODE;
+}

--- a/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover-fallback-positions.ts
@@ -7,12 +7,12 @@
 
 import { ConnectedPosition } from '@angular/cdk/overlay';
 import { Component, ViewEncapsulation } from '@angular/core';
-import { ClrIcon, ClrPopoverContent, ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+import { ClrIcon, ClrPopoverContent, ClrPopoverModuleNext, ClrPopoverService } from '@clr/angular';
 
 import { StackblitzExampleComponent } from '../../../shared/stackblitz-example/stackblitz-example.component';
 
 const HTML = `
-<button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+<button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverOrigin>
   Open (prefers top-right)
 </button>
 <div
@@ -38,13 +38,13 @@ const HTML = `
 const CODE = `
 import { ConnectedPosition } from '@angular/cdk/overlay';
 import { Component } from '@angular/core';
-import { ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+import { ClrPopoverService, ClrPopoverModuleNext } from '@clr/angular';
 
 @Component({
   selector: 'app-popover-fallback',
   templateUrl: './popover-fallback.component.html',
   providers: [ClrPopoverService],
-  imports: [ÇlrClrPopoverModuleNext],
+  imports: [ClrPopoverModuleNext],
 })
 export class PopoverFallbackComponent {
   open = false;
@@ -67,7 +67,7 @@ export class PopoverFallbackComponent {
   styleUrl: './popover.demo.scss',
   encapsulation: ViewEncapsulation.None,
   providers: [ClrPopoverService],
-  imports: [ClrPopoverContent, ClrIcon, ÇlrClrPopoverModuleNext, StackblitzExampleComponent],
+  imports: [ClrPopoverContent, ClrIcon, ClrPopoverModuleNext, StackblitzExampleComponent],
 })
 export class PopoverFallbackPositionsDemo {
   open = false;

--- a/projects/website/src/app/documentation/demos/popover/popover-positions.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover-positions.demo.html
@@ -17,7 +17,7 @@
   </div>
 
   <div class="clr-example popover-positions-area">
-    <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+    <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverOrigin>
       <cds-icon shape="home"></cds-icon> {{ selectedPosition }}
     </button>
     <div

--- a/projects/website/src/app/documentation/demos/popover/popover-positions.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover-positions.demo.html
@@ -1,0 +1,46 @@
+<!--
+  ~ Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+  ~ The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+<div>
+  <div class="popover-positions-controls">
+    <clr-select-container>
+      <label>Select a position:</label>
+      <select clrSelect name="position" [(ngModel)]="selectedPosition">
+        @for (pos of positions; track pos) {
+        <option [value]="pos">{{ pos }}</option>
+        }
+      </select>
+    </clr-select-container>
+  </div>
+
+  <div class="clr-example popover-positions-area">
+    <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+      <cds-icon shape="home"></cds-icon> {{ selectedPosition }}
+    </button>
+    <div
+      class="popover-panel"
+      role="dialog"
+      cdkTrapFocus
+      *clrPopoverContent="open; at: selectedPosition; outsideClickToClose: true; scrollToClose: false"
+    >
+      <h4 cds-text="section">Position: {{ selectedPosition }}</h4>
+      <p cds-text="body" class="clr-mt-8px">
+        The overlay is positioned at
+        <code cds-text="code">{{ selectedPosition }}</code>
+        relative to the anchor button.
+      </p>
+      <button class="btn btn-sm btn-outline clr-mt-8px" clrPopoverCloseButton>
+        Close <cds-icon shape="times"></cds-icon>
+      </button>
+    </div>
+  </div>
+
+  <app-stackblitz-example
+    name="popover positions"
+    [componentTemplate]="html"
+    [componentClass]="code"
+  ></app-stackblitz-example>
+</div>

--- a/projects/website/src/app/documentation/demos/popover/popover-positions.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover-positions.ts
@@ -12,15 +12,15 @@ import {
   ClrFormsModule,
   ClrIcon,
   ClrPopoverContent,
+  ClrPopoverModuleNext,
   ClrPopoverPosition,
   ClrPopoverService,
-  ÇlrClrPopoverModuleNext,
 } from '@clr/angular';
 
 import { StackblitzExampleComponent } from '../../../shared/stackblitz-example/stackblitz-example.component';
 
 const HTML = `
-<button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>Open Popover</button>
+<button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverOrigin>Open Popover</button>
 <div role="dialog" cdkTrapFocus *clrPopoverContent="open; at: position; outsideClickToClose: true">
   <h4 style="margin-top: 0">Popover Content</h4>
   <p>
@@ -33,13 +33,13 @@ const HTML = `
 
 const CODE = `
 import { Component } from '@angular/core';
-import { ClrPopoverPosition, ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+import { ClrPopoverPosition, ClrPopoverService, ClrPopoverModuleNext } from '@clr/angular';
 
 @Component({
   selector: 'app-popover-positions',
   templateUrl: './popover-positions.component.html',
   providers: [ClrPopoverService],
-  imports: [ÇlrClrPopoverModuleNext],
+  imports: [ClrPopoverModuleNext],
 })
 export class PopoverPositionsComponent {
   open = false;
@@ -59,7 +59,7 @@ export class PopoverPositionsComponent {
     ClrCommonFormsModule,
     ClrFormsModule,
     FormsModule,
-    ÇlrClrPopoverModuleNext,
+    ClrPopoverModuleNext,
     StackblitzExampleComponent,
   ],
 })

--- a/projects/website/src/app/documentation/demos/popover/popover-positions.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover-positions.ts
@@ -1,0 +1,73 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, ViewEncapsulation } from '@angular/core';
+import { FormsModule } from '@angular/forms';
+import {
+  ClrCommonFormsModule,
+  ClrFormsModule,
+  ClrIcon,
+  ClrPopoverContent,
+  ClrPopoverPosition,
+  ClrPopoverService,
+  ÇlrClrPopoverModuleNext,
+} from '@clr/angular';
+
+import { StackblitzExampleComponent } from '../../../shared/stackblitz-example/stackblitz-example.component';
+
+const HTML = `
+<button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>Open Popover</button>
+<div role="dialog" cdkTrapFocus *clrPopoverContent="open; at: position; outsideClickToClose: true">
+  <h4 style="margin-top: 0">Popover Content</h4>
+  <p>
+    Positioned at
+    <code>{{ position }}</code>
+  </p>
+  <button class="btn btn-sm btn-outline" clrPopoverCloseButton>Close</button>
+</div>
+`;
+
+const CODE = `
+import { Component } from '@angular/core';
+import { ClrPopoverPosition, ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+
+@Component({
+  selector: 'app-popover-positions',
+  templateUrl: './popover-positions.component.html',
+  providers: [ClrPopoverService],
+  imports: [ÇlrClrPopoverModuleNext],
+})
+export class PopoverPositionsComponent {
+  open = false;
+  position = ClrPopoverPosition.BOTTOM_LEFT;
+}
+`;
+
+@Component({
+  selector: 'clr-popover-positions-demo',
+  templateUrl: './popover-positions.demo.html',
+  styleUrl: './popover.demo.scss',
+  encapsulation: ViewEncapsulation.None,
+  providers: [ClrPopoverService],
+  imports: [
+    ClrPopoverContent,
+    ClrIcon,
+    ClrCommonFormsModule,
+    ClrFormsModule,
+    FormsModule,
+    ÇlrClrPopoverModuleNext,
+    StackblitzExampleComponent,
+  ],
+})
+export class PopoverPositionsDemo {
+  open = false;
+  selectedPosition = ClrPopoverPosition.BOTTOM_LEFT;
+  positions = Object.values(ClrPopoverPosition);
+
+  html = HTML;
+  code = CODE;
+}

--- a/projects/website/src/app/documentation/demos/popover/popover-scroll-to-close.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover-scroll-to-close.demo.html
@@ -13,7 +13,7 @@
     <div class="popover-scroll-content">
       <p cds-text="body">Scroll down inside this container while the popover is open.</p>
       <div class="clr-mt-16px" style="display: flex; justify-content: center">
-        <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+        <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverOrigin>
           <cds-icon shape="home"></cds-icon> Open Popover
         </button>
         <div

--- a/projects/website/src/app/documentation/demos/popover/popover-scroll-to-close.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover-scroll-to-close.demo.html
@@ -1,0 +1,43 @@
+<!--
+  ~ Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+  ~ The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+<div>
+  <p cds-text="body" class="clr-mt-16px">
+    Open the popover and then scroll inside the container below. The popover closes automatically because
+    <code cds-text="code">scrollToClose</code> is set to <code cds-text="code">true</code>.
+  </p>
+  <div class="clr-example popover-scroll-container">
+    <div class="popover-scroll-content">
+      <p cds-text="body">Scroll down inside this container while the popover is open.</p>
+      <div class="clr-mt-16px" style="display: flex; justify-content: center">
+        <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>
+          <cds-icon shape="home"></cds-icon> Open Popover
+        </button>
+        <div
+          class="popover-panel"
+          role="dialog"
+          cdkTrapFocus
+          *clrPopoverContent="open; at: 'bottom-left'; outsideClickToClose: true; scrollToClose: true"
+        >
+          <h4 cds-text="section" style="margin-top: 0">Scroll to Close</h4>
+          <p cds-text="body" class="clr-mt-8px">
+            This popover will close when you scroll. Try scrolling the container below.
+          </p>
+          <button class="btn btn-sm btn-outline clr-mt-8px" clrPopoverCloseButton>
+            Close <cds-icon shape="times"></cds-icon>
+          </button>
+        </div>
+      </div>
+      <div class="popover-scroll-spacer"></div>
+    </div>
+  </div>
+
+  <app-stackblitz-example
+    name="popover scroll to close"
+    [componentTemplate]="html"
+    [componentClass]="code"
+  ></app-stackblitz-example>
+</div>

--- a/projects/website/src/app/documentation/demos/popover/popover-scroll-to-close.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover-scroll-to-close.ts
@@ -6,7 +6,7 @@
  */
 
 import { Component, ViewEncapsulation } from '@angular/core';
-import { ClrIcon, ClrPopoverContent, ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+import { ClrIcon, ClrPopoverContent, ClrPopoverModuleNext, ClrPopoverService } from '@clr/angular';
 
 import { StackblitzExampleComponent } from '../../../shared/stackblitz-example/stackblitz-example.component';
 
@@ -22,7 +22,7 @@ const HTML = `
 >
   <p>Scroll down inside this container while the popover is open.</p>
   <div style="margin-top: 16px; display: flex; justify-content: center">
-    <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>Open Popover</button>
+    <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverOrigin>Open Popover</button>
     <div
       role="dialog"
       cdkTrapFocus
@@ -39,13 +39,13 @@ const HTML = `
 
 const CODE = `
 import { Component } from '@angular/core';
-import { ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+import { ClrPopoverService, ClrPopoverModuleNext } from '@clr/angular';
 
 @Component({
   selector: 'app-popover-scroll',
   templateUrl: './popover-scroll.component.html',
   providers: [ClrPopoverService],
-  imports: [ÇlrClrPopoverModuleNext],
+  imports: [ClrPopoverModuleNext],
 })
 export class PopoverScrollComponent {
   open = false;
@@ -58,7 +58,7 @@ export class PopoverScrollComponent {
   styleUrl: './popover.demo.scss',
   encapsulation: ViewEncapsulation.None,
   providers: [ClrPopoverService],
-  imports: [ClrPopoverContent, ClrIcon, ÇlrClrPopoverModuleNext, StackblitzExampleComponent],
+  imports: [ClrPopoverContent, ClrIcon, ClrPopoverModuleNext, StackblitzExampleComponent],
 })
 export class PopoverScrollToCloseDemo {
   open = false;

--- a/projects/website/src/app/documentation/demos/popover/popover-scroll-to-close.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover-scroll-to-close.ts
@@ -1,0 +1,68 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, ViewEncapsulation } from '@angular/core';
+import { ClrIcon, ClrPopoverContent, ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+
+import { StackblitzExampleComponent } from '../../../shared/stackblitz-example/stackblitz-example.component';
+
+const HTML = `
+<div
+  style="
+    height: 160px;
+    overflow-y: auto;
+    border: 1px solid var(--cds-alias-object-border-color);
+    border-radius: 4px;
+    padding: 16px;
+  "
+>
+  <p>Scroll down inside this container while the popover is open.</p>
+  <div style="margin-top: 16px; display: flex; justify-content: center">
+    <button class="btn btn-outline" clrPopoverOpenCloseButton clrPopoverAnchor>Open Popover</button>
+    <div
+      role="dialog"
+      cdkTrapFocus
+      *clrPopoverContent="open; at: 'bottom-left'; outsideClickToClose: true; scrollToClose: true"
+    >
+      <h4 style="margin-top: 0">Scroll to Close</h4>
+      <p>This popover closes when you scroll.</p>
+      <button class="btn btn-sm btn-outline" clrPopoverCloseButton>Close</button>
+    </div>
+  </div>
+  <div style="height: 300px"></div>
+</div>
+`;
+
+const CODE = `
+import { Component } from '@angular/core';
+import { ClrPopoverService, ÇlrClrPopoverModuleNext } from '@clr/angular';
+
+@Component({
+  selector: 'app-popover-scroll',
+  templateUrl: './popover-scroll.component.html',
+  providers: [ClrPopoverService],
+  imports: [ÇlrClrPopoverModuleNext],
+})
+export class PopoverScrollComponent {
+  open = false;
+}
+`;
+
+@Component({
+  selector: 'clr-popover-scroll-to-close-demo',
+  templateUrl: './popover-scroll-to-close.demo.html',
+  styleUrl: './popover.demo.scss',
+  encapsulation: ViewEncapsulation.None,
+  providers: [ClrPopoverService],
+  imports: [ClrPopoverContent, ClrIcon, ÇlrClrPopoverModuleNext, StackblitzExampleComponent],
+})
+export class PopoverScrollToCloseDemo {
+  open = false;
+
+  html = HTML;
+  code = CODE;
+}

--- a/projects/website/src/app/documentation/demos/popover/popover.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover.demo.html
@@ -70,15 +70,15 @@
 
     <h3 id="point-origin" class="clr-mt-32px" cds-text="section">Point-based Origin (Context Menus)</h3>
     <p class="clr-mt-16px" cds-text="body">
-      Popovers can also be opened at an arbitrary <code cds-text="code">{ x, y }</code> screen coordinate instead of an
-      element. This is useful for context menus triggered by right-click, where the overlay should appear at the cursor
-      position rather than anchored to a specific element.
+      Popovers can also be opened at an arbitrary <code cds-text="code">&#123; x, y &#125;</code> screen coordinate
+      instead of an element. This is useful for context menus triggered by right-click, where the overlay should appear
+      at the cursor position rather than anchored to a specific element.
     </p>
     <p class="clr-mt-16px" cds-text="body">
-      Call <code cds-text="code">openAtPoint({ x, y })</code> on the <code cds-text="code">ClrPopoverService</code> to
-      open the popover at a specific point. Point-based origins automatically close on any scroll event and delay
-      outside-click detection by 500 ms to prevent the initial right-click mouseup from immediately dismissing the
-      popover.
+      Call <code cds-text="code">openAtPoint(&#123; x, y &#125;)</code> on the
+      <code cds-text="code">ClrPopoverService</code> to open the popover at a specific point. Point-based origins
+      automatically close on any scroll event and delay outside-click detection by 500 ms to prevent the initial
+      right-click mouseup from immediately dismissing the popover.
     </p>
 
     <h2 id="behavior" class="clr-mt-48px" cds-text="title">Behavior</h2>
@@ -276,7 +276,7 @@
             The positioning origin for the overlay. Can be an <code cds-text="code">ElementRef</code> (set automatically
             by <code cds-text="code">[clrPopoverOrigin]</code>) or a <code cds-text="code">ClrPopoverPoint</code> (<code
               cds-text="code"
-              >{ x, y }</code
+              >&#123; x, y &#125;</code
             >) for point-based positioning.
           </td>
         </tr>
@@ -298,7 +298,7 @@
           </td>
           <td class="left hidden-xs-down">ClrPopoverPoint | null</td>
           <td class="left">
-            Returns the origin as a <code cds-text="code">{ x, y }</code> point when point-based, or
+            Returns the origin as a <code cds-text="code">&#123; x, y &#125;</code> point when point-based, or
             <code cds-text="code">null</code> for element-based origins.
           </td>
         </tr>
@@ -320,9 +320,9 @@
           </td>
           <td class="left hidden-xs-down">void</td>
           <td class="left">
-            Opens the popover at a specific <code cds-text="code">{ x, y }</code> screen coordinate. Sets the origin to
-            the given point and opens the overlay. If the popover is already open, it closes first and reopens at the
-            new point.
+            Opens the popover at a specific <code cds-text="code">&#123; x, y &#125;</code> screen coordinate. Sets the
+            origin to the given point and opens the overlay. If the popover is already open, it closes first and reopens
+            at the new point.
           </td>
         </tr>
         <tr>
@@ -341,8 +341,9 @@
 
     <h3 class="clr-mt-32px" cds-text="section"><code cds-text="code">ClrPopoverPoint</code> &mdash; interface</h3>
     <p class="clr-mt-16px" cds-text="body">
-      A simple interface representing a screen coordinate: <code cds-text="code">{ x: number; y: number }</code>. Used
-      with <code cds-text="code">openAtPoint()</code> to position the popover at an arbitrary point.
+      A simple interface representing a screen coordinate:
+      <code cds-text="code">&#123; x: number; y: number &#125;</code>. Used with
+      <code cds-text="code">openAtPoint()</code> to position the popover at an arbitrary point.
     </p>
 
     <h3 class="clr-mt-32px" cds-text="section">
@@ -411,7 +412,7 @@
           <td class="left">
             Overrides the positioning origin for this content. Accepts an
             <code cds-text="code">ElementRef</code>, an <code cds-text="code">HTMLElement</code>, or a
-            <code cds-text="code">{ x, y }</code> point. When set, this takes precedence over the
+            <code cds-text="code">&#123; x, y &#125;</code> point. When set, this takes precedence over the
             <code cds-text="code">[clrPopoverOrigin]</code> directive.
           </td>
         </tr>

--- a/projects/website/src/app/documentation/demos/popover/popover.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover.demo.html
@@ -1,0 +1,373 @@
+<!--
+  ~ Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+  ~ The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+<app-doc-tabs>
+  <app-doc-tab tab="overview">
+    <p class="component-summary" id="popover-header">
+      A popover is a temporary overlay anchored to an element on the page. It displays supplementary content such as
+      details, confirmations, or custom controls without navigating away from the current context.
+    </p>
+
+    <h2 id="usage" class="clr-mt-48px" cds-text="title">Usage</h2>
+
+    <p class="clr-mt-16px" cds-text="body">
+      The Popover utility is the low-level foundation behind Clarity's overlay components. It is built on the
+      <a href="https://material.angular.dev/cdk/overlay/overview" target="_blank">Angular CDK Overlay</a>, which handles
+      rendering, positioning, and z-indexing. Use the popover utility directly when you need custom overlay behavior
+      that doesn't fit the standard components:
+    </p>
+    <ul class="list" cds-text="body" cds-layout="m-t:md m-l:lg">
+      <li>
+        A <b>confirmation dialog</b> anchored to a delete button, asking the user to confirm an action before it
+        proceeds.
+      </li>
+      <li>A <b>detail panel</b> showing extra metadata when the user clicks a table row or list item.</li>
+      <li>A <b>custom picker</b> such as a color or icon selector attached to an input field.</li>
+    </ul>
+    <p class="clr-mt-16px" cds-text="body">
+      For common patterns, prefer the specialized components built on top of popover:
+    </p>
+    <table class="table clr-mt-16px">
+      <thead>
+        <tr>
+          <th class="left">Scenario</th>
+          <th class="left">Recommended</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="left">Action menu with items, headers, dividers</td>
+          <td class="left">Use <b>Dropdown</b></td>
+        </tr>
+        <tr>
+          <td class="left">Contextual help with an arrow and close button</td>
+          <td class="left">Use <b>Signpost</b></td>
+        </tr>
+        <tr>
+          <td class="left">Brief, non-interactive description on hover</td>
+          <td class="left">Use <b>Tooltip</b></td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h2 id="placement" class="clr-mt-48px" cds-text="title">Placement</h2>
+
+    <p class="clr-mt-16px" cds-text="body">
+      The popover is positioned relative to its anchor element using a connected position strategy. You choose a
+      preferred position &mdash; for example, below and to the left of the anchor. If there isn't enough room in the
+      viewport for that position, the overlay automatically tries a set of fallback positions until it finds one that
+      fits.
+    </p>
+    <p class="clr-mt-16px" cds-text="body">
+      Twelve positions are available, covering every combination of direction (top, bottom, left, right) and alignment
+      (start, middle, end). You can also provide custom fallback positions using CDK's
+      <code cds-text="code">ConnectedPosition</code> interface for full control over how the overlay repositions itself.
+    </p>
+
+    <h2 id="behavior" class="clr-mt-48px" cds-text="title">Behavior</h2>
+
+    <p class="clr-mt-16px" cds-text="body">
+      Clicking the trigger element opens the popover. It stays visible until the user explicitly closes it or interacts
+      elsewhere:
+    </p>
+    <ul class="list" cds-text="body" cds-layout="m-t:md m-l:lg">
+      <li>Clicking the trigger again toggles the popover closed.</li>
+      <li>Clicking outside the overlay dismisses it (configurable).</li>
+      <li>Pressing <b>Escape</b> closes the popover.</li>
+    </ul>
+
+    <h3 id="scroll-behavior" class="clr-mt-32px" cds-text="section">Scroll Behavior</h3>
+    <p class="clr-mt-16px" cds-text="body">
+      Popovers support two scroll strategies, inspired by the
+      <a href="https://material.angular.dev/cdk/overlay/overview" target="_blank">CDK Overlay scroll strategies</a>:
+    </p>
+    <ul class="list" cds-text="body" cds-layout="m-t:md m-l:lg">
+      <li>
+        <b>Reposition</b> (default) &mdash; the overlay follows the anchor as the page scrolls, staying aligned with it.
+        This is appropriate when the popover should remain visible during scrolling.
+      </li>
+      <li>
+        <b>Close on scroll</b> &mdash; the overlay is dismissed as soon as any ancestor container scrolls. This is
+        appropriate for popovers attached to items in scrollable lists or tables, where the anchor may scroll out of
+        view.
+      </li>
+    </ul>
+
+    <h3 id="focus" class="clr-mt-32px" cds-text="section">Focus Management</h3>
+    <p class="clr-mt-16px" cds-text="body">
+      When the popover closes, focus returns to the trigger element to maintain keyboard accessibility. While the
+      popover is open, focus should be trapped inside the overlay so keyboard users cannot tab into the page behind it.
+    </p>
+
+    <h2 id="content" class="clr-mt-48px" cds-text="title">Content</h2>
+
+    <ul class="list" cds-text="body" cds-layout="m-t:md m-l:lg">
+      <li>Keep popover content concise. If you need a full page of content, consider a modal or side panel instead.</li>
+      <li>Include a close button inside the overlay so keyboard and assistive-technology users can dismiss it.</li>
+      <li>Popovers accept any HTML content &mdash; text, forms, images, or other components.</li>
+      <li>
+        Avoid nesting popovers inside other popovers. If the content requires deeper navigation, use a different
+        pattern.
+      </li>
+    </ul>
+
+    <h2 id="accessibility" class="clr-mt-48px" cds-text="title">Accessibility</h2>
+
+    <ul class="list" cds-text="body" cds-layout="m-t:md m-l:lg">
+      <li>
+        Give the overlay a <code cds-text="code">role="dialog"</code> attribute so screen readers announce it as a
+        dialog.
+      </li>
+      <li>
+        Use <code cds-text="code">cdkTrapFocus</code> on the content container to trap keyboard navigation within the
+        overlay while it is open.
+      </li>
+      <li>Ensure the trigger element is a focusable, interactive element (typically a button).</li>
+    </ul>
+  </app-doc-tab>
+
+  <app-doc-tab tab="code">
+    <h2 id="setup" cds-text="title" class="clr-mt-48px">Setup</h2>
+
+    <p cds-text="body" class="clr-mt-16px">
+      The popover utility is built on the
+      <a href="https://material.angular.dev/cdk/overlay/overview" target="_blank">Angular CDK Overlay</a>. It abstracts
+      the CDK into a set of directives coordinated by a transient service. To use it in your component:
+    </p>
+    <ol class="list" cds-text="body" cds-layout="m-t:md m-l:lg">
+      <li>
+        <b>Import the module:</b> Add <code cds-text="code">ClrPopoverModuleNext</code> to your component's
+        <code cds-text="code">imports</code> array. This provides all popover directives (<code cds-text="code"
+          >[clrPopoverAnchor]</code
+        >, <code cds-text="code">[clrPopoverOpenCloseButton]</code>,
+        <code cds-text="code">[clrPopoverCloseButton]</code>, and <code cds-text="code">*clrPopoverContent</code>).
+      </li>
+      <li>
+        <b>Provide the service:</b> Add <code cds-text="code">ClrPopoverService</code> to your component's
+        <code cds-text="code">providers</code> array. Each popover needs its own service instance &mdash; if you have
+        multiple popovers, each host component must provide its own.
+      </li>
+      <li>
+        <b>Add a boolean property</b> (e.g. <code cds-text="code">open = false</code>) to track the popover state in
+        your template.
+      </li>
+    </ol>
+
+    <h2 id="examples" cds-text="title" class="clr-mt-48px">Examples</h2>
+
+    <h3 data-toc-item id="basic-popover" cds-text="section" class="clr-mt-32px">Basic Popover</h3>
+    <p cds-text="body" class="clr-mt-16px">
+      A minimal popover with a toggle button, content panel, and close button. Click the button to open the popover
+      below the anchor.
+    </p>
+
+    <clr-popover-basic-demo></clr-popover-basic-demo>
+
+    <h3 data-toc-item id="popover-positions" cds-text="section" class="clr-mt-32px">Positions</h3>
+    <p cds-text="body" class="clr-mt-16px">
+      Control where the overlay appears relative to the anchor using the <code cds-text="code">at</code> input. Select a
+      position below to see the popover open in that direction.
+    </p>
+
+    <clr-popover-positions-demo></clr-popover-positions-demo>
+
+    <h3 data-toc-item id="fallback-positions" cds-text="section" class="clr-mt-32px">Fallback Positions</h3>
+    <p cds-text="body" class="clr-mt-16px">
+      Use the <code cds-text="code">availablePositions</code> input to provide custom fallback positions. Each fallback
+      is a CDK <code cds-text="code">ConnectedPosition</code> object that defines how the overlay attaches to the
+      anchor. When the preferred position doesn't fit within the viewport, the overlay tries each fallback in order
+      until one fits. See the
+      <a href="https://material.angular.dev/cdk/overlay/overview" target="_blank"
+        >CDK FlexibleConnectedPositionStrategy</a
+      >
+      documentation for details on the <code cds-text="code">ConnectedPosition</code> interface.
+    </p>
+
+    <clr-popover-fallback-positions-demo></clr-popover-fallback-positions-demo>
+
+    <h3 data-toc-item id="scroll-to-close" cds-text="section" class="clr-mt-32px">Scroll to Close</h3>
+    <p cds-text="body" class="clr-mt-16px">
+      By default, scrolling repositions the overlay to keep it aligned with the anchor. Set
+      <code cds-text="code">scrollToClose</code> to <code cds-text="code">true</code> to dismiss the popover instead.
+      This is useful for popovers attached to items in scrollable lists or tables where the anchor may scroll out of
+      view.
+    </p>
+
+    <clr-popover-scroll-to-close-demo></clr-popover-scroll-to-close-demo>
+  </app-doc-tab>
+
+  <app-doc-tab tab="api">
+    <h2 id="api" class="clr-mt-48px" cds-text="title">API Reference</h2>
+
+    <p class="clr-mt-16px" cds-text="body">
+      The popover utility builds on the
+      <a href="https://material.angular.dev/cdk/overlay/api" target="_blank">Angular CDK Overlay</a>. The types
+      <code cds-text="code">ConnectedPosition</code>, <code cds-text="code">FlexibleConnectedPositionStrategy</code>,
+      and <code cds-text="code">OverlayRef</code> referenced below are from the
+      <code cds-text="code">&#64;angular/cdk/overlay</code> package.
+    </p>
+
+    <h3 class="clr-mt-32px" cds-text="section"><code cds-text="code">ClrPopoverService</code> &mdash; service</h3>
+    <p class="clr-mt-16px" cds-text="body">
+      A transient service provided at the component level. Each popover instance gets its own service to manage state
+      independently.
+    </p>
+    <table class="table clr-mt-16px">
+      <thead>
+        <tr>
+          <th class="left">Property / Method</th>
+          <th class="left hidden-xs-down">Type</th>
+          <th class="left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">open</b>
+            <div class="hidden-sm-up">Type: boolean</div>
+          </td>
+          <td class="left hidden-xs-down">boolean</td>
+          <td class="left">Gets or sets the open/closed state of the popover.</td>
+        </tr>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">openChange</b>
+            <div class="hidden-sm-up">Type: Observable&lt;boolean&gt;</div>
+          </td>
+          <td class="left hidden-xs-down">Observable&lt;boolean&gt;</td>
+          <td class="left">Emits whenever the open state changes.</td>
+        </tr>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">toggleWithEvent(event)</b>
+            <div class="hidden-sm-up">Type: Method</div>
+          </td>
+          <td class="left hidden-xs-down">void</td>
+          <td class="left">
+            Toggles the open state and stores the triggering event. Used internally by
+            <code cds-text="code">[clrPopoverOpenCloseButton]</code>.
+          </td>
+        </tr>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">focusAnchor()</b>
+            <div class="hidden-sm-up">Type: Method</div>
+          </td>
+          <td class="left hidden-xs-down">void</td>
+          <td class="left">Returns focus to the anchor element. Called automatically when the popover closes.</td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 class="clr-mt-32px" cds-text="section">
+      <code cds-text="code">*clrPopoverContent</code> &mdash; structural directive
+    </h3>
+    <p class="clr-mt-16px" cds-text="body">
+      Creates and manages the CDK overlay. The content is only present in the DOM when the popover is open. Under the
+      hood, it uses a <code cds-text="code">FlexibleConnectedPositionStrategy</code> and a
+      <code cds-text="code">DomPortal</code> to attach content to the overlay container.
+    </p>
+    <table class="table clr-mt-16px">
+      <thead>
+        <tr>
+          <th class="left">Input</th>
+          <th class="left hidden-xs-down">Type</th>
+          <th class="left hidden-xs-down">Default</th>
+          <th class="left">Description</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">clrPopoverContent</b>
+            <div class="hidden-sm-up">Type: boolean</div>
+            <div class="hidden-sm-up">Default: false</div>
+          </td>
+          <td class="left hidden-xs-down">boolean</td>
+          <td class="left hidden-xs-down">false</td>
+          <td class="left">Controls the open/closed state of the overlay.</td>
+        </tr>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">at</b>
+            <div class="hidden-sm-up">Type: ClrPopoverPosition</div>
+            <div class="hidden-sm-up">Default: bottom-left</div>
+          </td>
+          <td class="left hidden-xs-down">ClrPopoverPosition | ConnectedPosition</td>
+          <td class="left hidden-xs-down">bottom-left</td>
+          <td class="left">
+            Preferred position relative to the anchor. Accepts a
+            <code cds-text="code">ClrPopoverPosition</code> string (e.g. <code cds-text="code">'top-right'</code>) or a
+            CDK <code cds-text="code">ConnectedPosition</code> object for custom alignment.
+          </td>
+        </tr>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">availablePositions</b>
+            <div class="hidden-sm-up">Type: ConnectedPosition[]</div>
+            <div class="hidden-sm-up">Default: auto</div>
+          </td>
+          <td class="left hidden-xs-down">ConnectedPosition[]</td>
+          <td class="left hidden-xs-down">auto</td>
+          <td class="left">
+            Fallback positions tried in order when the preferred position doesn't fit the viewport. If not set, a
+            default set of fallbacks is generated based on the popover type.
+          </td>
+        </tr>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">outsideClickToClose</b>
+            <div class="hidden-sm-up">Type: boolean</div>
+            <div class="hidden-sm-up">Default: true</div>
+          </td>
+          <td class="left hidden-xs-down">boolean</td>
+          <td class="left hidden-xs-down">true</td>
+          <td class="left">Whether clicking outside the overlay closes it.</td>
+        </tr>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">scrollToClose</b>
+            <div class="hidden-sm-up">Type: boolean</div>
+            <div class="hidden-sm-up">Default: false</div>
+          </td>
+          <td class="left hidden-xs-down">boolean</td>
+          <td class="left hidden-xs-down">false</td>
+          <td class="left">
+            When <code cds-text="code">true</code>, scrolling any ancestor closes the popover (close strategy). When
+            <code cds-text="code">false</code>, scrolling repositions the overlay to stay aligned with the anchor
+            (reposition strategy).
+          </td>
+        </tr>
+      </tbody>
+    </table>
+
+    <h3 class="clr-mt-32px" cds-text="section">
+      <code cds-text="code">[clrPopoverAnchor]</code> &mdash; attribute directive
+    </h3>
+    <p class="clr-mt-16px" cds-text="body">
+      Marks the element as the positioning reference point for the overlay. Registers the element's
+      <code cds-text="code">ElementRef</code> with the <code cds-text="code">ClrPopoverService</code>, which the CDK
+      <code cds-text="code">FlexibleConnectedPositionStrategy</code> uses as the origin for positioning calculations.
+    </p>
+
+    <h3 class="clr-mt-32px" cds-text="section">
+      <code cds-text="code">[clrPopoverOpenCloseButton]</code> &mdash; attribute directive
+    </h3>
+    <p class="clr-mt-16px" cds-text="body">
+      Place on a button to toggle the popover open and closed. Calls
+      <code cds-text="code">toggleWithEvent()</code> on click and handles keyboard events (Enter, Space) for
+      accessibility.
+    </p>
+
+    <h3 class="clr-mt-32px" cds-text="section">
+      <code cds-text="code">[clrPopoverCloseButton]</code> &mdash; attribute directive
+    </h3>
+    <p class="clr-mt-16px" cds-text="body">
+      Place inside the overlay content to provide a close action. Closes the popover and restores focus to the anchor
+      element. Only valid inside a <code cds-text="code">*clrPopoverContent</code> container.
+    </p>
+  </app-doc-tab>
+</app-doc-tabs>

--- a/projects/website/src/app/documentation/demos/popover/popover.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover.demo.html
@@ -361,12 +361,19 @@
       <code cds-text="code">toggleWithEvent()</code> on click and handles keyboard events (Enter, Space) for
       accessibility.
     </p>
+    <p class="clr-mt-8px" cds-text="body">
+      <strong>Note:</strong> <code cds-text="code">[clrPopoverAnchor]</code> and
+      <code cds-text="code">[clrPopoverOpenCloseButton]</code> are independent directives and do not have to be on the
+      same element. However, placing them together on the trigger button is the recommended pattern — it ensures the
+      overlay positions relative to the same element the user clicked. Separating them across different elements is
+      possible but requires careful consideration of positioning and focus behavior.
+    </p>
 
     <h3 class="clr-mt-32px" cds-text="section">
       <code cds-text="code">[clrPopoverCloseButton]</code> &mdash; attribute directive
     </h3>
     <p class="clr-mt-16px" cds-text="body">
-      Place inside the overlay content to provide a close action. Closes the popover and restores focus to the anchor
+      Place inside the overlay content to provide a close action. Closes the popover and restores focus to the origin
       element. Only valid inside a <code cds-text="code">*clrPopoverContent</code> container.
     </p>
   </app-doc-tab>

--- a/projects/website/src/app/documentation/demos/popover/popover.demo.html
+++ b/projects/website/src/app/documentation/demos/popover/popover.demo.html
@@ -55,9 +55,10 @@
 
     <h2 id="placement" class="clr-mt-48px" cds-text="title">Placement</h2>
 
+    <h3 id="element-origin" class="clr-mt-32px" cds-text="section">Element Origin</h3>
     <p class="clr-mt-16px" cds-text="body">
-      The popover is positioned relative to its anchor element using a connected position strategy. You choose a
-      preferred position &mdash; for example, below and to the left of the anchor. If there isn't enough room in the
+      The popover is positioned relative to its origin element using a connected position strategy. You choose a
+      preferred position &mdash; for example, below and to the left of the origin. If there isn't enough room in the
       viewport for that position, the overlay automatically tries a set of fallback positions until it finds one that
       fits.
     </p>
@@ -65,6 +66,19 @@
       Twelve positions are available, covering every combination of direction (top, bottom, left, right) and alignment
       (start, middle, end). You can also provide custom fallback positions using CDK's
       <code cds-text="code">ConnectedPosition</code> interface for full control over how the overlay repositions itself.
+    </p>
+
+    <h3 id="point-origin" class="clr-mt-32px" cds-text="section">Point-based Origin (Context Menus)</h3>
+    <p class="clr-mt-16px" cds-text="body">
+      Popovers can also be opened at an arbitrary <code cds-text="code">{ x, y }</code> screen coordinate instead of an
+      element. This is useful for context menus triggered by right-click, where the overlay should appear at the cursor
+      position rather than anchored to a specific element.
+    </p>
+    <p class="clr-mt-16px" cds-text="body">
+      Call <code cds-text="code">openAtPoint({ x, y })</code> on the <code cds-text="code">ClrPopoverService</code> to
+      open the popover at a specific point. Point-based origins automatically close on any scroll event and delay
+      outside-click detection by 500 ms to prevent the initial right-click mouseup from immediately dismissing the
+      popover.
     </p>
 
     <h2 id="behavior" class="clr-mt-48px" cds-text="title">Behavior</h2>
@@ -98,8 +112,9 @@
 
     <h3 id="focus" class="clr-mt-32px" cds-text="section">Focus Management</h3>
     <p class="clr-mt-16px" cds-text="body">
-      When the popover closes, focus returns to the trigger element to maintain keyboard accessibility. While the
-      popover is open, focus should be trapped inside the overlay so keyboard users cannot tab into the page behind it.
+      When the popover closes, focus returns to the origin element to maintain keyboard accessibility. While the popover
+      is open, focus should be trapped inside the overlay so keyboard users cannot tab into the page behind it. For
+      point-based origins (no element), focus restoration is skipped since there is no trigger element to return to.
     </p>
 
     <h2 id="content" class="clr-mt-48px" cds-text="title">Content</h2>
@@ -141,7 +156,7 @@
       <li>
         <b>Import the module:</b> Add <code cds-text="code">ClrPopoverModuleNext</code> to your component's
         <code cds-text="code">imports</code> array. This provides all popover directives (<code cds-text="code"
-          >[clrPopoverAnchor]</code
+          >[clrPopoverOrigin]</code
         >, <code cds-text="code">[clrPopoverOpenCloseButton]</code>,
         <code cds-text="code">[clrPopoverCloseButton]</code>, and <code cds-text="code">*clrPopoverContent</code>).
       </li>
@@ -197,6 +212,16 @@
     </p>
 
     <clr-popover-scroll-to-close-demo></clr-popover-scroll-to-close-demo>
+
+    <h3 data-toc-item id="context-menu" cds-text="section" class="clr-mt-32px">Context Menu (Point-based Origin)</h3>
+    <p cds-text="body" class="clr-mt-16px">
+      Open a popover at an arbitrary screen coordinate using
+      <code cds-text="code">ClrPopoverService.openAtPoint()</code>. Right-click inside the dashed area to see the
+      popover appear at the cursor position. No <code cds-text="code">[clrPopoverOrigin]</code> directive is needed
+      &mdash; the origin is set programmatically to the click coordinates.
+    </p>
+
+    <clr-popover-context-menu-demo></clr-popover-context-menu-demo>
   </app-doc-tab>
 
   <app-doc-tab tab="api">
@@ -205,8 +230,9 @@
     <p class="clr-mt-16px" cds-text="body">
       The popover utility builds on the
       <a href="https://material.angular.dev/cdk/overlay/api" target="_blank">Angular CDK Overlay</a>. The types
-      <code cds-text="code">ConnectedPosition</code>, <code cds-text="code">FlexibleConnectedPositionStrategy</code>,
-      and <code cds-text="code">OverlayRef</code> referenced below are from the
+      <code cds-text="code">ConnectedPosition</code>,
+      <code cds-text="code">FlexibleConnectedPositionStrategyOrigin</code>, and
+      <code cds-text="code">OverlayRef</code> referenced below are from the
       <code cds-text="code">&#64;angular/cdk/overlay</code> package.
     </p>
 
@@ -242,6 +268,42 @@
         </tr>
         <tr>
           <td class="left">
+            <b cds-text="medium">origin</b>
+            <div class="hidden-sm-up">Type: FlexibleConnectedPositionStrategyOrigin</div>
+          </td>
+          <td class="left hidden-xs-down">FlexibleConnectedPositionStrategyOrigin</td>
+          <td class="left">
+            The positioning origin for the overlay. Can be an <code cds-text="code">ElementRef</code> (set automatically
+            by <code cds-text="code">[clrPopoverOrigin]</code>) or a <code cds-text="code">ClrPopoverPoint</code> (<code
+              cds-text="code"
+              >{ x, y }</code
+            >) for point-based positioning.
+          </td>
+        </tr>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">originElement</b>
+            <div class="hidden-sm-up">Type: ElementRef | null</div>
+          </td>
+          <td class="left hidden-xs-down">ElementRef&lt;HTMLElement&gt; | null</td>
+          <td class="left">
+            Returns the origin as an <code cds-text="code">ElementRef</code> when element-based, or
+            <code cds-text="code">null</code> for point-based origins.
+          </td>
+        </tr>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">originPoint</b>
+            <div class="hidden-sm-up">Type: ClrPopoverPoint | null</div>
+          </td>
+          <td class="left hidden-xs-down">ClrPopoverPoint | null</td>
+          <td class="left">
+            Returns the origin as a <code cds-text="code">{ x, y }</code> point when point-based, or
+            <code cds-text="code">null</code> for element-based origins.
+          </td>
+        </tr>
+        <tr>
+          <td class="left">
             <b cds-text="medium">toggleWithEvent(event)</b>
             <div class="hidden-sm-up">Type: Method</div>
           </td>
@@ -253,14 +315,35 @@
         </tr>
         <tr>
           <td class="left">
-            <b cds-text="medium">focusAnchor()</b>
+            <b cds-text="medium">openAtPoint(point)</b>
             <div class="hidden-sm-up">Type: Method</div>
           </td>
           <td class="left hidden-xs-down">void</td>
-          <td class="left">Returns focus to the anchor element. Called automatically when the popover closes.</td>
+          <td class="left">
+            Opens the popover at a specific <code cds-text="code">{ x, y }</code> screen coordinate. Sets the origin to
+            the given point and opens the overlay. If the popover is already open, it closes first and reopens at the
+            new point.
+          </td>
+        </tr>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">focusOrigin()</b>
+            <div class="hidden-sm-up">Type: Method</div>
+          </td>
+          <td class="left hidden-xs-down">void</td>
+          <td class="left">
+            Returns focus to the origin element. Called automatically when the popover closes. No-op for point-based
+            origins.
+          </td>
         </tr>
       </tbody>
     </table>
+
+    <h3 class="clr-mt-32px" cds-text="section"><code cds-text="code">ClrPopoverPoint</code> &mdash; interface</h3>
+    <p class="clr-mt-16px" cds-text="body">
+      A simple interface representing a screen coordinate: <code cds-text="code">{ x: number; y: number }</code>. Used
+      with <code cds-text="code">openAtPoint()</code> to position the popover at an arbitrary point.
+    </p>
 
     <h3 class="clr-mt-32px" cds-text="section">
       <code cds-text="code">*clrPopoverContent</code> &mdash; structural directive
@@ -299,7 +382,7 @@
           <td class="left hidden-xs-down">ClrPopoverPosition | ConnectedPosition</td>
           <td class="left hidden-xs-down">bottom-left</td>
           <td class="left">
-            Preferred position relative to the anchor. Accepts a
+            Preferred position relative to the origin. Accepts a
             <code cds-text="code">ClrPopoverPosition</code> string (e.g. <code cds-text="code">'top-right'</code>) or a
             CDK <code cds-text="code">ConnectedPosition</code> object for custom alignment.
           </td>
@@ -315,6 +398,21 @@
           <td class="left">
             Fallback positions tried in order when the preferred position doesn't fit the viewport. If not set, a
             default set of fallbacks is generated based on the popover type.
+          </td>
+        </tr>
+        <tr>
+          <td class="left">
+            <b cds-text="medium">origin</b>
+            <div class="hidden-sm-up">Type: FlexibleConnectedPositionStrategyOrigin</div>
+            <div class="hidden-sm-up">Default: &mdash;</div>
+          </td>
+          <td class="left hidden-xs-down">FlexibleConnectedPositionStrategyOrigin</td>
+          <td class="left hidden-xs-down">&mdash;</td>
+          <td class="left">
+            Overrides the positioning origin for this content. Accepts an
+            <code cds-text="code">ElementRef</code>, an <code cds-text="code">HTMLElement</code>, or a
+            <code cds-text="code">{ x, y }</code> point. When set, this takes precedence over the
+            <code cds-text="code">[clrPopoverOrigin]</code> directive.
           </td>
         </tr>
         <tr>
@@ -337,15 +435,15 @@
           <td class="left hidden-xs-down">false</td>
           <td class="left">
             When <code cds-text="code">true</code>, scrolling any ancestor closes the popover (close strategy). When
-            <code cds-text="code">false</code>, scrolling repositions the overlay to stay aligned with the anchor
-            (reposition strategy).
+            <code cds-text="code">false</code>, scrolling repositions the overlay to stay aligned with the origin
+            (reposition strategy). Point-based origins always close on scroll regardless of this setting.
           </td>
         </tr>
       </tbody>
     </table>
 
     <h3 class="clr-mt-32px" cds-text="section">
-      <code cds-text="code">[clrPopoverAnchor]</code> &mdash; attribute directive
+      <code cds-text="code">[clrPopoverOrigin]</code> &mdash; attribute directive
     </h3>
     <p class="clr-mt-16px" cds-text="body">
       Marks the element as the positioning reference point for the overlay. Registers the element's
@@ -362,10 +460,10 @@
       accessibility.
     </p>
     <p class="clr-mt-8px" cds-text="body">
-      <strong>Note:</strong> <code cds-text="code">[clrPopoverAnchor]</code> and
+      <strong>Note:</strong> <code cds-text="code">[clrPopoverOrigin]</code> and
       <code cds-text="code">[clrPopoverOpenCloseButton]</code> are independent directives and do not have to be on the
-      same element. However, placing them together on the trigger button is the recommended pattern — it ensures the
-      overlay positions relative to the same element the user clicked. Separating them across different elements is
+      same element. However, placing them together on the trigger button is the recommended pattern &mdash; it ensures
+      the overlay positions relative to the same element the user clicked. Separating them across different elements is
       possible but requires careful consideration of positioning and focus behavior.
     </p>
 
@@ -375,6 +473,15 @@
     <p class="clr-mt-16px" cds-text="body">
       Place inside the overlay content to provide a close action. Closes the popover and restores focus to the origin
       element. Only valid inside a <code cds-text="code">*clrPopoverContent</code> container.
+    </p>
+
+    <h3 class="clr-mt-32px" cds-text="section">
+      <code cds-text="code">POPOVER_HOST_ORIGIN</code> &mdash; InjectionToken
+    </h3>
+    <p class="clr-mt-16px" cds-text="body">
+      An injection token for providing the host element as the popover origin. Used internally by
+      <code cds-text="code">ClrPopoverHostDirective</code> to register the host's
+      <code cds-text="code">ElementRef</code> as the origin for components like dropdown, signpost, and tooltip.
     </p>
   </app-doc-tab>
 </app-doc-tabs>

--- a/projects/website/src/app/documentation/demos/popover/popover.demo.module.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover.demo.module.ts
@@ -11,6 +11,7 @@ import { RouterModule } from '@angular/router';
 import { ClarityModule } from '@clr/angular';
 
 import { PopoverBasicDemo } from './popover-basic';
+import { PopoverContextMenuDemo } from './popover-context-menu';
 import { PopoverFallbackPositionsDemo } from './popover-fallback-positions';
 import { PopoverPositionsDemo } from './popover-positions';
 import { PopoverScrollToCloseDemo } from './popover-scroll-to-close';
@@ -29,6 +30,7 @@ import { StackblitzExampleComponent } from '../../../shared/stackblitz-example/s
     PopoverPositionsDemo,
     PopoverFallbackPositionsDemo,
     PopoverScrollToCloseDemo,
+    PopoverContextMenuDemo,
     PopoverDemo,
   ],
   exports: [PopoverDemo],

--- a/projects/website/src/app/documentation/demos/popover/popover.demo.module.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover.demo.module.ts
@@ -1,0 +1,36 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { CommonModule } from '@angular/common';
+import { NgModule } from '@angular/core';
+import { RouterModule } from '@angular/router';
+import { ClarityModule } from '@clr/angular';
+
+import { PopoverBasicDemo } from './popover-basic';
+import { PopoverFallbackPositionsDemo } from './popover-fallback-positions';
+import { PopoverPositionsDemo } from './popover-positions';
+import { PopoverScrollToCloseDemo } from './popover-scroll-to-close';
+import { PopoverDemo } from './popover.demo';
+import { DocTabsModule } from '../../../shared/doc-tabs/doc-tabs.module';
+import { StackblitzExampleComponent } from '../../../shared/stackblitz-example/stackblitz-example.component';
+
+@NgModule({
+  imports: [
+    CommonModule,
+    ClarityModule,
+    RouterModule.forChild([{ path: '', component: PopoverDemo }]),
+    DocTabsModule,
+    StackblitzExampleComponent,
+    PopoverBasicDemo,
+    PopoverPositionsDemo,
+    PopoverFallbackPositionsDemo,
+    PopoverScrollToCloseDemo,
+    PopoverDemo,
+  ],
+  exports: [PopoverDemo],
+})
+export class PopoverDemoModule {}

--- a/projects/website/src/app/documentation/demos/popover/popover.demo.scss
+++ b/projects/website/src/app/documentation/demos/popover/popover.demo.scss
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+.popover-panel {
+  background: var(--cds-alias-object-container-background);
+  border: var(--cds-alias-object-border-width-100) solid var(--cds-alias-object-border-color);
+  border-radius: var(--cds-alias-object-border-radius-100);
+  padding: var(--cds-global-space-7);
+  box-shadow: var(--cds-alias-object-shadow-300);
+  min-width: 220px;
+  max-width: 320px;
+}
+
+.popover-positions-controls {
+  margin-bottom: var(--cds-global-space-6);
+}
+
+.popover-positions-area,
+.popover-centered-area {
+  display: flex;
+  justify-content: center;
+  min-height: 200px;
+  align-items: center;
+}
+
+.popover-scroll-container {
+  height: 180px;
+  overflow-y: auto;
+  border: var(--cds-alias-object-border-width-100) solid var(--cds-alias-object-border-color);
+  border-radius: var(--cds-alias-object-border-radius-100);
+  padding: var(--cds-global-space-7);
+}
+
+.popover-scroll-content {
+  .popover-scroll-spacer {
+    height: 400px;
+  }
+}

--- a/projects/website/src/app/documentation/demos/popover/popover.demo.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover.demo.ts
@@ -9,6 +9,7 @@ import { Component } from '@angular/core';
 import { ClarityIcons, homeIcon, timesIcon } from '@clr/angular';
 
 import { PopoverBasicDemo } from './popover-basic';
+import { PopoverContextMenuDemo } from './popover-context-menu';
 import { PopoverFallbackPositionsDemo } from './popover-fallback-positions';
 import { PopoverPositionsDemo } from './popover-positions';
 import { PopoverScrollToCloseDemo } from './popover-scroll-to-close';
@@ -30,6 +31,7 @@ import { ClarityDocComponent } from '../clarity-doc';
     PopoverPositionsDemo,
     PopoverFallbackPositionsDemo,
     PopoverScrollToCloseDemo,
+    PopoverContextMenuDemo,
   ],
 })
 export class PopoverDemo extends ClarityDocComponent {

--- a/projects/website/src/app/documentation/demos/popover/popover.demo.ts
+++ b/projects/website/src/app/documentation/demos/popover/popover.demo.ts
@@ -1,0 +1,40 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component } from '@angular/core';
+import { ClarityIcons, homeIcon, timesIcon } from '@clr/angular';
+
+import { PopoverBasicDemo } from './popover-basic';
+import { PopoverFallbackPositionsDemo } from './popover-fallback-positions';
+import { PopoverPositionsDemo } from './popover-positions';
+import { PopoverScrollToCloseDemo } from './popover-scroll-to-close';
+import { DocTabComponent } from '../../../shared/doc-tabs/doc-tab.component';
+import { DocTabsComponent } from '../../../shared/doc-tabs/doc-tabs.component';
+import { ClarityDocComponent } from '../clarity-doc';
+
+@Component({
+  selector: 'clr-popover-demo',
+  templateUrl: './popover.demo.html',
+  host: {
+    '[class.content-area]': 'true',
+    '[class.dox-content-panel]': 'true',
+  },
+  imports: [
+    DocTabsComponent,
+    DocTabComponent,
+    PopoverBasicDemo,
+    PopoverPositionsDemo,
+    PopoverFallbackPositionsDemo,
+    PopoverScrollToCloseDemo,
+  ],
+})
+export class PopoverDemo extends ClarityDocComponent {
+  constructor() {
+    super('popover');
+    ClarityIcons.addIcons(homeIcon, timesIcon);
+  }
+}

--- a/projects/website/src/app/documentation/documentation-routes.ts
+++ b/projects/website/src/app/documentation/documentation-routes.ts
@@ -212,6 +212,11 @@ export const documentationRoutes: Routes = [
       },
       {
         matcher: documentationRouteMatcher,
+        data: { routePath: 'popover/:tab?' },
+        loadChildren: () => import('./demos/popover/popover.demo.module').then(m => m.PopoverDemoModule),
+      },
+      {
+        matcher: documentationRouteMatcher,
         data: { routePath: 'progress/:tab?' },
         loadChildren: () =>
           import('./demos/progress-bars/progress-bars.demo.module').then(m => m.ProgressBarsDemoModule),

--- a/projects/website/src/settings/componentlist.json
+++ b/projects/website/src/settings/componentlist.json
@@ -178,6 +178,11 @@
       "storybookPath": "forms-reactive"
     },
     {
+      "url": "popover",
+      "text": "Popover",
+      "type": "component"
+    },
+    {
       "url": "progress",
       "text": "Progress Bar",
       "type": "component"


### PR DESCRIPTION
## PR Checklist

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The Clarity website has no documentation page for the Popover utility. Users who want to build custom overlays using the low-level popover directives and service have no reference material on the website.

Issue Number: N/A

## What is the new behavior?

Adds a full documentation page for the Popover utility at `/documentation/popover` with three tabs:

### Overview tab
- Component summary describing what a popover is from a UI/UX perspective
- Usage guidance with concrete examples (confirmation dialogs, detail panels, custom pickers) and a comparison table recommending Dropdown, Signpost, or Tooltip for common patterns
- Placement section explaining the connected position strategy and automatic viewport-aware repositioning
- Behavior section covering trigger toggling, outside-click dismissal, Escape key, and two scroll strategies (reposition vs close-on-scroll)
- Content best practices and accessibility guidelines

### Code tab
- Step-by-step setup guide (import module, provide service, add state property)
- Four interactive examples:
  1. **Basic Popover** — minimal toggle + content + close button
  2. **Positions** — interactive position picker with all 12 `ClrPopoverPosition` values
  3. **Fallback Positions** — demonstrates `availablePositions` with CDK `ConnectedPosition` objects
  4. **Scroll to Close** — scrollable container that dismisses the popover on scroll
- All examples include Stackblitz-exportable code snippets (HTML + TypeScript tabs)

### API tab
- `ClrPopoverService` properties and methods
- `*clrPopoverContent` inputs with types, defaults, and descriptions
- `[clrPopoverAnchor]`, `[clrPopoverOpenCloseButton]`, `[clrPopoverCloseButton]` directive descriptions
- References to Angular CDK Overlay types (`ConnectedPosition`, `FlexibleConnectedPositionStrategy`)

### Infrastructure
- Registered `popover` in `componentlist.json`
- Added lazy-loaded route in `documentation-routes.ts`
- All demo components use `ViewEncapsulation.None` so popover panel styles reach the CDK overlay portal

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

- Documentation links to the [Angular CDK Overlay docs](https://material.angular.dev/cdk/overlay/overview) where appropriate, since the popover utility is built on top of it.
- Website build passes with no errors.