### PR TITLE
feat(schematics): v18 datagrid migration and migrate-v18 schematic

### DIFF
--- a/projects/angular/schematics/collection.json
+++ b/projects/angular/schematics/collection.json
@@ -2,9 +2,13 @@
   "$schema": "../../../node_modules/@angular-devkit/schematics/collection-schema.json",
   "schematics": {
     "ng-update": {
-      "version": "18.0.0-beta.5",
+      "version": "18.0.0",
       "description": "Migrates @clr/angular from v17 to v18",
-      "factory": "./schematics/ng-update/index#migrate"
+      "factory": "./ng-update/index#migrate"
+    },
+    "migrate-v18": {
+      "description": "Applies automated @clr/angular v17→v18 source migrations (templates, imports, CSS). Run with: ng generate @clr/angular:migrate-v18",
+      "factory": "./ng-update/index#migrate"
     }
   }
 }

--- a/projects/angular/schematics/ng-update/migrations/template-migration.ts
+++ b/projects/angular/schematics/ng-update/migrations/template-migration.ts
@@ -11,6 +11,7 @@ import { CSS_ATTRIBUTE_REPLACEMENTS } from '../replacements/css-replacements';
 import {
   HEADER_CLASS_REPLACEMENTS,
   TEMPLATE_ATTRIBUTE_REPLACEMENTS,
+  TEMPLATE_DATAGRID_MIGRATION_CANDIDATES,
   TEMPLATE_INPUT_REPLACEMENTS,
   TEMPLATE_OUTPUT_REPLACEMENTS,
 } from '../replacements/template-replacements';
@@ -50,6 +51,12 @@ const COMPILED_GLOBAL_ATTR_REGEXES = TEMPLATE_ATTRIBUTE_REPLACEMENTS.filter(r =>
 // Handles attribute values that contain > (e.g. [attr.size]="size > 0 ? 'lg' : 'md'").
 const CDS_ICON_TAG_RE = /<cds-icon\b(?:[^"'/>]|"[^"]*"|'[^']*')*(?:\/?>)/g;
 
+// Opening tag of clr-datagrid only (not clr-dg-* children).
+const CLR_DATAGRID_OPEN_TAG_RE = /<clr-datagrid\b(?:[^"'/>]|"[^"]*"|'[^']*')*(?:\/?>)/g;
+
+// Bare attribute form: clrDgItemsTrackBy="..." (clr-datagrid host only; applied in datagrid pass).
+const BARE_CLR_DG_ITEMS_TRACK_BY_RE = /(?<=\s)clrDgItemsTrackBy(?==)/g;
+
 const COMPILED_HEADER_REGEXES = HEADER_CLASS_REPLACEMENTS.map(r => ({
   old: r.old,
   new: r.new,
@@ -69,6 +76,7 @@ const COMPILED_CDS_TEXT_REGEXES = CSS_ATTRIBUTE_REPLACEMENTS.map(r => ({
 export const TEMPLATE_MIGRATION_HTML_CANDIDATES: readonly string[] = [
   ...TEMPLATE_OUTPUT_REPLACEMENTS.map(r => r.old),
   ...TEMPLATE_INPUT_REPLACEMENTS.map(r => r.old),
+  ...TEMPLATE_DATAGRID_MIGRATION_CANDIDATES,
   ...TEMPLATE_ATTRIBUTE_REPLACEMENTS.map(r => r.old),
   ...HEADER_CLASS_REPLACEMENTS.map(r => r.old),
   ...CSS_ATTRIBUTE_REPLACEMENTS.map(r => r.old),
@@ -158,6 +166,9 @@ export function migrateTemplates(): Rule {
 // ---------------------------------------------------------------------------
 
 export function applyHtmlTransforms(text: string): string {
+  // Datagrid must run before migrateOutputBindings so `(clrDgSingleSelectedChange)` is still in the
+  // source; `hadLegacySingleSelection` uses substring `clrDgSingleSelected` (matches that output name too).
+  text = migrateClrDatagridOpeningTags(text);
   text = migrateOutputBindings(text);
   text = migrateInputBindings(text);
   text = migrateCdsIconAttributes(text);
@@ -175,6 +186,67 @@ function migrateOutputBindings(text: string): string {
     text = text.replace(r.regex, `(${r.new})`);
   }
   return text;
+}
+
+// --- clr-datagrid (#2007 identity input, #2203 selection API) ----------------------------
+
+function migrateClrDatagridOpeningTags(html: string): string {
+  if (!html.includes('<clr-datagrid')) {
+    return html;
+  }
+
+  CLR_DATAGRID_OPEN_TAG_RE.lastIndex = 0;
+  return html.replace(CLR_DATAGRID_OPEN_TAG_RE, transformClrDatagridOpeningTag);
+}
+
+function transformClrDatagridOpeningTag(openingTag: string): string {
+  const hadLegacySingleSelection = openingTag.includes('clrDgSingleSelected');
+
+  let tag = openingTag;
+  tag = renameLegacyDatagridSingleOutputs(tag);
+  tag = renameLegacyDatagridSingleInputs(tag);
+  tag = renameDatagridHostIdentityFn(tag);
+  tag = addExplicitSelectionTypeIfMissing(tag, hadLegacySingleSelection);
+
+  return tag;
+}
+
+function renameLegacyDatagridSingleOutputs(openingTag: string): string {
+  return openingTag.split('(clrDgSingleSelectedChange)').join('(clrDgSelectedChange)');
+}
+
+function renameLegacyDatagridSingleInputs(openingTag: string): string {
+  return openingTag
+    .split('[(clrDgSingleSelected)]')
+    .join('[(clrDgSelected)]')
+    .replace(/\[clrDgSingleSelected\]/g, '[clrDgSelected]');
+}
+
+/** Host-only: `clr-dg-items` keeps `clrDgItemsTrackBy`; this runs only on `<clr-datagrid>` tags. */
+function renameDatagridHostIdentityFn(openingTag: string): string {
+  BARE_CLR_DG_ITEMS_TRACK_BY_RE.lastIndex = 0;
+  return openingTag
+    .split('[clrDgItemsTrackBy]')
+    .join('[clrDgItemsIdentityFn]')
+    .replace(BARE_CLR_DG_ITEMS_TRACK_BY_RE, 'clrDgItemsIdentityFn');
+}
+
+/** `tag` is the opening tag after legacy single renames (so implicit multi can see `clrDgSelected`). */
+function addExplicitSelectionTypeIfMissing(tag: string, hadLegacySingleSelection: boolean): string {
+  if (tag.includes('clrDgSelectionType')) {
+    return tag;
+  }
+  if (hadLegacySingleSelection) {
+    return appendAttributeBeforeTagClose(tag, 'clrDgSelectionType="single"');
+  }
+  if (tag.includes('clrDgSelected')) {
+    return appendAttributeBeforeTagClose(tag, 'clrDgSelectionType="multi"');
+  }
+  return tag;
+}
+
+function appendAttributeBeforeTagClose(openingTag: string, attribute: string): string {
+  return openingTag.replace(/\s*(\/?>)\s*$/, ` ${attribute}$1`);
 }
 
 function migrateInputBindings(text: string): string {

--- a/projects/angular/schematics/ng-update/replacements/import-replacements.ts
+++ b/projects/angular/schematics/ng-update/replacements/import-replacements.ts
@@ -112,4 +112,12 @@ export const IMPORT_REPLACEMENTS: readonly ImportReplacement[] = [
     oldSymbol: '*',
     newSymbol: '*',
   },
+
+  // #2203 - Datagrid SelectionType enum: addons re-export removed; use @clr/angular/data/datagrid
+  {
+    oldModule: '@clr/addons/datagrid',
+    newModule: '@clr/angular/data/datagrid',
+    oldSymbol: 'SelectionType',
+    newSymbol: 'SelectionType',
+  },
 ];

--- a/projects/angular/schematics/ng-update/replacements/symbol-replacements.ts
+++ b/projects/angular/schematics/ng-update/replacements/symbol-replacements.ts
@@ -21,8 +21,7 @@ export const SYMBOL_REPLACEMENTS: readonly SymbolReplacement[] = [
   // #2023 - ClrLabel → ClrControlLabel (form directive)
   { old: 'ClrLabel', new: 'ClrControlLabel', context: 'form-label-directive' },
 
-  // #2007 - clrDgItemsTrackBy → clrDgItemsIdentityFn
-  { old: 'clrDgItemsTrackBy', new: 'clrDgItemsIdentityFn', context: 'datagrid' },
+  // #2007 — clrDgItemsTrackBy → clrDgItemsIdentityFn is template-scoped to <clr-datagrid> only (see template-migration).
 
   // #2107 - FocusService → FormsFocusService
   { old: 'FocusService', new: 'FormsFocusService', context: 'forms' },

--- a/projects/angular/schematics/ng-update/replacements/template-replacements.ts
+++ b/projects/angular/schematics/ng-update/replacements/template-replacements.ts
@@ -48,13 +48,17 @@ export const TEMPLATE_INPUT_REPLACEMENTS: readonly TemplateReplacement[] = [
     new: 'clrColor',
     context: 'badge',
   },
+];
 
-  // #2007 - Datagrid identity function rename (input, not output)
-  {
-    old: 'clrDgItemsTrackBy',
-    new: 'clrDgItemsIdentityFn',
-    context: 'datagrid',
-  },
+/**
+ * Substrings that trigger the clr-datagrid–scoped migration pass (see template-migration).
+ * `clrDgItemsTrackBy` alone can appear on clr-dg-items (unchanged); the pass no-ops without `<clr-datagrid`.
+ */
+export const TEMPLATE_DATAGRID_MIGRATION_CANDIDATES: readonly string[] = [
+  '<clr-datagrid',
+  'clrDgSingleSelected',
+  'clrDgSingleSelectedChange',
+  'clrDgItemsTrackBy',
 ];
 
 export const HEADER_CLASS_REPLACEMENTS: readonly TemplateReplacement[] = [

--- a/projects/angular/schematics/ng-update/tests/import-migration.vitest.ts
+++ b/projects/angular/schematics/ng-update/tests/import-migration.vitest.ts
@@ -66,6 +66,15 @@ import { ClrFormsModule } from '@clr/angular/src/forms';`
       expect(tree.readText('/app.ts')).toContain("from '@clr/angular/icon'");
     });
 
+    it('should move SelectionType import from @clr/addons/datagrid to @clr/angular/data/datagrid', () => {
+      tree.create('/grid.ts', `import { SelectionType } from '@clr/addons/datagrid';`);
+
+      runMigrations(tree);
+
+      expect(tree.readText('/grid.ts')).toContain("from '@clr/angular/data/datagrid'");
+      expect(tree.readText('/grid.ts')).not.toContain('@clr/addons/datagrid');
+    });
+
     it('should not alter a local ./src/ import path that resembles a Clarity deep import', () => {
       tree.create('/app.ts', `import { MyService } from './src/accordion';`);
 

--- a/projects/angular/schematics/ng-update/tests/template-migration.vitest.ts
+++ b/projects/angular/schematics/ng-update/tests/template-migration.vitest.ts
@@ -52,12 +52,26 @@ describe('template migration', () => {
   });
 
   describe('input bindings', () => {
-    it('should rename clrDgItemsTrackBy to clrDgItemsIdentityFn in templates', () => {
+    it('should keep clrDgItemsTrackBy on clr-dg-items (only clr-datagrid uses clrDgItemsIdentityFn)', () => {
       tree.create('/app.component.html', `<clr-dg-items [clrDgItemsTrackBy]="trackFn"></clr-dg-items>`);
 
       runMigrations(tree);
 
-      expect(tree.readText('/app.component.html')).toContain('clrDgItemsIdentityFn');
+      expect(tree.readText('/app.component.html')).toContain('[clrDgItemsTrackBy]');
+      expect(tree.readText('/app.component.html')).not.toContain('clrDgItemsIdentityFn');
+    });
+
+    it('should rename clrDgItemsTrackBy to clrDgItemsIdentityFn on clr-datagrid only', () => {
+      tree.create(
+        '/app.component.html',
+        `<clr-datagrid [clrDgItemsTrackBy]="dgTrack" [clrDgSelectionType]="'multi'"></clr-datagrid>`
+      );
+
+      runMigrations(tree);
+
+      const content = tree.readText('/app.component.html');
+      expect(content).toContain('[clrDgItemsIdentityFn]');
+      expect(content).not.toContain('[clrDgItemsTrackBy]');
     });
 
     it('should rename clrBadgeColor to clrColor', () => {
@@ -76,6 +90,39 @@ describe('template migration', () => {
       runMigrations(tree);
 
       expect(tree.readText('/app.component.html')).toContain('clrBadgeColor');
+    });
+  });
+
+  describe('datagrid selection API (#2203)', () => {
+    it('should migrate clrDgSingleSelectedChange to clrDgSelectedChange and add clrDgSelectionType single', () => {
+      tree.create('/dg.component.html', `<clr-datagrid (clrDgSingleSelectedChange)="onOne($event)"></clr-datagrid>`);
+
+      runMigrations(tree);
+
+      const content = tree.readText('/dg.component.html');
+      expect(content).toContain('(clrDgSelectedChange)');
+      expect(content).not.toContain('clrDgSingleSelectedChange');
+      expect(content).toContain('clrDgSelectionType="single"');
+    });
+
+    it('should migrate two-way clrDgSingleSelected to clrDgSelected and add clrDgSelectionType single', () => {
+      tree.create('/dg.component.html', `<clr-datagrid [(clrDgSingleSelected)]="user"></clr-datagrid>`);
+
+      runMigrations(tree);
+
+      const content = tree.readText('/dg.component.html');
+      expect(content).toContain('[(clrDgSelected)]');
+      expect(content).toContain('clrDgSelectionType="single"');
+      expect(content).not.toContain('clrDgSingleSelected');
+    });
+
+    it('should add clrDgSelectionType multi when clrDgSelected is used without clrDgSelectionType', () => {
+      tree.create('/dg.component.html', `<clr-datagrid [(clrDgSelected)]="rows"></clr-datagrid>`);
+
+      runMigrations(tree);
+
+      const content = tree.readText('/dg.component.html');
+      expect(content).toContain('clrDgSelectionType="multi"');
     });
   });
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The v18 `ng-update` migration did not cover datagrid breaking changes from the v18.0.0-beta.1 release (unified selection API, `clrDgItemsIdentityFn` only on `clr-datagrid`, `SelectionType` import path from addons). The schematic collection used factory paths that resolve incorrectly relative to `collection.json`. There was no dedicated schematic to run the migration without `ng update`.

Issue Number: N/A

## What is the new behavior?

- **Datagrid templates:** Scoped rename `clrDgItemsTrackBy` → `clrDgItemsIdentityFn` only on `<clr-datagrid>` opening tags (preserves `clr-dg-items` / `clrDgItemsTrackBy`). Migrates legacy single selection bindings and `(clrDgSingleSelectedChange)` to the unified API and adds explicit `clrDgSelectionType` where missing. Adds `SelectionType` import migration from `@clr/addons/datagrid` to `@clr/angular/data/datagrid`.
- **Schematics:** New `migrate-v18` schematic (same rule as `ng-update`) so consumers can run `ng generate @clr/angular:migrate-v18` without going through package updates.
- **Collection:** Factory paths updated to `./ng-update/index#migrate` (resolved from the directory containing `collection.json`, per `@angular-devkit/schematics`).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

- Refactors datagrid HTML migration into smaller helpers for readability.
- Removes the incorrect global `clrDgItemsTrackBy` symbol replacement that could break `clr-dg-items`.
