### PR TITLE
chore: release only clr/addons

### DIFF
--- a/.releaserc.release.js
+++ b/.releaserc.release.js
@@ -17,14 +17,6 @@ module.exports = {
       '@amanda-mitchell/semantic-release-npm-multiple',
       {
         registries: {
-          angular: {
-            npmPublish: true,
-            pkgRoot: './dist/clr-angular',
-          },
-          ui: {
-            npmPublish: true,
-            pkgRoot: './dist/clr-ui',
-          },
           addons: {
             npmPublish: true,
             pkgRoot: './dist/clr-addons',


### PR DESCRIPTION
Clr/addons have failed in beta chanel.

forcing only addon release.

This PR will be reverted when the addons are released in beta chanel.