### PR TITLE
fix(datagrid): import two-way-arrow icon in module

### DIFF
--- a/projects/angular/data/datagrid/datagrid.module.ts
+++ b/projects/angular/data/datagrid/datagrid.module.ts
@@ -23,6 +23,7 @@ import {
   filterGridIcon,
   stepForward2Icon,
   timesIcon,
+  twoWayArrowsIcon,
   viewColumnsIcon,
   windowCloseIcon,
 } from '@clr/angular/icon';
@@ -160,6 +161,7 @@ export class ClrDatagridModule {
       windowCloseIcon,
       arrowIcon,
       timesIcon,
+      twoWayArrowsIcon,
       stepForward2Icon,
       angleDoubleIcon,
       filterGridCircleIcon,


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The unsort `two-way-arrow` icon is not imported in datagrid module.

Issue Number: N/A

## What is the new behavior?
The unsort `two-way-arrow` icon is imported in datagrid module.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
