### PR TITLE
fix(datagrid): clrDgRowSelection receive click events from other actions

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -2175,6 +2175,8 @@ export class ClrDatagridActionOverflow implements OnDestroy {
     get open(): boolean;
     set open(open: boolean);
     // (undocumented)
+    openActionStopPropagation(event: MouseEvent): void;
+    // (undocumented)
     openChange: EventEmitter<boolean>;
     // (undocumented)
     popoverId: string;
@@ -2700,6 +2702,8 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)
+    openDetails(event: MouseEvent, detailButton: HTMLButtonElement): void;
+    // (undocumented)
     radioId: string;
     // (undocumented)
     replaced: boolean;
@@ -2724,7 +2728,7 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     // (undocumented)
     toggle(selected?: boolean): void;
     // (undocumented)
-    toggleExpand(): void;
+    toggleExpand(event: MouseEvent): void;
     // (undocumented)
     get _view(): any;
     // (undocumented)

--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -2175,8 +2175,6 @@ export class ClrDatagridActionOverflow implements OnDestroy {
     get open(): boolean;
     set open(open: boolean);
     // (undocumented)
-    openActionStopPropagation(event: MouseEvent): void;
-    // (undocumented)
     openChange: EventEmitter<boolean>;
     // (undocumented)
     popoverId: string;

--- a/projects/angular/data/data.api.md
+++ b/projects/angular/data/data.api.md
@@ -239,6 +239,8 @@ export class ClrDatagridActionOverflow implements OnDestroy {
     get open(): boolean;
     set open(open: boolean);
     // (undocumented)
+    openActionStopPropagation(event: MouseEvent): void;
+    // (undocumented)
     openChange: EventEmitter<boolean>;
     // (undocumented)
     popoverId: string;
@@ -776,6 +778,8 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)
+    openDetails(event: MouseEvent, detailButton: HTMLButtonElement): void;
+    // (undocumented)
     radioId: string;
     // (undocumented)
     replaced: boolean;
@@ -800,7 +804,7 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     // (undocumented)
     toggle(selected?: boolean): void;
     // (undocumented)
-    toggleExpand(): void;
+    toggleExpand(event: MouseEvent): void;
     // (undocumented)
     get _view(): any;
     // (undocumented)
@@ -1681,7 +1685,7 @@ export class WrappedRow implements AfterViewInit, OnDestroy {
 
 // Warnings were encountered during analysis:
 //
-// dist/clr-angular/types/clr-angular-data-datagrid.d.ts:1050:335 - (ae-forgotten-export) The symbol "i1_2" needs to be exported by the entry point clr-angular-data.d.ts
+// dist/clr-angular/types/clr-angular-data-datagrid.d.ts:1052:335 - (ae-forgotten-export) The symbol "i1_2" needs to be exported by the entry point clr-angular-data.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/projects/angular/data/data.api.md
+++ b/projects/angular/data/data.api.md
@@ -239,8 +239,6 @@ export class ClrDatagridActionOverflow implements OnDestroy {
     get open(): boolean;
     set open(open: boolean);
     // (undocumented)
-    openActionStopPropagation(event: MouseEvent): void;
-    // (undocumented)
     openChange: EventEmitter<boolean>;
     // (undocumented)
     popoverId: string;
@@ -1685,7 +1683,7 @@ export class WrappedRow implements AfterViewInit, OnDestroy {
 
 // Warnings were encountered during analysis:
 //
-// dist/clr-angular/types/clr-angular-data-datagrid.d.ts:1052:335 - (ae-forgotten-export) The symbol "i1_2" needs to be exported by the entry point clr-angular-data.d.ts
+// dist/clr-angular/types/clr-angular-data-datagrid.d.ts:1051:335 - (ae-forgotten-export) The symbol "i1_2" needs to be exported by the entry point clr-angular-data.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/projects/angular/data/datagrid/datagrid-action-overflow.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-action-overflow.spec.ts
@@ -109,6 +109,18 @@ export default function (): void {
       const firstButton: HTMLButtonElement = context.testComponent.actionItem.nativeElement;
       expectActiveElementToBe(firstButton);
     });
+
+    it('stops click event propagation when the toggle button is clicked', function () {
+      let propagatedToParent = false;
+      context.testElement.addEventListener('click', () => {
+        propagatedToParent = true;
+      });
+
+      toggle.click();
+      context.detectChanges();
+
+      expect(propagatedToParent).toBe(false);
+    });
   });
 }
 

--- a/projects/angular/data/datagrid/datagrid-action-overflow.ts
+++ b/projects/angular/data/datagrid/datagrid-action-overflow.ts
@@ -125,7 +125,6 @@ export class ClrDatagridActionOverflow implements OnDestroy {
   }
 
   openActionStopPropagation(event: MouseEvent) {
-    event.preventDefault();
     event.stopPropagation();
   }
 

--- a/projects/angular/data/datagrid/datagrid-action-overflow.ts
+++ b/projects/angular/data/datagrid/datagrid-action-overflow.ts
@@ -37,6 +37,7 @@ let clrDgActionId = 0;
       [attr.aria-label]="buttonLabel || commonStrings.keys.rowActions"
       clrPopoverOrigin
       clrPopoverOpenCloseButton
+      (click)="openActionStopPropagation($event)"
     >
       <cds-icon shape="ellipsis-vertical" [attr.title]="buttonLabel || commonStrings.keys.rowActions"></cds-icon>
     </button>
@@ -121,6 +122,11 @@ export class ClrDatagridActionOverflow implements OnDestroy {
 
   closeOverflowContent(event: Event): void {
     this.popoverService.toggleWithEvent(event);
+  }
+
+  openActionStopPropagation(event: MouseEvent) {
+    event.preventDefault();
+    event.stopPropagation();
   }
 
   private initializeFocus(): void {

--- a/projects/angular/data/datagrid/datagrid-action-overflow.ts
+++ b/projects/angular/data/datagrid/datagrid-action-overflow.ts
@@ -37,7 +37,7 @@ let clrDgActionId = 0;
       [attr.aria-label]="buttonLabel || commonStrings.keys.rowActions"
       clrPopoverOrigin
       clrPopoverOpenCloseButton
-      (click)="openActionStopPropagation($event)"
+      (click)="$event.stopPropagation()"
     >
       <cds-icon shape="ellipsis-vertical" [attr.title]="buttonLabel || commonStrings.keys.rowActions"></cds-icon>
     </button>
@@ -122,10 +122,6 @@ export class ClrDatagridActionOverflow implements OnDestroy {
 
   closeOverflowContent(event: Event): void {
     this.popoverService.toggleWithEvent(event);
-  }
-
-  openActionStopPropagation(event: MouseEvent) {
-    event.stopPropagation();
   }
 
   private initializeFocus(): void {

--- a/projects/angular/data/datagrid/datagrid-row.html
+++ b/projects/angular/data/datagrid/datagrid-row.html
@@ -74,7 +74,7 @@
         @if (expand.expandable) { @if (!expand.loading) {
         <button
           tabindex="-1"
-          (click)="toggleExpand()"
+          (click)="toggleExpand($event)"
           type="button"
           class="datagrid-expandable-caret-button"
           [attr.aria-expanded]="expand.expanded"
@@ -97,7 +97,7 @@
         @if (!detailHidden) {
         <button
           tabindex="-1"
-          (click)="detailService.toggle(item, detailButton)"
+          (click)="openDetails($event, detailButton)"
           type="button"
           #detailButton
           class="datagrid-detail-caret-button"

--- a/projects/angular/data/datagrid/datagrid-row.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-row.spec.ts
@@ -558,40 +558,31 @@ export default function (): void {
 
     describe('CDE-2323: Sticky controls do not trigger row selection', function () {
       describe('with expandable rows and action overflow', function () {
-        let fixture: ComponentFixture<RowSelectionWithExpandAndActionTest>;
-        let nativeElement: HTMLElement;
+        let context: TestContext<ClrDatagridRow<Item>, RowSelectionWithExpandAndActionTest>;
 
         beforeEach(function () {
-          TestBed.configureTestingModule({
-            imports: [ClrDatagridModule, NoopAnimationsModule],
-            declarations: [RowSelectionWithExpandAndActionTest],
-            providers: [AnimationBuilder],
-          });
-
-          fixture = TestBed.createComponent(RowSelectionWithExpandAndActionTest);
-          nativeElement = fixture.nativeElement;
-          fixture.detectChanges();
-        });
-
-        afterEach(function () {
-          fixture.destroy();
+          context = this.create(ClrDatagridRow, RowSelectionWithExpandAndActionTest, DATAGRID_SPEC_PROVIDERS);
+          context.detectChanges();
         });
 
         it('does not select the row when the action overflow toggle is clicked', function () {
-          expect(fixture.componentInstance.selected).toEqual([]);
-          const actionToggle: HTMLButtonElement = nativeElement.querySelector('.datagrid-action-toggle');
+          expect(context.testComponent.selected).toEqual([]);
+          const actionToggle: HTMLButtonElement = context.clarityElement.querySelector('.datagrid-action-toggle');
           actionToggle.click();
-          fixture.detectChanges();
-          expect(fixture.componentInstance.selected).toEqual([]);
+          context.detectChanges();
+          expect(context.testComponent.selected).toEqual([]);
         });
 
         it('does not select the row when the expand caret is clicked', async function () {
-          expect(fixture.componentInstance.selected).toEqual([]);
-          const expandCaret: HTMLButtonElement = nativeElement.querySelector('.datagrid-expandable-caret-button');
+          expect(context.testComponent.selected).toEqual([]);
+          const expandCaret: HTMLButtonElement = context.clarityElement.querySelector(
+            '.datagrid-expandable-caret button'
+          );
           expandCaret.click();
+          context.detectChanges();
           await delay();
-          fixture.detectChanges();
-          expect(fixture.componentInstance.selected).toEqual([]);
+          context.detectChanges();
+          expect(context.testComponent.selected).toEqual([]);
         });
       });
 
@@ -615,10 +606,11 @@ export default function (): void {
           fixture.destroy();
         });
 
-        it('does not select the row when the action overflow toggle is clicked', function () {
+        it('does not select the row when the action overflow toggle is clicked', async function () {
           expect(fixture.componentInstance.selected).toEqual([]);
           const actionToggle: HTMLButtonElement = nativeElement.querySelector('.datagrid-action-toggle');
           actionToggle.click();
+          await delay();
           fixture.detectChanges();
           expect(fixture.componentInstance.selected).toEqual([]);
         });
@@ -865,16 +857,20 @@ class DatagridWithDisabledOrHiddenDetails {
  */
 @Component({
   template: `
-    <clr-datagrid [(clrDgSelected)]="selected" [clrDgRowSelection]="true">
-      @for (item of items; track item.id) {
-        <clr-dg-row [clrDgItem]="item">
-          <clr-dg-action-overflow>
-            <button class="action-item">Edit</button>
-          </clr-dg-action-overflow>
-          <clr-dg-cell>{{ item.id }}</clr-dg-cell>
-          <clr-dg-row-detail *clrIfExpanded>Detail {{ item.id }}</clr-dg-row-detail>
-        </clr-dg-row>
-      }
+    <clr-datagrid [(clrDgSelected)]="selected" [clrDgSelectionType]="'multi'" [clrDgRowSelection]="true">
+      <clr-dg-column>ID</clr-dg-column>
+
+      <clr-dg-row
+        *clrDgItems="let item of items"
+        clrDgItem]="item"
+        [clrDgRowSelectionLabel]="'Select row for ' + item.id"
+      >
+        <clr-dg-action-overflow>
+          <button class="action-item">Edit</button>
+        </clr-dg-action-overflow>
+        <clr-dg-cell>{{ item.id }}</clr-dg-cell>
+        <clr-dg-row-detail *clrIfExpanded>Detail {{ item.id }}</clr-dg-row-detail>
+      </clr-dg-row>
     </clr-datagrid>
   `,
   standalone: false,
@@ -887,15 +883,20 @@ class RowSelectionWithExpandAndActionTest {
 /** CDE-2323: detail caret + action overflow with row selection. */
 @Component({
   template: `
-    <clr-datagrid [(clrDgSelected)]="selected" [clrDgRowSelection]="true">
-      @for (item of items; track item.id) {
-        <clr-dg-row [clrDgItem]="item">
-          <clr-dg-action-overflow>
-            <button class="action-item">Edit</button>
-          </clr-dg-action-overflow>
-          <clr-dg-cell>{{ item.id }}</clr-dg-cell>
-        </clr-dg-row>
-      }
+    <clr-datagrid [(clrDgSelected)]="selected" [clrDgSelectionType]="'multi'" [clrDgRowSelection]="true">
+      <clr-dg-column>ID</clr-dg-column>
+
+      <clr-dg-row
+        *clrDgItems="let item of items"
+        clrDgItem]="item"
+        [clrDgRowSelectionLabel]="'Select row for ' + item.id"
+      >
+        <clr-dg-action-overflow>
+          <button class="action-item">Edit</button>
+        </clr-dg-action-overflow>
+        <clr-dg-cell>{{ item.id }}</clr-dg-cell>
+      </clr-dg-row>
+
       <clr-dg-detail *clrIfDetail="let detail">
         <clr-dg-detail-header>Details</clr-dg-detail-header>
         <clr-dg-detail-body>{{ detail.id }}</clr-dg-detail-body>

--- a/projects/angular/data/datagrid/datagrid-row.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-row.spec.ts
@@ -565,6 +565,26 @@ export default function (): void {
           context.detectChanges();
         });
 
+        it('does select deselect the row when the row is clicked', async function () {
+          expect(context.testComponent.selected).toEqual([]);
+          const cell: HTMLButtonElement = context.clarityElement.querySelector(
+            '.datagrid-scrolling-cells .datagrid-cell'
+          );
+
+          // select first row
+          cell.click();
+          await delay();
+          context.detectChanges();
+          expect(context.testComponent.selected.length).toEqual(1);
+          expect(context.testComponent.selected[0].id).toEqual(1);
+
+          // deselect first row
+          cell.click();
+          await delay();
+          context.detectChanges();
+          expect(context.testComponent.selected).toEqual([]);
+        });
+
         it('does not select the row when the action overflow toggle is clicked', function () {
           expect(context.testComponent.selected).toEqual([]);
           const actionToggle: HTMLButtonElement = context.clarityElement.querySelector('.datagrid-action-toggle');
@@ -862,7 +882,7 @@ class DatagridWithDisabledOrHiddenDetails {
 
       <clr-dg-row
         *clrDgItems="let item of items"
-        clrDgItem]="item"
+        [clrDgItem]="item"
         [clrDgRowSelectionLabel]="'Select row for ' + item.id"
       >
         <clr-dg-action-overflow>
@@ -888,7 +908,7 @@ class RowSelectionWithExpandAndActionTest {
 
       <clr-dg-row
         *clrDgItems="let item of items"
-        clrDgItem]="item"
+        [clrDgItem]="item"
         [clrDgRowSelectionLabel]="'Select row for ' + item.id"
       >
         <clr-dg-action-overflow>

--- a/projects/angular/data/datagrid/datagrid-row.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-row.spec.ts
@@ -8,6 +8,7 @@
 import { AnimationBuilder } from '@angular/animations';
 import { ChangeDetectorRef, Component } from '@angular/core';
 import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
 import { delay, TestContext } from '@clr/angular/testing';
 import { LoadingListener } from '@clr/angular/utils';
 
@@ -536,11 +537,101 @@ export default function (): void {
         context.detectChanges();
         expect(context.clarityElement.querySelectorAll('clr-dg-cell').length).toBe(1);
       });
+
+      it('does not propagate click to the parent row when the expand caret is clicked', function () {
+        const rowMaster: HTMLElement = context.clarityElement.querySelector('.datagrid-row-master');
+        let rowMasterClickCount = 0;
+        rowMaster.addEventListener('click', () => rowMasterClickCount++);
+
+        const caret: HTMLButtonElement = context.clarityElement.querySelector('.datagrid-expandable-caret-button');
+        caret.click();
+
+        expect(rowMasterClickCount).toBe(0);
+      });
+
       async function flushAnimations() {
         context.detectChanges();
         await delay();
         context.detectChanges();
       }
+    });
+
+    describe('CDE-2323: Sticky controls do not trigger row selection', function () {
+      describe('with expandable rows and action overflow', function () {
+        let fixture: ComponentFixture<RowSelectionWithExpandAndActionTest>;
+        let nativeElement: HTMLElement;
+
+        beforeEach(function () {
+          TestBed.configureTestingModule({
+            imports: [ClrDatagridModule, NoopAnimationsModule],
+            declarations: [RowSelectionWithExpandAndActionTest],
+            providers: [AnimationBuilder],
+          });
+
+          fixture = TestBed.createComponent(RowSelectionWithExpandAndActionTest);
+          nativeElement = fixture.nativeElement;
+          fixture.detectChanges();
+        });
+
+        afterEach(function () {
+          fixture.destroy();
+        });
+
+        it('does not select the row when the action overflow toggle is clicked', function () {
+          expect(fixture.componentInstance.selected).toEqual([]);
+          const actionToggle: HTMLButtonElement = nativeElement.querySelector('.datagrid-action-toggle');
+          actionToggle.click();
+          fixture.detectChanges();
+          expect(fixture.componentInstance.selected).toEqual([]);
+        });
+
+        it('does not select the row when the expand caret is clicked', async function () {
+          expect(fixture.componentInstance.selected).toEqual([]);
+          const expandCaret: HTMLButtonElement = nativeElement.querySelector('.datagrid-expandable-caret-button');
+          expandCaret.click();
+          await delay();
+          fixture.detectChanges();
+          expect(fixture.componentInstance.selected).toEqual([]);
+        });
+      });
+
+      describe('with detail view and action overflow', function () {
+        let fixture: ComponentFixture<RowSelectionWithDetailAndActionTest>;
+        let nativeElement: HTMLElement;
+
+        beforeEach(function () {
+          TestBed.configureTestingModule({
+            imports: [ClrDatagridModule, NoopAnimationsModule],
+            declarations: [RowSelectionWithDetailAndActionTest],
+            providers: [AnimationBuilder],
+          });
+
+          fixture = TestBed.createComponent(RowSelectionWithDetailAndActionTest);
+          nativeElement = fixture.nativeElement;
+          fixture.detectChanges();
+        });
+
+        afterEach(function () {
+          fixture.destroy();
+        });
+
+        it('does not select the row when the action overflow toggle is clicked', function () {
+          expect(fixture.componentInstance.selected).toEqual([]);
+          const actionToggle: HTMLButtonElement = nativeElement.querySelector('.datagrid-action-toggle');
+          actionToggle.click();
+          fixture.detectChanges();
+          expect(fixture.componentInstance.selected).toEqual([]);
+        });
+
+        it('does not select the row when the detail caret is clicked', async function () {
+          expect(fixture.componentInstance.selected).toEqual([]);
+          const detailCaret: HTMLButtonElement = nativeElement.querySelector('.datagrid-detail-caret-button');
+          detailCaret.click();
+          await delay();
+          fixture.detectChanges();
+          expect(fixture.componentInstance.selected).toEqual([]);
+        });
+      });
     });
 
     describe('Details', function () {
@@ -622,6 +713,21 @@ export default function (): void {
 
         const buttons = context.clarityElement.querySelectorAll('button.datagrid-detail-caret-button');
         expect(buttons.length).toBe(1);
+      });
+
+      it('does not propagate click to the parent row when the detail caret is clicked', async function () {
+        const rowMaster: HTMLElement = context.clarityElement.querySelector('.datagrid-row-master');
+        let rowMasterClickCount = 0;
+        rowMaster.addEventListener('click', () => rowMasterClickCount++);
+
+        const detailButton: HTMLButtonElement = context.clarityElement.querySelector(
+          'button.datagrid-detail-caret-button'
+        );
+        detailButton.click();
+        await delay();
+        context.detectChanges();
+
+        expect(rowMasterClickCount).toBe(0);
       });
     });
   });
@@ -751,4 +857,54 @@ class DatagridWithDisabledOrHiddenDetails {
     this._preState = value;
     this.cdr.detectChanges();
   }
+}
+
+/**
+ * CDE-2323: expand caret + action overflow with row selection.
+ * Note: detail service disables the expand caret, so these are separate components.
+ */
+@Component({
+  template: `
+    <clr-datagrid [(clrDgSelected)]="selected" [clrDgRowSelection]="true">
+      @for (item of items; track item.id) {
+        <clr-dg-row [clrDgItem]="item">
+          <clr-dg-action-overflow>
+            <button class="action-item">Edit</button>
+          </clr-dg-action-overflow>
+          <clr-dg-cell>{{ item.id }}</clr-dg-cell>
+          <clr-dg-row-detail *clrIfExpanded>Detail {{ item.id }}</clr-dg-row-detail>
+        </clr-dg-row>
+      }
+    </clr-datagrid>
+  `,
+  standalone: false,
+})
+class RowSelectionWithExpandAndActionTest {
+  selected: Item[] = [];
+  readonly items: Item[] = [{ id: 1 }, { id: 2 }];
+}
+
+/** CDE-2323: detail caret + action overflow with row selection. */
+@Component({
+  template: `
+    <clr-datagrid [(clrDgSelected)]="selected" [clrDgRowSelection]="true">
+      @for (item of items; track item.id) {
+        <clr-dg-row [clrDgItem]="item">
+          <clr-dg-action-overflow>
+            <button class="action-item">Edit</button>
+          </clr-dg-action-overflow>
+          <clr-dg-cell>{{ item.id }}</clr-dg-cell>
+        </clr-dg-row>
+      }
+      <clr-dg-detail *clrIfDetail="let detail">
+        <clr-dg-detail-header>Details</clr-dg-detail-header>
+        <clr-dg-detail-body>{{ detail.id }}</clr-dg-detail-body>
+      </clr-dg-detail>
+    </clr-datagrid>
+  `,
+  standalone: false,
+})
+class RowSelectionWithDetailAndActionTest {
+  selected: Item[] = [];
+  readonly items: Item[] = [{ id: 1 }, { id: 2 }];
 }

--- a/projects/angular/data/datagrid/datagrid-row.ts
+++ b/projects/angular/data/datagrid/datagrid-row.ts
@@ -239,6 +239,13 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     return this.items.identifyBy;
   }
 
+  openDetails(event: MouseEvent, detailButton: HTMLButtonElement) {
+    event.preventDefault();
+    event.stopPropagation();
+
+    this.detailService.toggle(this.item, detailButton);
+  }
+
   ngOnInit() {
     this.wrappedInjector = new HostWrapper(WrappedRow, this.vcr);
     this.selection.lockItem(this.item, this.clrDgSelectable === false);
@@ -309,7 +316,10 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
     }
   }
 
-  toggleExpand() {
+  toggleExpand(event: MouseEvent) {
+    event.preventDefault();
+    event.stopPropagation();
+
     if (this.expand.expandable) {
       this.expandAnimation.updateStartHeight();
       this.expanded = !this.expanded;

--- a/projects/angular/data/datagrid/datagrid-row.ts
+++ b/projects/angular/data/datagrid/datagrid-row.ts
@@ -240,7 +240,6 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
   }
 
   openDetails(event: MouseEvent, detailButton: HTMLButtonElement) {
-    event.preventDefault();
     event.stopPropagation();
 
     this.detailService.toggle(this.item, detailButton);
@@ -317,7 +316,6 @@ export class ClrDatagridRow<T = any> implements AfterContentInit, AfterViewInit 
   }
 
   toggleExpand(event: MouseEvent) {
-    event.preventDefault();
     event.stopPropagation();
 
     if (this.expand.expandable) {

--- a/projects/demo/src/app/datagrid/selection-row-mode/selection-row-mode.html
+++ b/projects/demo/src/app/datagrid/selection-row-mode/selection-row-mode.html
@@ -44,12 +44,18 @@
     [clrDgItem]="user"
     [clrDgRowSelectionLabel]="'Select row for ' + user.name"
   >
+    <clr-dg-action-overflow>
+      <button class="action-item">Edit</button>
+      <button class="action-item">Delete</button>
+    </clr-dg-action-overflow>
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
     <clr-dg-cell>
       <span class="color-square" [style.backgroundColor]="user.color"></span>
     </clr-dg-cell>
+
+    <clr-dg-row-detail *clrIfExpanded>Lorem ipsum...</clr-dg-row-detail>
   </clr-dg-row>
 
   <clr-dg-footer>{{users.length}} users</clr-dg-footer>
@@ -78,6 +84,10 @@
     [clrDgItem]="user"
     [clrDgRowSelectionLabel]="'Select row for ' + user.name"
   >
+    <clr-dg-action-overflow>
+      <button class="action-item">Edit</button>
+      <button class="action-item">Delete</button>
+    </clr-dg-action-overflow>
     <clr-dg-cell>{{user.id}}</clr-dg-cell>
     <clr-dg-cell>{{user.name}}</clr-dg-cell>
     <clr-dg-cell>{{user.creation | date}}</clr-dg-cell>
@@ -85,6 +95,14 @@
       <span class="color-square" [style.backgroundColor]="user.color"></span>
     </clr-dg-cell>
   </clr-dg-row>
+
+  <clr-dg-detail *clrIfDetail="let detail">
+    <clr-dg-detail-header>HEADER {{detail.name}}</clr-dg-detail-header>
+    <clr-dg-detail-body>
+      <b cds-text="medium">Additional Details</b>
+      {{detail | json}}
+    </clr-dg-detail-body>
+  </clr-dg-detail>
 
   <clr-dg-footer>{{users.length}} users</clr-dg-footer>
 </clr-datagrid>


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The click propagation on system actions (action overflow, details, expand) is NOT stopped and the rows are selected/deselected.

Issue Number: CDE-2323

## What is the new behavior?
The click propagation is stopped on system actions (action overflow, details, expand) and the rows are NOT selected/deselected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information
