### PR TITLE
fix(stepper): prevent step button from submitting parent form and fix navigation logic

### DIFF
--- a/projects/angular/clarity.api.md
+++ b/projects/angular/clarity.api.md
@@ -5469,7 +5469,7 @@ export class ClrStartDateInputValidator implements Validator {
 export class ClrStepButton implements OnInit {
     constructor(clrStep: ClrStepperPanel, stepperService: StepperService);
     // (undocumented)
-    navigateToNextPanel(): void;
+    navigateToNextPanel(event: Event): void;
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)

--- a/projects/angular/stepper/step-button.spec.ts
+++ b/projects/angular/stepper/step-button.spec.ts
@@ -103,6 +103,34 @@ describe('ClrStepButton Next', () => {
   });
 });
 
+describe('ClrStepButton Custom type', () => {
+  let fixture: ComponentFixture<any>;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [TestComponent],
+      providers: [StepperService, { provide: StepperService, useClass: MockStepperService }],
+      imports: [ReactiveFormsModule, NoopAnimationsModule, ClrStepperModule],
+    });
+
+    fixture = TestBed.createComponent(TestComponent);
+    fixture.componentInstance.buttonType = 'custom' as ClrStepButtonType;
+    fixture.detectChanges();
+  });
+
+  it('should not navigate when button type is not next, previous, or submit', () => {
+    const stepperService = fixture.debugElement.query(By.directive(ClrStepButton)).injector.get(StepperService);
+    spyOn(stepperService, 'navigateToNextPanel');
+    spyOn(stepperService, 'navigateToPreviousPanel');
+
+    fixture.nativeElement.querySelector('.clr-step-button').click();
+    fixture.detectChanges();
+
+    expect(stepperService.navigateToNextPanel).not.toHaveBeenCalled();
+    expect(stepperService.navigateToPreviousPanel).not.toHaveBeenCalled();
+  });
+});
+
 describe('ClrStepButton Previous', () => {
   let fixture: ComponentFixture<any>;
 

--- a/projects/angular/stepper/step-button.spec.ts
+++ b/projects/angular/stepper/step-button.spec.ts
@@ -88,6 +88,19 @@ describe('ClrStepButton Next', () => {
     fixture.detectChanges();
     expect(stepperService.navigateToNextPanel).toHaveBeenCalled();
   });
+
+  it('should have type="button" attribute set on the host element', () => {
+    const btn = fixture.debugElement.query(By.directive(ClrStepButton));
+    expect(btn.nativeElement.getAttribute('type')).toBe('button');
+  });
+
+  it('should prevent default on click to avoid form submission', () => {
+    const btn = fixture.debugElement.query(By.directive(ClrStepButton));
+    const event = new MouseEvent('click', { bubbles: true, cancelable: true });
+    const preventDefaultSpy = spyOn(event, 'preventDefault');
+    btn.nativeElement.dispatchEvent(event);
+    expect(preventDefaultSpy).toHaveBeenCalled();
+  });
 });
 
 describe('ClrStepButton Previous', () => {

--- a/projects/angular/stepper/step-button.ts
+++ b/projects/angular/stepper/step-button.ts
@@ -21,7 +21,7 @@ export enum ClrStepButtonType {
   host: {
     '[class.clr-step-button]': 'true',
     '[class.btn]': 'true',
-    '[type]': "'button'",
+    '[attr.type]': "'button'",
   },
   standalone: false,
 })
@@ -40,8 +40,9 @@ export class ClrStepButton implements OnInit {
     this.previousButton = this.type === ClrStepButtonType.Previous;
   }
 
-  @HostListener('click')
-  navigateToNextPanel() {
+  @HostListener('click', ['$event'])
+  navigateToNextPanel(event: Event) {
+    event.preventDefault();
     if (this.previousButton) {
       this.stepperService.navigateToPreviousPanel(this.clrStep.id);
       return;

--- a/projects/angular/stepper/step-button.ts
+++ b/projects/angular/stepper/step-button.ts
@@ -43,11 +43,10 @@ export class ClrStepButton implements OnInit {
   @HostListener('click', ['$event'])
   navigateToNextPanel(event: Event) {
     event.preventDefault();
-    if (this.previousButton) {
+    if (this.type === ClrStepButtonType.Previous) {
       this.stepperService.navigateToPreviousPanel(this.clrStep.id);
-      return;
+    } else if (this.type === ClrStepButtonType.Next || this.type === ClrStepButtonType.Submit) {
+      this.stepperService.navigateToNextPanel(this.clrStep.id, this.clrStep.formGroup.valid);
     }
-
-    this.stepperService.navigateToNextPanel(this.clrStep.id, this.clrStep.formGroup.valid);
   }
 }

--- a/projects/angular/stepper/stepper.api.md
+++ b/projects/angular/stepper/stepper.api.md
@@ -34,7 +34,7 @@ import { Type } from '@angular/core';
 export class ClrStepButton implements OnInit {
     constructor(clrStep: ClrStepperPanel, stepperService: StepperService);
     // (undocumented)
-    navigateToNextPanel(): void;
+    navigateToNextPanel(event: Event): void;
     // (undocumented)
     ngOnInit(): void;
     // (undocumented)


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

Two related bugs in `ClrStepButton`:

1. The button used `[type]="'button'"` (Angular property binding), which sets the DOM property but not the HTML attribute. Browsers default the `type` attribute to `submit`, causing the button to submit any parent `<form>` on click.

2. Navigation logic used `if (this.previousButton) ... else navigateToNextPanel()`, meaning any button type that was not `previous` — including custom string types — would unconditionally call `navigateToNextPanel()`.

Issue Number: CDE-3004

## What is the new behavior?

1. The button now uses `[attr.type]="'button'"` to set the HTML attribute directly.

2. Navigation is now gated on explicit enum checks: only `ClrStepButtonType.Next` and `ClrStepButtonType.Submit` navigate forward; only `ClrStepButtonType.Previous` navigates backward. Custom or unknown button types perform no navigation.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information