### PR TITLE
fix(datagrid): prevent column header icons from being hidden on resize

### DIFF
--- a/projects/angular/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/data/datagrid/_datagrid.clarity.scss
@@ -442,6 +442,7 @@
       .datagrid-filter-toggle {
         @include mixins.clr-no-styles-button();
 
+        flex-shrink: 0; // prevent icon from being compressed when column is narrow
         cursor: pointer;
         float: right;
         vertical-align: middle;
@@ -486,6 +487,7 @@
       .datagrid-column-flex {
         display: flex;
         flex: 1 1 auto;
+        min-width: 0;
       }
 
       .datagrid-column-title {
@@ -494,9 +496,11 @@
         color: tables-variables.$clr-table-font-color;
         text-align: left;
         flex: 1 1 auto;
+        min-width: 0;
         align-items: center;
         align-self: center;
         display: flex;
+        overflow: hidden;
 
         .signpost .signpost-action.btn {
           height: inherit;
@@ -516,6 +520,7 @@
         }
 
         .sort-icon {
+          flex-shrink: 0; // prevent icon from being compressed when column is narrow
           color: tokens.$cds-alias-object-interaction-color;
           margin-left: auto; // pushes icon to rhs b/c of parents display: flex
 


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

Sort and filter icons in datagrid column headers get clipped and hidden when the column is resized to a small width, because the flex container shrinks all children uniformly.

Issue Number: CDE-3129

## What is the new behavior?

Icons now have `flex-shrink: 0` so they are never clipped during resize. `overflow: hidden` is scoped to the column title element only, so the resize handle affordance remains intact.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information