### PR TITLE
chore(website): document custom select all and add clrDgSelectionType in selection demo

### DIFF
--- a/projects/website/src/app/documentation/demos/datagrid/custom-select-all/custom-select-all.html
+++ b/projects/website/src/app/documentation/demos/datagrid/custom-select-all/custom-select-all.html
@@ -1,0 +1,139 @@
+<!--
+  ~ Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+  ~ The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+
+<h2 class="clr-mt-48px" cds-text="title">Custom Select All</h2>
+
+<p class="clr-mt-16px" cds-text="body">
+  By default, the "select all" checkbox in the datagrid header selects or deselects all currently displayed items using
+  the built-in selection logic. However, in some scenarios you may need full control over what happens when the user
+  clicks the "select all" checkbox. The <code cds-text="code">clrDgCustomSelectAll</code> feature lets you override the
+  default behavior and implement your own select-all logic.
+</p>
+
+<h3 class="clr-mt-32px" cds-text="section">When to use</h3>
+
+<p class="clr-mt-16px" cds-text="body">Custom select all is particularly useful in the following scenarios:</p>
+<ul class="list list-spacer">
+  <li>
+    <strong>Virtual scroll datagrids</strong> &mdash; In a virtual scroll datagrid, only a subset of rows are rendered
+    in the DOM at any given time. The default select-all behavior only toggles selection for rendered rows. With custom
+    select all, you can select items from the entire dataset, including rows that are not currently rendered.
+  </li>
+  <li>
+    <strong>Server-driven selection</strong> &mdash; When your data is fetched from a server and you want the select-all
+    action to trigger a server-side operation (e.g., marking all records as selected in the backend).
+  </li>
+  <li>
+    <strong>Conditional selection</strong> &mdash; When you want to apply custom filtering logic to determine which
+    items should be selected (e.g., select only items matching certain criteria).
+  </li>
+</ul>
+
+<h3 class="clr-mt-32px" cds-text="section">Basic usage</h3>
+
+<p class="clr-mt-16px" cds-text="body">
+  To enable custom select all, set <code cds-text="code">[clrDgCustomSelectAllEnabled]</code> to
+  <code cds-text="code">true</code> on the <code cds-text="code">&lt;clr-datagrid&gt;</code> component and listen to the
+  <code cds-text="code">(clrDgCustomSelectAll)</code> output event. When the user clicks the "select all" checkbox, the
+  datagrid will emit a <code cds-text="code">boolean</code> value through this event instead of modifying the selection
+  internally.
+</p>
+
+<p class="clr-mt-16px clr-mb-16px" cds-text="body">
+  The emitted value is <code cds-text="code">true</code> when the checkbox is being checked (select all) and
+  <code cds-text="code">false</code> when it is being unchecked (deselect all).
+</p>
+
+<app-code-snippet [code]="examples.basicUsage" language="html"></app-code-snippet>
+
+<p class="clr-mt-16px clr-mb-16px" cds-text="body">
+  In your component, handle the event to apply your own selection logic:
+</p>
+
+<app-code-snippet [code]="handlerExample" language="typescript"></app-code-snippet>
+
+<clr-alert [clrAlertType]="'info'" [clrAlertClosable]="false">
+  <clr-alert-item>
+    <span class="alert-text">
+      When <code cds-text="code">[clrDgCustomSelectAllEnabled]</code> is <code cds-text="code">true</code>, the datagrid
+      will <strong>not</strong> modify the selection internally when the "select all" checkbox is clicked. You are fully
+      responsible for updating the <code cds-text="code">[(clrDgSelected)]</code> binding in your event handler.
+    </span>
+  </clr-alert-item>
+</clr-alert>
+
+<h3 class="clr-mt-32px" cds-text="section">Example</h3>
+
+<p class="clr-mt-16px clr-mb-16px" cds-text="body">
+  In the following example, clicking the "select all" checkbox triggers custom logic that selects all users. The
+  selected user names are displayed above the datagrid.
+</p>
+
+<div class="card card-block">
+  <p class="card-text username-list">
+    Selected users: @if (selected.length == 0) {
+    <em>No user selected.</em>
+    } @for (user of selected; track user) {
+    <span class="username">{{ user.name }}</span>
+    }
+  </p>
+</div>
+
+<clr-datagrid
+  [(clrDgSelected)]="selected"
+  [clrDgSelectionType]="'multi'"
+  [clrDgItemsIdentityFn]="trackUserItemById"
+  [clrDgCustomSelectAllEnabled]="true"
+  (clrDgCustomSelectAll)="onCustomSelectAll($event)"
+>
+  <clr-dg-column>User ID</clr-dg-column>
+  <clr-dg-column>Name</clr-dg-column>
+  <clr-dg-column>Creation date</clr-dg-column>
+  <clr-dg-column>Favorite color</clr-dg-column>
+
+  <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+    <clr-dg-cell>{{ user.id }}</clr-dg-cell>
+    <clr-dg-cell>{{ user.name }}</clr-dg-cell>
+    <clr-dg-cell>{{ user.creation | date }}</clr-dg-cell>
+    <clr-dg-cell>
+      <span class="color-square" [style.backgroundColor]="user.color"></span>
+    </clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer>{{ users.length }} users</clr-dg-footer>
+</clr-datagrid>
+
+<app-stackblitz-example
+  name="Datagrid Custom Select All"
+  [componentTemplate]="examples.main"
+  [componentClass]="examples.componentTS"
+  [componentStyles]="commonFiles.exampleCss"
+  [showComponentStyles]="false"
+  [additionalFiles]="commonFiles.additionalFiles"
+></app-stackblitz-example>
+
+{{examples}}
+
+<h3 class="clr-mt-32px" cds-text="section">Usage with virtual scroll</h3>
+
+<p class="clr-mt-16px" cds-text="body">
+  Custom select all is especially important when using virtual scroll. In a virtual scroll datagrid, only the rows
+  visible in the viewport (plus a small buffer) are rendered in the DOM. The default select-all behavior would only
+  toggle selection for those rendered rows, which is typically not what users expect.
+</p>
+
+<p class="clr-mt-16px clr-mb-16px" cds-text="body">
+  By enabling custom select all, you can ensure that clicking "select all" selects every item in the full dataset:
+</p>
+
+<app-code-snippet [code]="examples.virtualScrollExample" language="html"></app-code-snippet>
+
+<p class="clr-mt-16px clr-mb-16px" cds-text="body">
+  The handler for virtual scroll should account for items that may already be selected:
+</p>
+
+<app-code-snippet [code]="virtualScrollHandlerExample" language="typescript"></app-code-snippet>

--- a/projects/website/src/app/documentation/demos/datagrid/custom-select-all/custom-select-all.html
+++ b/projects/website/src/app/documentation/demos/datagrid/custom-select-all/custom-select-all.html
@@ -116,8 +116,6 @@
   [additionalFiles]="commonFiles.additionalFiles"
 ></app-stackblitz-example>
 
-{{examples}}
-
 <h3 class="clr-mt-32px" cds-text="section">Usage with virtual scroll</h3>
 
 <p class="clr-mt-16px" cds-text="body">

--- a/projects/website/src/app/documentation/demos/datagrid/custom-select-all/custom-select-all.ts
+++ b/projects/website/src/app/documentation/demos/datagrid/custom-select-all/custom-select-all.ts
@@ -17,47 +17,64 @@ import { User } from '../inventory/user';
 import { CommonFiles } from '../utils/stackblitz-common-data';
 
 @Component({
-  selector: 'clr-datagrid-selection-demo',
+  selector: 'clr-datagrid-custom-select-all-demo',
   providers: [Inventory],
-  templateUrl: 'selection.html',
+  templateUrl: 'custom-select-all.html',
   styleUrl: '../datagrid.demo.scss',
   imports: [ClrDatagridModule, StackblitzExampleComponent, ClrAlertModule, CodeSnippetComponent, DatePipe],
 })
-export class DatagridSelectionDemo {
+export class DatagridCustomSelectAllDemo {
   commonFiles = CommonFiles;
   examples = EXAMPLES;
 
+  handlerExample = `
+  onCustomSelectAll(selectAll: boolean) {
+    if (selectAll) {
+      // Custom logic. Select all items from your full dataset
+      this.selected = [...this.allItems];
+    } else {
+      this.selected = [];
+    }
+  }`;
+
+  virtualScrollHandlerExample = `
+    onCustomSelectAll(selectAll: boolean) {
+      if (selectAll) {
+        // In virtual scroll, only a subset of rows are rendered at a time.
+        // Use custom select all to select from the full dataset,
+        // not just the currently rendered rows.
+        const newSelection = [...this.selected];
+        this.allItems.forEach(item => {
+          if (!this.selected.some(s => this.trackItemById(s) === this.trackItemById(item))) {
+            newSelection.push(item);
+          }
+        });
+        this.selected = newSelection;
+      } else {
+        this.selected = [];
+      }
+    }
+    `;
+
   users: User[];
   selected: User[] = [];
-  rowSelected: User[] = [];
-  lockedUsers: User[] = [];
 
   constructor(inventory: Inventory) {
     inventory.size = 10;
     inventory.reset();
     this.users = inventory.all;
-
-    this.lockedUsers = [...inventory.all];
-  }
-
-  unlockRows() {
-    this.lockedUsers = this.lockedUsers.map(row => {
-      delete row.locked;
-      return row;
-    });
-  }
-
-  lockRows() {
-    this.lockedUsers = this.lockedUsers.map((user, index) => {
-      // lock few rows
-      if ([2, 3, 5, 9].includes(index)) {
-        user.locked = true;
-      }
-      return user;
-    });
   }
 
   trackUserItemById(user: User) {
     return user.id;
+  }
+
+  onCustomSelectAll(selectAll: boolean) {
+    console.log('onCustomSelectAll');
+    if (selectAll) {
+      this.selected = [...this.users];
+    } else {
+      this.selected = [];
+    }
   }
 }

--- a/projects/website/src/app/documentation/demos/datagrid/custom-select-all/example.component.html
+++ b/projects/website/src/app/documentation/demos/datagrid/custom-select-all/example.component.html
@@ -1,0 +1,7 @@
+<!--
+  ~ Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+  ~ The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+  ~ This software is released under MIT license.
+  ~ The full license information can be found in LICENSE in the root directory of this project.
+  -->
+<p>StackBlitz example placeholder</p>

--- a/projects/website/src/app/documentation/demos/datagrid/custom-select-all/examples.ts
+++ b/projects/website/src/app/documentation/demos/datagrid/custom-select-all/examples.ts
@@ -1,0 +1,130 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+const basicUsage = `
+<clr-datagrid
+  [(clrDgSelected)]="selected"
+  [clrDgSelectionType]="'multi'"
+  [clrDgCustomSelectAllEnabled]="true"
+  (clrDgCustomSelectAll)="onCustomSelectAll($event)"
+>
+  <!-- columns and rows -->
+</clr-datagrid>
+`;
+
+const main = `
+<div class="card card-block">
+  <p class="card-text">
+    Selected users:
+    @if (selected.length === 0) {
+      <em>No user selected.</em>
+    }
+    @for (user of selected; track user.id; let isLast = $last) {
+      <span class="username">{{ user.name }}{{ isLast ? '.' : ',' }}</span>
+    }
+  </p>
+</div>
+
+<clr-datagrid
+  [(clrDgSelected)]="selected"
+  [clrDgSelectionType]="'multi'"
+  [clrDgItemsIdentityFn]="trackUserItemById"
+  [clrDgCustomSelectAllEnabled]="true"
+  (clrDgCustomSelectAll)="onCustomSelectAll($event)"
+>
+  <clr-dg-column>User ID</clr-dg-column>
+  <clr-dg-column>Name</clr-dg-column>
+  <clr-dg-column>Creation date</clr-dg-column>
+  <clr-dg-column>Favorite color</clr-dg-column>
+
+  <clr-dg-row *clrDgItems="let user of users" [clrDgItem]="user">
+    <clr-dg-cell>{{ user.id }}</clr-dg-cell>
+    <clr-dg-cell>{{ user.name }}</clr-dg-cell>
+    <clr-dg-cell>{{ user.creation | date }}</clr-dg-cell>
+    <clr-dg-cell>
+      <span class="color-square" [style.backgroundColor]="user.color"></span>
+    </clr-dg-cell>
+  </clr-dg-row>
+
+  <clr-dg-footer>{{ users.length }} users</clr-dg-footer>
+</clr-datagrid>
+`;
+
+const componentTS = `
+import { DatePipe } from '@angular/common';
+import { Component } from '@angular/core';
+import { ClrDatagridModule } from '@clr/angular';
+import { Inventory } from './inventory/inventory';
+import { User } from './inventory/user';
+
+@Component({
+  selector: 'app-example',
+  templateUrl: './example.component.html',
+  styleUrl: './example.component.scss',
+
+  providers: [Inventory],
+  imports: [DatePipe, ClrDatagridModule],
+})
+export class ExampleComponent {
+  users: User[];
+  selected: User[] = [];
+
+  constructor(inventory: Inventory) {
+    inventory.size = 10;
+    inventory.reset();
+    this.users = inventory.all;
+  }
+
+  trackUserItemById(user: User) {
+    return user.id;
+  }
+
+  onCustomSelectAll(selectAll: boolean) {
+    if (selectAll) {
+      this.selected = [...this.users];
+    } else {
+      this.selected = [];
+    }
+  }
+}
+`;
+
+const virtualScrollExample = `
+<clr-datagrid
+  [(clrDgSelected)]="selected"
+  [clrDgSelectionType]="'multi'"
+  [clrDgItemsIdentityFn]="trackItemById"
+  [clrDgCustomSelectAllEnabled]="true"
+  (clrDgCustomSelectAll)="onCustomSelectAll($event)"
+  style="height: 32rem"
+>
+  <clr-dg-column>User ID</clr-dg-column>
+  <clr-dg-column>Name</clr-dg-column>
+
+  <ng-template
+    clrVirtualScroll
+    let-user
+    [clrVirtualRowsOf]="users"
+    [clrVirtualRowsTrackBy]="rowByIndex"
+  >
+    <clr-dg-row [clrDgItem]="user">
+      <clr-dg-cell>{{ user.id }}</clr-dg-cell>
+      <clr-dg-cell>{{ user.name }}</clr-dg-cell>
+    </clr-dg-row>
+  </ng-template>
+
+  <clr-dg-footer>{{ users.length }} users</clr-dg-footer>
+</clr-datagrid>
+`;
+
+export const EXAMPLES = {
+  basicUsage,
+  main,
+  componentTS,
+  handlerExample,
+  virtualScrollExample,
+};

--- a/projects/website/src/app/documentation/demos/datagrid/custom-select-all/examples.ts
+++ b/projects/website/src/app/documentation/demos/datagrid/custom-select-all/examples.ts
@@ -125,6 +125,5 @@ export const EXAMPLES = {
   basicUsage,
   main,
   componentTS,
-  handlerExample,
   virtualScrollExample,
 };

--- a/projects/website/src/app/documentation/demos/datagrid/datagrid.demo.module.ts
+++ b/projects/website/src/app/documentation/demos/datagrid/datagrid.demo.module.ts
@@ -18,6 +18,7 @@ import { DatagridBindingPropertiesDemo } from './binding-properties/binding-prop
 import { DatagridBuiltInFiltersDemo } from './built-in-filters/built-in-filters';
 import { DatagridCompactDemo } from './compact/compact';
 import { DatagridCustomRenderingDemo } from './custom-rendering/custom-rendering';
+import { DatagridCustomSelectAllDemo } from './custom-select-all/custom-select-all';
 import { DatagridDemo } from './datagrid.demo';
 import { DatagridDetailPaneDemo } from './detail/detail';
 import { DatagridExpandableRowsDemo } from './expandable-rows/expandable-rows';
@@ -119,6 +120,13 @@ const routes: Routes = [
         component: DatagridSelectionSingleDemo,
         data: {
           demoName: 'Single Selection',
+        },
+      },
+      {
+        path: 'custom-select-all',
+        component: DatagridCustomSelectAllDemo,
+        data: {
+          demoName: 'Custom Select All',
         },
       },
       {
@@ -226,6 +234,7 @@ const routes: Routes = [
     DatagridBindingPropertiesDemo,
     DatagridCompactDemo,
     DatagridCustomRenderingDemo,
+    DatagridCustomSelectAllDemo,
     DatagridFilteringDemo,
     DatagridFullDemo,
     DatagridPaginationDemo,

--- a/projects/website/src/app/documentation/demos/datagrid/datagrid.demo.ts
+++ b/projects/website/src/app/documentation/demos/datagrid/datagrid.demo.ts
@@ -162,6 +162,20 @@ export class DatagridDemo extends ClarityDocComponent implements OnInit, OnDestr
           description:
             'Set to true to preserve selected rows between data changes. E.g - page changes or filter changes.',
         },
+        {
+          name: '[clrDgCustomSelectAllEnabled]',
+          type: 'boolean',
+          defaultValue: 'false',
+          description:
+            'When true, the "select all" checkbox emits a custom event instead of using the built-in check-all logic. Use with (clrDgCustomSelectAll) to implement custom select-all behavior.',
+        },
+        {
+          name: '(clrDgCustomSelectAll)',
+          type: 'boolean',
+          defaultValue: 'n/a',
+          description:
+            'Emits when the "select all" checkbox is clicked and [clrDgCustomSelectAllEnabled] is true. Emits true for select all and false for deselect all.',
+        },
       ],
     },
     {

--- a/projects/website/src/app/documentation/demos/datagrid/selection/examples.ts
+++ b/projects/website/src/app/documentation/demos/datagrid/selection/examples.ts
@@ -18,7 +18,11 @@ const main = `
   </p>
 </div>
 
-<clr-datagrid [(clrDgSelected)]="selected" [clrDgItemsIdentityFn]="trackUserItemById">
+<clr-datagrid
+  [(clrDgSelected)]="selected"
+  [clrDgSelectionType]="'multi'"
+  [clrDgItemsIdentityFn]="trackUserItemById"
+>
   <clr-dg-column>User ID</clr-dg-column>
   <clr-dg-column>Name</clr-dg-column>
   <clr-dg-column>Creation date</clr-dg-column>
@@ -42,12 +46,6 @@ const singleRow = `
   <!-- ... -->
 </clr-dg-row>
 `;
-/*
- * Copyright (c) 2016-2025 Broadcom. All Rights Reserved.
- * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
- * This software is released under MIT license.
- * The full license information can be found in LICENSE in the root directory of this project.
- */
 
 const rowSelection = `
 <clr-datagrid
@@ -74,7 +72,11 @@ const rowSelection = `
 `;
 
 const selectionChangeEvent = `
-<clr-datagrid [clrDgSelected]="selected" (clrDgSelectedChange)="selectionChanged($event)">
+<clr-datagrid
+  [clrDgSelected]="selected"
+  [clrDgSelectionType]="'multi'"
+  (clrDgSelectedChange)="selectionChanged($event)"
+>
   <!-- ... -->
 </clr-datagrid>
 `;

--- a/projects/website/src/app/documentation/demos/datagrid/selection/selection.html
+++ b/projects/website/src/app/documentation/demos/datagrid/selection/selection.html
@@ -22,6 +22,10 @@
     list of currently selected items. Note that by adding items to this list yourself, you can dynamically select
     elements if you need to.
   </li>
+  <li>
+    Add a <code cds-text="code">[clrDgSelectionType]="'multi'"</code> on the datagrid itself, to specify the selection
+    type.
+  </li>
 </ul>
 
 <p class="clr-mt-16px" cds-text="body">
@@ -44,7 +48,7 @@
   </p>
 </div>
 
-<clr-datagrid [(clrDgSelected)]="selected" [clrDgItemsIdentityFn]="trackUserItemById">
+<clr-datagrid [(clrDgSelected)]="selected" [clrDgSelectionType]="'multi'" [clrDgItemsIdentityFn]="trackUserItemById">
   <clr-dg-column>User ID</clr-dg-column>
   <clr-dg-column>Name</clr-dg-column>
   <clr-dg-column>Creation date</clr-dg-column>
@@ -93,7 +97,7 @@
   </clr-alert-item>
 </clr-alert>
 
-<clr-datagrid [(clrDgSelected)]="rowSelected" [clrDgRowSelection]="true">
+<clr-datagrid [(clrDgSelected)]="rowSelected" [clrDgSelectionType]="'multi'" [clrDgRowSelection]="true">
   <clr-dg-column>User ID</clr-dg-column>
   <clr-dg-column>Name</clr-dg-column>
   <clr-dg-column>Creation date</clr-dg-column>
@@ -145,7 +149,7 @@
 <button class="btn btn-primary" (click)="lockRows()">Lock Rows</button>
 <button class="btn btn-primary" (click)="unlockRows()">Unlock Rows</button>
 
-<clr-datagrid [(clrDgSelected)]="selected">
+<clr-datagrid [(clrDgSelected)]="selected" [clrDgSelectionType]="'multi'">
   <clr-dg-column>User ID</clr-dg-column>
   <clr-dg-column>Name</clr-dg-column>
   <clr-dg-column>Creation date</clr-dg-column>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [x] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

- The `clrDgCustomSelectAll` functionality is undocumented on the website. 
- The existing selection demo pages does not show the explicit `[clrDgSelectionType]="'multi'"` binding, relying on implicit selection type inference.

Issue Number: CDE-2935

## What is the new behavior?

### New "Custom Select All" documentation page

Adds a dedicated documentation page for the `clrDgCustomSelectAll` feature under the datagrid section, accessible at `/documentation/datagrid/code/custom-select-all`.

### API table updated

Added `[clrDgCustomSelectAllEnabled]` (boolean input, default `false`) and `(clrDgCustomSelectAll)` (boolean output) to the `ClrDatagrid` API reference table.

### Selection demo improvements

- Added explicit `[clrDgSelectionType]="'multi'"` to all multi-selection datagrid examples in the selection demo page and code snippets, making the required binding clear to users.
- Removed duplicate copyright comment block in `selection/examples.ts`.
- Cleaned up unused imports (`ClrPopoverHostDirective`, `ClrStopEscapePropagationDirective`) from `selection/selection.ts`.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

New files:
- `custom-select-all/custom-select-all.html` — documentation page template
- `custom-select-all/custom-select-all.ts` — demo component
- `custom-select-all/examples.ts` — code snippet constants
- `custom-select-all/example.component.html` — StackBlitz placeholder
