### PR TITLE
fix(scss): add interpolation to SASS module variables inside calc expressions

### DIFF
--- a/projects/angular/data/datagrid/_variables.datagrid.scss
+++ b/projects/angular/data/datagrid/_variables.datagrid.scss
@@ -84,7 +84,7 @@ $clr-datagrid-column-separator-expandby: var(--clr-datagrid-column-separator-exp
 $clr-datagrid-icon-size: var(--clr-datagrid-icon-size) !default;
 $clr-datagrid-action-arrow-size: var(--clr-datagrid-action-arrow-size) !default;
 $clr-datagrid-expandable-row-spinner-margin: calc(
-  (tables-variables.$clr-table-cell-height - spinner-variables.$clr-spinner-small-size) / 2
+  (#{tables-variables.$clr-table-cell-height} - #{spinner-variables.$clr-spinner-small-size}) / 2
 );
 // @deprecated in favor of compact mode in density theme
 // using the compact value of spinner-variables.$clr-spinner-small-size as cds-global-space-7

--- a/projects/angular/data/datagrid/_variables.datagrid.scss
+++ b/projects/angular/data/datagrid/_variables.datagrid.scss
@@ -89,7 +89,7 @@ $clr-datagrid-expandable-row-spinner-margin: calc(
 // @deprecated in favor of compact mode in density theme
 // using the compact value of spinner-variables.$clr-spinner-small-size as cds-global-space-7
 $clr-datagrid-compact-expandable-row-spinner-margin: calc(
-  (tables-variables.$clr-table-compact-cell-height - #{tokens.$cds-global-space-7}) / 2
+  (#{tables-variables.$clr-table-compact-cell-height} - #{tokens.$cds-global-space-7}) / 2
 );
 $clr-datagrid-compact-fixed-column-size: calc(
   #{tokens.$cds-global-space-7} + (#{tables-variables.$clr-table-compact-horizontal-padding} * 2)

--- a/projects/angular/forms/datepicker/_variables.datepicker.scss
+++ b/projects/angular/forms/datepicker/_variables.datepicker.scss
@@ -55,8 +55,8 @@ $clr-calendar-width: calc(3 * #{$clr-calendar-btn-size} + (2 * #{$clr-calendar-b
 
 //(7 = 6 date rows + 1 row for calendar switches and month/year pickers) + 1 row for day heading + 2 * 16px padding + 2px for border + 6 * 4px vertical gap for buttons
 $clr-calendar-height: calc(
-  (7 * #{$clr-calendar-header-btn-height}) + $clr-calendar-weekday-height + (2 * #{$clr-calendar-vertical-padding}) +
-    (2 * #{tokens.$cds-alias-object-border-width-100}) + density.$clr-base-gap-s
+  (7 * #{$clr-calendar-header-btn-height}) + #{$clr-calendar-weekday-height} + (2 * #{$clr-calendar-vertical-padding}) +
+    (2 * #{tokens.$cds-alias-object-border-width-100}) + #{density.$clr-base-gap-s}
 );
 
 $clr-monthpicker-min-height: calc(6 * #{$clr-calendar-header-btn-height});

--- a/projects/angular/layout/nav/_variables.subnav.scss
+++ b/projects/angular/layout/nav/_variables.subnav.scss
@@ -18,4 +18,4 @@ $clr-subnav-bgColor: var(--clr-subnav-bg-color) !default;
 $clr-subnav-height: density.$clr-base-row-height-m !default;
 
 // Usage: ../layout/nav/_subnav.clarity.scss
-$clr-nav-shadow: 0 calc(-1 * tokens.$cds-alias-object-border-width-100) 0 var(--clr-nav-box-shadow-color) inset !default;
+$clr-nav-shadow: 0 calc(-1 * #{tokens.$cds-alias-object-border-width-100}) 0 var(--clr-nav-box-shadow-color) inset !default;

--- a/projects/angular/popover/tooltip/_variables.tooltip.scss
+++ b/projects/angular/popover/tooltip/_variables.tooltip.scss
@@ -12,7 +12,7 @@
 $clr-tooltip-arrow-height: #{density.$clr-base-icon-size-xs} !default;
 $clr-tooltip-arrow-width: #{density.$clr-base-icon-size-xs} !default;
 // arrow width/height (12px) + distance (8px)
-$clr-tooltip-adjusted-margin: calc($clr-tooltip-arrow-height + density.$clr-base-vertical-offset-m) !default;
+$clr-tooltip-adjusted-margin: calc(#{$clr-tooltip-arrow-height} + #{density.$clr-base-vertical-offset-m}) !default;
 
 $clr-tooltip-color: var(--clr-tooltip-color) !default;
 $clr-tooltip-background-color: var(--clr-tooltip-background-color) !default;

--- a/projects/angular/timeline/_variables.timeline.scss
+++ b/projects/angular/timeline/_variables.timeline.scss
@@ -20,7 +20,7 @@ $clr-timeline-error-step-color: var(--clr-timeline-error-step-color) !default;
 
 // overall
 $clr-timeline-icon-size: var(--clr-timeline-icon-size);
-$clr-timeline-spinner-size: calc($clr-timeline-icon-size - tokens.$cds-global-space-3);
+$clr-timeline-spinner-size: calc(#{$clr-timeline-icon-size} - #{tokens.$cds-global-space-3});
 $clr-timeline-default-icon-size: #{density.$clr-base-icon-size-s};
 $clr-timeline-line-thickness: #{tokens.$cds-alias-object-border-width-200};
 $clr-timeline-step-internal-spacing: var(--clr-timeline-step-internal-spacing);


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

dart-sass cannot evaluate SASS module-namespaced variables that resolve to CSS custom properties (`var(--)`) when they appear bare (without `#{}` interpolation) inside `calc()` expressions in SASS variable definitions. This causes build failures or incorrect CSS output.

The pattern:
```scss
$foo: calc(module.$some-var - other-module.$other-var);
```

fails because SASS tries to perform arithmetic on `var(--...)` values.

Issue Number: N/A

## What is the new behavior?

All bare SASS module variable references inside `calc()` expressions in SCSS variable definition files are now wrapped with `#{}` interpolation, forcing dart-sass to treat them as string substitution rather than SASS arithmetic:

```scss
$foo: calc(#{module.$some-var} - #{other-module.$other-var});
```

**Files fixed:**
- `projects/angular/data/datagrid/_variables.datagrid.scss` — expandable row spinner margin variables
- `projects/angular/forms/datepicker/_variables.datepicker.scss` — calendar height calculation
- `projects/angular/popover/tooltip/_variables.tooltip.scss` — tooltip adjusted margin
- `projects/angular/timeline/_variables.timeline.scss` — timeline spinner size
- `projects/angular/layout/nav/_variables.subnav.scss` — nav shadow

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information