### PR TITLE
chore: remove main from semantic-release branches

### DIFF
--- a/.releaserc.base.js
+++ b/.releaserc.base.js
@@ -6,7 +6,7 @@
  */
 
 module.exports = {
-  branches: ['main', '+([0-9]).x', { name: 'beta', prerelease: true }, { name: 'next', prerelease: true }],
+  branches: ['+([0-9]).x', { name: 'beta', prerelease: true }, { name: 'next', prerelease: true }],
   plugins: [
     [
       '@semantic-release/commit-analyzer',


### PR DESCRIPTION
## Summary

- Removes `main` from the `branches` array in `.releaserc.base.js`
- `main` is a development-only branch and will not publish releases
- Stable releases are published exclusively from version branches (`N.x`)
- Prerelease releases continue from `beta` and `next` branches
- Fixes the `EINVALIDNEXTVERSION` error on `18.x` Preview Release (the `>=18.0.0 <18.0.0` impossible range was caused by `main` being listed as a release channel at the same version)