### PR TITLE
feat(appfx-datagrid): expose toggleAll() function

### DIFF
--- a/projects/addons/datagrid/datagrid.api.md
+++ b/projects/addons/datagrid/datagrid.api.md
@@ -481,6 +481,8 @@ export class DatagridComponent<T> implements OnInit, OnDestroy, AfterViewInit, O
     // (undocumented)
     protected get showDeselectAll(): boolean;
     singleRowActions: ActionDefinition[] | null;
+    // (undocumented)
+    toggleAll(): void;
     totalItems: number;
     // (undocumented)
     trackByColumnId(index: number, column: ColumnDefinition<T>): string;

--- a/projects/addons/datagrid/datagrid.component.spec.ts
+++ b/projects/addons/datagrid/datagrid.component.spec.ts
@@ -1857,6 +1857,8 @@ describe('DatagridComponent', () => {
   describe('toggleAll', () => {
     it('should toggle the allSelected property of clrDatagrid', function (this: any) {
       this.component.selectionType = SelectionType.Multi;
+      this.component.data = this.data;
+      this.component.columnsDefs = this.columnsDefs;
       this.fixture.detectChanges();
 
       const datagridComponent = this.component.appfxDatagridComponent;

--- a/projects/addons/datagrid/datagrid.component.spec.ts
+++ b/projects/addons/datagrid/datagrid.component.spec.ts
@@ -1853,6 +1853,27 @@ describe('DatagridComponent', () => {
       });
     });
   });
+
+  describe('toggleAll', () => {
+    it('should toggle the allSelected property of clrDatagrid', function (this: any) {
+      this.component.selectionType = SelectionType.Multi;
+      this.fixture.detectChanges();
+
+      const datagridComponent = this.component.appfxDatagridComponent;
+
+      expect((datagridComponent as any).clrDatagrid.allSelected).toBeFalsy();
+
+      datagridComponent.toggleAll();
+      this.fixture.detectChanges();
+
+      expect((datagridComponent as any).clrDatagrid.allSelected).toBeTruthy();
+
+      datagridComponent.toggleAll();
+      this.fixture.detectChanges();
+
+      expect((datagridComponent as any).clrDatagrid.allSelected).toBeFalsy();
+    });
+  });
 });
 
 class StatusComparator implements ClrDatagridComparatorInterface<any> {

--- a/projects/addons/datagrid/datagrid.component.ts
+++ b/projects/addons/datagrid/datagrid.component.ts
@@ -894,6 +894,12 @@ export class DatagridComponent<T> implements OnInit, OnDestroy, AfterViewInit, O
     return footer;
   }
 
+  toggleAll(): void {
+    if (this.clrDatagrid) {
+      this.clrDatagrid.allSelected = !this.clrDatagrid.allSelected;
+    }
+  }
+
   protected getExpandDetailsLabel(item: T): string {
     if (!this.hasExpandableRows(item)) {
       return '';

--- a/projects/website/src/app/documentation/demos/advanced-datagrid/advanced-datagrid.demo.html
+++ b/projects/website/src/app/documentation/demos/advanced-datagrid/advanced-datagrid.demo.html
@@ -838,6 +838,13 @@
           <td>Emits on advanced filter change.</td>
           <td>No</td>
         </tr>
+        <tr>
+          <td><code cds-text="code">toggleAll</code></td>
+          <td>Method</td>
+          <td><code cds-text="code">void</code></td>
+          <td>Toggles the selection state of all rows.</td>
+          <td>No</td>
+        </tr>
       </tbody>
     </table>
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

The `appfx-datagrid` component in the addons package did not expose a public method to programmatically toggle the selection state of all rows. Consumers had to access the internal Clarity datagrid instance to perform this action.

Issue Number: VCFUI-12095

## What is the new behavior?

This PR introduces a new `toggleAll()` method to the `DatagridComponent`. 
- **Implementation**: The method toggles the `allSelected` property of the underlying `ClrDatagrid` instance.
- **Testing**: Added unit tests in `datagrid.component.spec.ts` to verify that calling `toggleAll()` correctly flips the selection state.
- **Documentation**: Updated the API Reference section in the `advanced-datagrid` documentation to include the new method.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information