### PR TITLE
fix(datagrid): revalidate CDK viewport size when rows expand/collapse

### DIFF
--- a/projects/angular/data/datagrid/datagrid-virtual-scroll-strategy.ts
+++ b/projects/angular/data/datagrid/datagrid-virtual-scroll-strategy.ts
@@ -1,0 +1,285 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ListRange } from '@angular/cdk/collections';
+import { CdkVirtualScrollViewport, VirtualScrollStrategy } from '@angular/cdk/scrolling';
+import { Observable, Subject } from 'rxjs';
+import { distinctUntilChanged } from 'rxjs/operators';
+
+/**
+ * Virtual scroll strategy for the datagrid. It behaves exactly like CDK's
+ * FixedSizeVirtualScrollStrategy (every row is `itemSize` tall), except that a row can report an
+ * extra height on top of `itemSize` via `setItemExtraHeight()` - used for any row whose real
+ * rendered height ends up taller than itemSize, for whatever reason (expandable detail content,
+ * dynamically sized cell content, etc.). Total content size and the scroll offset / rendered-
+ * range math both account for that extra height so the CDK viewport stays in sync with the real
+ * DOM instead of the fixed-size assumption.
+ *
+ * When no row reports extra height this strategy is numerically identical to
+ * FixedSizeVirtualScrollStrategy: every `offsetForIndex(i)` call reduces to `i * itemSize`.
+ *
+ * This is deliberately not @angular/cdk-experimental's AutoSizeVirtualScrollStrategy. That
+ * strategy assumes item sizes are entirely unknown and tracks a running *average* from whatever
+ * is currently rendered, estimating everything else from it - which is why it can't support
+ * scrollToIndex/scrolledIndexChange (an averaged position isn't precise) and needs drift-
+ * correction machinery (offset correction while scrolling, backing off when an estimated removal
+ * turns out unsafe) to cope with its own estimates being wrong. The datagrid has a known,
+ * deterministic itemSize; rows are that size except when something (expansion, dynamic content)
+ * makes a specific one taller. Tracking exact extra height per row we've actually measured - and
+ * assuming itemSize for anything we haven't - gives exact (not estimated) math, so none of that
+ * drift-correction is needed and scrollToIndex/scrolledIndexChange stay precise.
+ */
+export class ClrDatagridVirtualScrollStrategy implements VirtualScrollStrategy {
+  scrolledIndexChange: Observable<number>;
+
+  private readonly _scrolledIndexChange = new Subject<number>();
+  private viewport: CdkVirtualScrollViewport | null = null;
+
+  // Extra height (beyond itemSize) contributed by an expanded row's detail content, keyed by
+  // data index. A row with no entry here is assumed to be exactly itemSize tall. Entries are
+  // deliberately kept for rows that scroll out of the rendered range - we can no longer measure
+  // them, but their real height still counts towards the total scrollable content size, so
+  // clearing them here would shrink the scrollbar every time an expanded row is virtualized away.
+  private extraHeights = new Map<number, number>();
+  private sortedIndexesDirty = false;
+  private sortedIndexes: number[] = [];
+  private prefixExtraHeights: number[] = [];
+
+  constructor(
+    private itemSize: number,
+    private minBufferPx: number,
+    private maxBufferPx: number
+  ) {
+    this.scrolledIndexChange = this._scrolledIndexChange.pipe(distinctUntilChanged());
+  }
+
+  attach(viewport: CdkVirtualScrollViewport) {
+    this.viewport = viewport;
+    this.updateTotalContentSize();
+    this.updateRenderedRange();
+  }
+
+  detach() {
+    this._scrolledIndexChange.complete();
+    this.viewport = null;
+  }
+
+  updateItemAndBufferSize(itemSize: number, minBufferPx: number, maxBufferPx: number) {
+    if (maxBufferPx < minBufferPx) {
+      throw Error('CDK virtual scroll: maxBufferPx must be greater than or equal to minBufferPx');
+    }
+    this.itemSize = itemSize;
+    this.minBufferPx = minBufferPx;
+    this.maxBufferPx = maxBufferPx;
+    this.updateTotalContentSize();
+    this.updateRenderedRange();
+  }
+
+  onContentScrolled() {
+    this.updateRenderedRange();
+  }
+
+  onDataLengthChanged() {
+    this.updateTotalContentSize();
+    this.updateRenderedRange();
+  }
+
+  onContentRendered() {
+    /* no-op, matches FixedSizeVirtualScrollStrategy */
+  }
+
+  onRenderedOffsetChanged() {
+    /* no-op, matches FixedSizeVirtualScrollStrategy */
+  }
+
+  scrollToIndex(index: number, behavior: ScrollBehavior) {
+    this.viewport?.scrollToOffset(this.offsetForIndex(index), behavior);
+  }
+
+  /**
+   * Registers the real measured height of a row so the scroll math accounts for it. Pass an
+   * extraHeight <= 0 to reset the row back to the base itemSize.
+   */
+  setItemExtraHeight(index: number, extraHeight: number) {
+    if (this.applyItemExtraHeight(index, extraHeight)) {
+      this.updateTotalContentSize();
+      this.updateRenderedRange();
+    }
+  }
+
+  /**
+   * Same as calling setItemExtraHeight() for every entry, but recomputes total content size and
+   * rendered range only once for the whole batch rather than once per row - use this when several
+   * rows are measured at the same time (e.g. from a single ResizeObserver callback).
+   */
+  setItemExtraHeights(extraHeightsByIndex: ReadonlyMap<number, number>) {
+    let changed = false;
+    for (const [index, extraHeight] of extraHeightsByIndex) {
+      changed = this.applyItemExtraHeight(index, extraHeight) || changed;
+    }
+    if (changed) {
+      this.updateTotalContentSize();
+      this.updateRenderedRange();
+    }
+  }
+
+  clearItemExtraHeight(index: number) {
+    if (this.extraHeights.delete(index)) {
+      this.sortedIndexesDirty = true;
+      this.updateTotalContentSize();
+      this.updateRenderedRange();
+    }
+  }
+
+  /** Updates the extraHeights map for a single row. Returns whether anything changed. */
+  private applyItemExtraHeight(index: number, extraHeight: number): boolean {
+    if (extraHeight <= 0) {
+      if (!this.extraHeights.delete(index)) {
+        return false;
+      }
+    } else if (this.extraHeights.get(index) === extraHeight) {
+      return false;
+    } else {
+      this.extraHeights.set(index, extraHeight);
+    }
+    this.sortedIndexesDirty = true;
+    return true;
+  }
+
+  private rebuildSortedIndexesIfNeeded() {
+    if (!this.sortedIndexesDirty) {
+      return;
+    }
+    this.sortedIndexes = Array.from(this.extraHeights.keys()).sort((a, b) => a - b);
+    let sum = 0;
+    this.prefixExtraHeights = this.sortedIndexes.map(index => (sum += this.extraHeights.get(index) as number));
+    this.sortedIndexesDirty = false;
+  }
+
+  /** Sum of extra heights for every expanded row at a data index strictly less than `index`. */
+  private cumulativeExtraHeightBefore(index: number): number {
+    this.rebuildSortedIndexesIfNeeded();
+    if (!this.sortedIndexes.length) {
+      return 0;
+    }
+    let low = 0;
+    let high = this.sortedIndexes.length;
+    while (low < high) {
+      const mid = (low + high) >>> 1;
+      if (this.sortedIndexes[mid] < index) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    return low === 0 ? 0 : this.prefixExtraHeights[low - 1];
+  }
+
+  private totalExtraHeight(): number {
+    this.rebuildSortedIndexesIfNeeded();
+    return this.prefixExtraHeights.length ? this.prefixExtraHeights[this.prefixExtraHeights.length - 1] : 0;
+  }
+
+  /** Pixel offset of the top edge of `index`, accounting for any expanded rows before it. */
+  private offsetForIndex(index: number): number {
+    return index * this.itemSize + this.cumulativeExtraHeightBefore(index);
+  }
+
+  /** Largest index in [0, dataLength] whose offsetForIndex() does not exceed `offset`. */
+  private indexForOffset(offset: number, dataLength: number): number {
+    if (offset <= 0 || dataLength <= 0) {
+      return 0;
+    }
+    let low = 0;
+    let high = dataLength;
+    while (low < high) {
+      const mid = Math.ceil((low + high) / 2);
+      if (this.offsetForIndex(mid) <= offset) {
+        low = mid;
+      } else {
+        high = mid - 1;
+      }
+    }
+    return low;
+  }
+
+  /** Smallest index in [0, dataLength] whose offsetForIndex() is at least `offset`. */
+  private endIndexForOffset(offset: number, dataLength: number): number {
+    if (offset <= 0) {
+      return 0;
+    }
+    if (this.offsetForIndex(dataLength) <= offset) {
+      return dataLength;
+    }
+    let low = 0;
+    let high = dataLength;
+    while (low < high) {
+      const mid = Math.floor((low + high) / 2);
+      if (this.offsetForIndex(mid) < offset) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+    return low;
+  }
+
+  private updateTotalContentSize() {
+    if (!this.viewport) {
+      return;
+    }
+    const dataLength = this.viewport.getDataLength();
+    this.viewport.setTotalContentSize(dataLength * this.itemSize + this.totalExtraHeight());
+  }
+
+  private updateRenderedRange() {
+    if (!this.viewport) {
+      return;
+    }
+    const renderedRange = this.viewport.getRenderedRange();
+    const newRange: ListRange = { start: renderedRange.start, end: renderedRange.end };
+    const viewportSize = this.viewport.getViewportSize();
+    const dataLength = this.viewport.getDataLength();
+    let scrollOffset = this.viewport.measureScrollOffset();
+
+    if (newRange.end > dataLength) {
+      // Walking back from the end of the list, find the start index whose remaining content
+      // still fills the viewport - mirrors FixedSizeVirtualScrollStrategy's tail-clamping.
+      const newStart = this.indexForOffset(this.offsetForIndex(dataLength) - viewportSize, dataLength);
+      if (newStart !== newRange.start) {
+        newRange.start = newStart;
+        scrollOffset = this.offsetForIndex(newStart);
+      }
+      newRange.end = Math.max(0, Math.min(dataLength, this.endIndexForOffset(scrollOffset + viewportSize, dataLength)));
+    }
+
+    const startBuffer = scrollOffset - this.offsetForIndex(newRange.start);
+    if (startBuffer < this.minBufferPx && newRange.start !== 0) {
+      newRange.start = Math.max(0, this.indexForOffset(scrollOffset - this.maxBufferPx, dataLength));
+      newRange.end = Math.min(
+        dataLength,
+        this.endIndexForOffset(scrollOffset + viewportSize + this.minBufferPx, dataLength)
+      );
+    } else {
+      const endBuffer = this.offsetForIndex(newRange.end) - (scrollOffset + viewportSize);
+      if (endBuffer < this.minBufferPx && newRange.end !== dataLength) {
+        const newEnd = Math.min(
+          dataLength,
+          this.endIndexForOffset(scrollOffset + viewportSize + this.maxBufferPx, dataLength)
+        );
+        if (newEnd > newRange.end) {
+          newRange.end = newEnd;
+          newRange.start = Math.max(0, this.indexForOffset(scrollOffset - this.minBufferPx, dataLength));
+        }
+      }
+    }
+
+    this.viewport.setRenderedRange(newRange);
+    this.viewport.setRenderedContentOffset(Math.round(this.offsetForIndex(newRange.start)));
+    this._scrolledIndexChange.next(this.indexForOffset(scrollOffset, dataLength));
+  }
+}

--- a/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
@@ -329,9 +329,11 @@ export default function (): void {
 
       it('attaches a ResizeObserver to the datagrid rows container on init', async function () {
         // Spy on ResizeObserver before detectChanges so we intercept the constructor call.
+        let capturedCallback: ResizeObserverCallback | null = null;
         const observeSpy = jasmine.createSpy('observe');
         const disconnectSpy = jasmine.createSpy('disconnect');
-        const resizeObserverSpy = jasmine.createSpy('ResizeObserver').and.callFake(function () {
+        const resizeObserverSpy = jasmine.createSpy('ResizeObserver').and.callFake(function (cb: ResizeObserverCallback) {
+          capturedCallback = cb;
           return { observe: observeSpy, disconnect: disconnectSpy };
         });
 
@@ -352,41 +354,45 @@ export default function (): void {
         } finally {
           (window as any).ResizeObserver = originalResizeObserver;
         }
-
-        fixture.destroy();
       });
 
       it('calls checkViewportSize() when the rows container height changes', async function () {
-        fixture.detectChanges();
-        await delay();
-        fixture.detectChanges();
+        // Intercept ResizeObserver construction to capture the callback.
+        let capturedCallback: ResizeObserverCallback | null = null;
+        const originalResizeObserver = (window as any).ResizeObserver;
+        (window as any).ResizeObserver = jasmine.createSpy('ResizeObserver').and.callFake(function (cb: ResizeObserverCallback) {
+          capturedCallback = cb;
+          return { observe: () => {}, disconnect: () => {} };
+        });
 
-        const virtualScroll = instance.virtualScroll as ClrDatagridVirtualScrollDirective<any>;
-        // Access internal viewport via the directive instance (same pattern used in production code).
-        const viewport = (virtualScroll as any).virtualScrollViewport;
-        const checkSpy = spyOn(viewport, 'checkViewportSize').and.callThrough();
+        try {
+          fixture.detectChanges();
+          await delay();
+          fixture.detectChanges();
 
-        // Simulate a ResizeObserver callback as if a row has expanded and changed height.
-        // We fire the stored callback directly through the private field.
-        const resizeObserver: ResizeObserver = (virtualScroll as any).rowsResizeObserver;
-        expect(resizeObserver).toBeTruthy();
+          const virtualScroll = instance.virtualScroll as ClrDatagridVirtualScrollDirective<any>;
+          // Access internal viewport via the directive instance (same pattern used in production code).
+          const viewport = (virtualScroll as any).virtualScrollViewport;
+          const checkSpy = spyOn(viewport, 'checkViewportSize').and.callThrough();
 
-        // Trigger a simulated resize entry. We call the observer's callback manually.
-        // Cast to any to reach the private constructor callback stored in the closure.
-        const datagridRowsElement =
-          fixture.nativeElement.querySelector('.datagrid-rows') as HTMLElement;
+          expect(capturedCallback).not.toBeNull();
 
-        // Initial fire (sets initialHeight) — should NOT trigger checkViewportSize.
-        resizeObserver.unobserve(datagridRowsElement);
-        // Re-observe so we get a fresh initial callback in the existing ResizeObserver.
-        // Instead of controlling the browser's ResizeObserver timing, we test by toggling
-        // a row and verifying the internal ResizeObserver disconnect/cleanup path:
-        // just verify the internal observer was created and is non-null.
-        expect((virtualScroll as any).rowsResizeObserver).not.toBeNull();
+          const makeEntry = (blockSize: number): ResizeObserverEntry =>
+            ({
+              borderBoxSize: [{ blockSize, inlineSize: 0 }],
+              contentRect: { height: blockSize } as DOMRectReadOnly,
+            }) as ResizeObserverEntry;
 
-        fixture.destroy();
-        // After destroy the observer should be null.
-        expect((virtualScroll as any).rowsResizeObserver).toBeNull();
+          // First fire: sets initialHeight — should NOT trigger checkViewportSize.
+          capturedCallback!([makeEntry(100)], null as any);
+          expect(checkSpy).not.toHaveBeenCalled();
+
+          // Second fire with a different blockSize: should trigger checkViewportSize.
+          capturedCallback!([makeEntry(200)], null as any);
+          expect(checkSpy).toHaveBeenCalled();
+        } finally {
+          (window as any).ResizeObserver = originalResizeObserver;
+        }
       });
 
       it('disconnects the ResizeObserver on ngOnDestroy', async function () {

--- a/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
@@ -306,5 +306,114 @@ export default function (): void {
         fixture.changeDetectorRef.detach();
       });
     });
+
+    describe('Expanded row virtual scroll (CDE-3126)', function () {
+      let fixture: ComponentFixture<any>;
+      let instance: any;
+
+      beforeEach(async function () {
+        await TestBed.configureTestingModule({
+          imports: [ClarityModule, NoopAnimationsModule],
+          declarations: [FullTest, ClrDatagridVirtualScrollDirective],
+          schemas: [CUSTOM_ELEMENTS_SCHEMA],
+          providers: DATAGRID_SPEC_PROVIDERS,
+        }).compileComponents();
+
+        fixture = TestBed.createComponent(FullTest);
+        instance = fixture.componentInstance;
+      });
+
+      afterEach(() => {
+        fixture.destroy();
+      });
+
+      it('attaches a ResizeObserver to the datagrid rows container on init', async function () {
+        // Spy on ResizeObserver before detectChanges so we intercept the constructor call.
+        const observeSpy = jasmine.createSpy('observe');
+        const disconnectSpy = jasmine.createSpy('disconnect');
+        const resizeObserverSpy = jasmine.createSpy('ResizeObserver').and.callFake(function () {
+          return { observe: observeSpy, disconnect: disconnectSpy };
+        });
+
+        const originalResizeObserver = (window as any).ResizeObserver;
+        (window as any).ResizeObserver = resizeObserverSpy;
+
+        try {
+          fixture.detectChanges();
+          await delay();
+          fixture.detectChanges();
+
+          expect(resizeObserverSpy).toHaveBeenCalled();
+          expect(observeSpy).toHaveBeenCalled();
+
+          // The observed element should be the .datagrid-rows container.
+          const observedElement = observeSpy.calls.mostRecent().args[0] as HTMLElement;
+          expect(observedElement.classList.contains('datagrid-rows')).toBeTrue();
+        } finally {
+          (window as any).ResizeObserver = originalResizeObserver;
+        }
+
+        fixture.destroy();
+      });
+
+      it('calls checkViewportSize() when the rows container height changes', async function () {
+        fixture.detectChanges();
+        await delay();
+        fixture.detectChanges();
+
+        const virtualScroll = instance.virtualScroll as ClrDatagridVirtualScrollDirective<any>;
+        // Access internal viewport via the directive instance (same pattern used in production code).
+        const viewport = (virtualScroll as any).virtualScrollViewport;
+        const checkSpy = spyOn(viewport, 'checkViewportSize').and.callThrough();
+
+        // Simulate a ResizeObserver callback as if a row has expanded and changed height.
+        // We fire the stored callback directly through the private field.
+        const resizeObserver: ResizeObserver = (virtualScroll as any).rowsResizeObserver;
+        expect(resizeObserver).toBeTruthy();
+
+        // Trigger a simulated resize entry. We call the observer's callback manually.
+        // Cast to any to reach the private constructor callback stored in the closure.
+        const datagridRowsElement =
+          fixture.nativeElement.querySelector('.datagrid-rows') as HTMLElement;
+
+        // Initial fire (sets initialHeight) — should NOT trigger checkViewportSize.
+        resizeObserver.unobserve(datagridRowsElement);
+        // Re-observe so we get a fresh initial callback in the existing ResizeObserver.
+        // Instead of controlling the browser's ResizeObserver timing, we test by toggling
+        // a row and verifying the internal ResizeObserver disconnect/cleanup path:
+        // just verify the internal observer was created and is non-null.
+        expect((virtualScroll as any).rowsResizeObserver).not.toBeNull();
+
+        fixture.destroy();
+        // After destroy the observer should be null.
+        expect((virtualScroll as any).rowsResizeObserver).toBeNull();
+      });
+
+      it('disconnects the ResizeObserver on ngOnDestroy', async function () {
+        let capturedDisconnect: jasmine.Spy | null = null;
+
+        const originalResizeObserver = (window as any).ResizeObserver;
+        (window as any).ResizeObserver = jasmine.createSpy('ResizeObserver').and.callFake(function (cb: ResizeObserverCallback) {
+          const disconnectSpy = jasmine.createSpy('disconnect');
+          capturedDisconnect = disconnectSpy;
+          return { observe: () => {}, disconnect: disconnectSpy };
+        });
+
+        try {
+          fixture.detectChanges();
+          await delay();
+          fixture.detectChanges();
+
+          expect(capturedDisconnect).not.toBeNull();
+          expect(capturedDisconnect!).not.toHaveBeenCalled();
+
+          fixture.destroy();
+
+          expect(capturedDisconnect!).toHaveBeenCalledTimes(1);
+        } finally {
+          (window as any).ResizeObserver = originalResizeObserver;
+        }
+      });
+    });
   });
 }

--- a/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
@@ -60,7 +60,7 @@ export interface Cells {
           >
             <clr-dg-row [clrDgItem]="row">
               @for (col of cols; track colByIndex($index, col)) {
-                <clr-dg-cell>{{ row?.cells[col.name] }}</clr-dg-cell>
+                <clr-dg-cell style="white-space: nowrap">{{ row?.cells[col.name] }}</clr-dg-cell>
               }
               <ng-container ngProjectAs="clr-dg-row-detail">
                 <clr-dg-row-detail *clrIfExpanded>
@@ -327,74 +327,80 @@ export default function (): void {
         fixture.destroy();
       });
 
-      it('attaches a ResizeObserver to the datagrid rows container on init', async function () {
-        // Spy on ResizeObserver before detectChanges so we intercept the constructor call.
-        const observeSpy = jasmine.createSpy('observe');
-        const disconnectSpy = jasmine.createSpy('disconnect');
-        const resizeObserverSpy = jasmine.createSpy('ResizeObserver').and.callFake(function (
-          _cb: ResizeObserverCallback
-        ) {
-          return { observe: observeSpy, disconnect: disconnectSpy };
-        });
+      async function expandFirstRow(compiled: any, fixture: ComponentFixture<any>) {
+        const caretButton: HTMLButtonElement = compiled.querySelector('button.datagrid-expandable-caret-button');
+        caretButton.click();
+        fixture.detectChanges();
+        await delay(50);
+        fixture.detectChanges();
+        await delay(50);
+        fixture.detectChanges();
+      }
 
-        const originalResizeObserver = (window as any).ResizeObserver;
-        (window as any).ResizeObserver = resizeObserverSpy;
+      it('grows and shrinks the total scrollable content size to match an expanded row real height', async function () {
+        const compiled = fixture.nativeElement;
 
-        try {
-          fixture.detectChanges();
-          await delay();
-          fixture.detectChanges();
+        fixture.detectChanges();
+        await delay();
+        fixture.detectChanges();
+        await delay();
 
-          expect(resizeObserverSpy).toHaveBeenCalled();
-          expect(observeSpy).toHaveBeenCalled();
+        const virtualScroll = instance.virtualScroll as ClrDatagridVirtualScrollDirective<any>;
+        const rowMaster: HTMLElement = compiled.querySelector('.datagrid-row-master[role="row"]');
 
-          // The observed element should be the .datagrid-rows container.
-          const observedElement = observeSpy.calls.mostRecent().args[0] as HTMLElement;
-          expect(observedElement.classList.contains('datagrid-rows')).toBeTrue();
-        } finally {
-          (window as any).ResizeObserver = originalResizeObserver;
-        }
+        const collapsedTotalHeight = parseFloat(virtualScroll.totalContentHeight);
+        const collapsedRowHeight = rowMaster.getBoundingClientRect().height;
+
+        await expandFirstRow(compiled, fixture);
+
+        const expandedRowHeight = rowMaster.getBoundingClientRect().height;
+        const expandedTotalHeight = parseFloat(virtualScroll.totalContentHeight);
+
+        // Sanity check: the row detail actually added real height in the DOM.
+        expect(expandedRowHeight).toBeGreaterThan(collapsedRowHeight);
+
+        // The bug: FixedSizeVirtualScrollStrategy's total content size is dataLength * itemSize,
+        // a value with no dependency on any row's real DOM height, so it never changes here.
+        // The fix must make it track the real height that was just added.
+        expect(expandedTotalHeight - collapsedTotalHeight).toBeCloseTo(expandedRowHeight - collapsedRowHeight, -1);
+
+        // Collapse it again and confirm the total size comes back down.
+        await expandFirstRow(compiled, fixture);
+        const collapsedAgainTotalHeight = parseFloat(virtualScroll.totalContentHeight);
+        expect(collapsedAgainTotalHeight).toBeCloseTo(collapsedTotalHeight, -1);
       });
 
-      it('calls checkViewportSize() when the rows container height changes', async function () {
-        // Intercept ResizeObserver construction to capture the callback.
-        let capturedCallback: ResizeObserverCallback | null = null;
-        const originalResizeObserver = (window as any).ResizeObserver;
-        (window as any).ResizeObserver = jasmine.createSpy('ResizeObserver').and.callFake(function (
-          cb: ResizeObserverCallback
-        ) {
-          capturedCallback = cb;
-          return { observe: () => {}, disconnect: () => {} };
-        });
+      it('accounts for an expanded row extra height when scrolling to an index past it', async function () {
+        const compiled = fixture.nativeElement;
 
-        try {
-          fixture.detectChanges();
-          await delay();
-          fixture.detectChanges();
+        fixture.detectChanges();
+        await delay();
+        fixture.detectChanges();
+        await delay();
 
-          const virtualScroll = instance.virtualScroll as ClrDatagridVirtualScrollDirective<any>;
-          // Access internal viewport via the directive instance (same pattern used in production code).
-          const viewport = (virtualScroll as any).virtualScrollViewport;
-          const checkSpy = spyOn(viewport, 'checkViewportSize').and.callThrough();
+        const virtualScroll = instance.virtualScroll as ClrDatagridVirtualScrollDirective<any>;
+        const viewport = (virtualScroll as any).virtualScrollViewport;
+        const rowMaster: HTMLElement = compiled.querySelector('.datagrid-row-master[role="row"]');
+        const collapsedRowHeight = rowMaster.getBoundingClientRect().height;
 
-          expect(capturedCallback).not.toBeNull();
+        await expandFirstRow(compiled, fixture);
+        const expandedRowHeight = rowMaster.getBoundingClientRect().height;
+        const extraHeight = expandedRowHeight - collapsedRowHeight;
 
-          const makeEntry = (blockSize: number): ResizeObserverEntry =>
-            ({
-              borderBoxSize: [{ blockSize, inlineSize: 0 }],
-              contentRect: { height: blockSize } as DOMRectReadOnly,
-            }) as unknown as ResizeObserverEntry;
+        // Scroll to a nearby index, still past the expanded row but well within the initial
+        // render/buffer window, so this stays a pure "did the offset account for the expanded
+        // row" check without picking up unrelated row-height variance (e.g. text wrapping) that
+        // can show up once virtual scroll has to render a completely different, far-away part of
+        // the (deliberately unstyled/no-fixed-column-width) test data set.
+        virtualScroll.scrollToIndex(5);
+        await delay(50);
+        fixture.detectChanges();
+        await delay(50);
 
-          // First fire: sets initialHeight — should NOT trigger checkViewportSize.
-          (capturedCallback as ResizeObserverCallback)([makeEntry(100)], null as any);
-          expect(checkSpy).not.toHaveBeenCalled();
-
-          // Second fire with a different blockSize: should trigger checkViewportSize.
-          (capturedCallback as ResizeObserverCallback)([makeEntry(200)], null as any);
-          expect(checkSpy).toHaveBeenCalled();
-        } finally {
-          (window as any).ResizeObserver = originalResizeObserver;
-        }
+        // The bug: scrollToIndex(index) computes index * itemSize, ignoring the extra height any
+        // earlier row picked up from being expanded, so the viewport lands short of where it
+        // should. The fix must offset by the real extra height of rows scrolled past.
+        expect(viewport.measureScrollOffset()).toBeCloseTo(5 * virtualScroll.itemSize + extraHeight, -1);
       });
 
       it('disconnects the ResizeObserver on ngOnDestroy', async function () {

--- a/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
@@ -329,11 +329,9 @@ export default function (): void {
 
       it('attaches a ResizeObserver to the datagrid rows container on init', async function () {
         // Spy on ResizeObserver before detectChanges so we intercept the constructor call.
-        let capturedCallback: ResizeObserverCallback | null = null;
         const observeSpy = jasmine.createSpy('observe');
         const disconnectSpy = jasmine.createSpy('disconnect');
-        const resizeObserverSpy = jasmine.createSpy('ResizeObserver').and.callFake(function (cb: ResizeObserverCallback) {
-          capturedCallback = cb;
+        const resizeObserverSpy = jasmine.createSpy('ResizeObserver').and.callFake(function (_cb: ResizeObserverCallback) {
           return { observe: observeSpy, disconnect: disconnectSpy };
         });
 
@@ -384,11 +382,11 @@ export default function (): void {
             }) as ResizeObserverEntry;
 
           // First fire: sets initialHeight — should NOT trigger checkViewportSize.
-          capturedCallback!([makeEntry(100)], null as any);
+          (capturedCallback as ResizeObserverCallback)([makeEntry(100)], null as any);
           expect(checkSpy).not.toHaveBeenCalled();
 
           // Second fire with a different blockSize: should trigger checkViewportSize.
-          capturedCallback!([makeEntry(200)], null as any);
+          (capturedCallback as ResizeObserverCallback)([makeEntry(200)], null as any);
           expect(checkSpy).toHaveBeenCalled();
         } finally {
           (window as any).ResizeObserver = originalResizeObserver;
@@ -399,7 +397,7 @@ export default function (): void {
         let capturedDisconnect: jasmine.Spy | null = null;
 
         const originalResizeObserver = (window as any).ResizeObserver;
-        (window as any).ResizeObserver = jasmine.createSpy('ResizeObserver').and.callFake(function (cb: ResizeObserverCallback) {
+        (window as any).ResizeObserver = jasmine.createSpy('ResizeObserver').and.callFake(function (_cb: ResizeObserverCallback) {
           const disconnectSpy = jasmine.createSpy('disconnect');
           capturedDisconnect = disconnectSpy;
           return { observe: () => {}, disconnect: disconnectSpy };
@@ -411,11 +409,11 @@ export default function (): void {
           fixture.detectChanges();
 
           expect(capturedDisconnect).not.toBeNull();
-          expect(capturedDisconnect!).not.toHaveBeenCalled();
+          expect(capturedDisconnect as jasmine.Spy).not.toHaveBeenCalled();
 
           fixture.destroy();
 
-          expect(capturedDisconnect!).toHaveBeenCalledTimes(1);
+          expect(capturedDisconnect as jasmine.Spy).toHaveBeenCalledTimes(1);
         } finally {
           (window as any).ResizeObserver = originalResizeObserver;
         }

--- a/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
@@ -331,7 +331,9 @@ export default function (): void {
         // Spy on ResizeObserver before detectChanges so we intercept the constructor call.
         const observeSpy = jasmine.createSpy('observe');
         const disconnectSpy = jasmine.createSpy('disconnect');
-        const resizeObserverSpy = jasmine.createSpy('ResizeObserver').and.callFake(function (_cb: ResizeObserverCallback) {
+        const resizeObserverSpy = jasmine.createSpy('ResizeObserver').and.callFake(function (
+          _cb: ResizeObserverCallback
+        ) {
           return { observe: observeSpy, disconnect: disconnectSpy };
         });
 
@@ -358,7 +360,9 @@ export default function (): void {
         // Intercept ResizeObserver construction to capture the callback.
         let capturedCallback: ResizeObserverCallback | null = null;
         const originalResizeObserver = (window as any).ResizeObserver;
-        (window as any).ResizeObserver = jasmine.createSpy('ResizeObserver').and.callFake(function (cb: ResizeObserverCallback) {
+        (window as any).ResizeObserver = jasmine.createSpy('ResizeObserver').and.callFake(function (
+          cb: ResizeObserverCallback
+        ) {
           capturedCallback = cb;
           return { observe: () => {}, disconnect: () => {} };
         });
@@ -397,7 +401,9 @@ export default function (): void {
         let capturedDisconnect: jasmine.Spy | null = null;
 
         const originalResizeObserver = (window as any).ResizeObserver;
-        (window as any).ResizeObserver = jasmine.createSpy('ResizeObserver').and.callFake(function (_cb: ResizeObserverCallback) {
+        (window as any).ResizeObserver = jasmine.createSpy('ResizeObserver').and.callFake(function (
+          _cb: ResizeObserverCallback
+        ) {
           const disconnectSpy = jasmine.createSpy('disconnect');
           capturedDisconnect = disconnectSpy;
           return { observe: () => {}, disconnect: disconnectSpy };

--- a/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.spec.ts
@@ -383,7 +383,7 @@ export default function (): void {
             ({
               borderBoxSize: [{ blockSize, inlineSize: 0 }],
               contentRect: { height: blockSize } as DOMRectReadOnly,
-            }) as ResizeObserverEntry;
+            }) as unknown as ResizeObserverEntry;
 
           // First fire: sets initialHeight — should NOT trigger checkViewportSize.
           (capturedCallback as ResizeObserverCallback)([makeEntry(100)], null as any);

--- a/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.ts
+++ b/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.ts
@@ -282,8 +282,7 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
     // the CDK viewport to recalculate the total scrollable content size.
     // We skip the very first observation (initial render) by ignoring entries
     // whose blockSize matches the current scrollHeight of the element.
-    const datagridRowsElement =
-      this.datagridElementRef.nativeElement.querySelector<HTMLElement>('.datagrid-rows');
+    const datagridRowsElement = this.datagridElementRef.nativeElement.querySelector<HTMLElement>('.datagrid-rows');
     if (datagridRowsElement && typeof ResizeObserver !== 'undefined') {
       let initialHeight: number | null = null;
       this.rowsResizeObserver = new ResizeObserver(entries => {

--- a/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.ts
+++ b/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.ts
@@ -86,6 +86,17 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
   private subscriptions: Subscription[] = [];
   private topIndex = 0;
 
+  /**
+   * ResizeObserver watching the datagrid rows container. When any row expands or
+   * collapses its detail content the container height changes. We use that signal
+   * to tell the CDK viewport to re-measure itself so it recalculates the total
+   * scrollable content size with the correct height.
+   *
+   * This avoids having to hook into each individual row's IfExpandService and works
+   * regardless of how the height change originates (CSS animations, dynamic content, etc.).
+   */
+  private rowsResizeObserver: ResizeObserver | null = null;
+
   // @deprecated remove the mutation observer when `datagrid-compact` class is deleted
   private mutationChanges: MutationObserver = new MutationObserver((mutations: MutationRecord[]) => {
     mutations.forEach((mutation: MutationRecord) => {
@@ -266,6 +277,35 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
 
     this.gridRoleElement = this.datagridElementRef.nativeElement.querySelector<HTMLElement>('[role="grid"]');
 
+    // Attach a ResizeObserver to the rows container so that when any row expands
+    // or collapses (changing the total height of the rows container), we notify
+    // the CDK viewport to recalculate the total scrollable content size.
+    // We skip the very first observation (initial render) by ignoring entries
+    // whose blockSize matches the current scrollHeight of the element.
+    const datagridRowsElement =
+      this.datagridElementRef.nativeElement.querySelector<HTMLElement>('.datagrid-rows');
+    if (datagridRowsElement && typeof ResizeObserver !== 'undefined') {
+      let initialHeight: number | null = null;
+      this.rowsResizeObserver = new ResizeObserver(entries => {
+        for (const entry of entries) {
+          const newHeight = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
+          if (initialHeight === null) {
+            // Record the height on first fire (initial layout) — do not trigger a
+            // re-measure because the viewport has just been initialised.
+            initialHeight = newHeight;
+          } else if (newHeight !== initialHeight) {
+            initialHeight = newHeight;
+            // Run inside NgZone so Angular change detection and the CDK viewport
+            // layout cycle are triggered correctly.
+            this.ngZone.run(() => {
+              this.virtualScrollViewport?.checkViewportSize();
+            });
+          }
+        }
+      });
+      this.rowsResizeObserver.observe(datagridRowsElement);
+    }
+
     this.updateCdkVirtualForInputs();
 
     this.subscriptions.push(
@@ -306,6 +346,8 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
     this.cdkVirtualFor?.ngOnDestroy();
     this.virtualScrollViewport?.ngOnDestroy();
     this.mutationChanges?.disconnect();
+    this.rowsResizeObserver?.disconnect();
+    this.rowsResizeObserver = null;
     this.subscriptions.forEach(subscription => {
       subscription.unsubscribe();
     });

--- a/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.ts
+++ b/projects/angular/data/datagrid/datagrid-virtual-scroll.directive.ts
@@ -16,7 +16,6 @@ import {
   CdkVirtualScrollable,
   CdkVirtualScrollableElement,
   CdkVirtualScrollViewport,
-  FixedSizeVirtualScrollStrategy,
   ScrollDispatcher,
   ViewportRuler,
   VIRTUAL_SCROLL_STRATEGY,
@@ -48,6 +47,7 @@ import {
 import { Subscription } from 'rxjs';
 
 import { ClrDatagrid } from './datagrid';
+import { ClrDatagridVirtualScrollStrategy } from './datagrid-virtual-scroll-strategy';
 import { ClrDatagridVirtualScrollRangeInterface } from './interfaces/virtual-scroll-data-range.interface';
 import { Items } from './providers/items';
 
@@ -80,20 +80,18 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
   private readonly datagridElementRef: ElementRef<HTMLElement>;
 
   private gridRoleElement: HTMLElement | null | undefined;
-  private readonly virtualScrollStrategy: FixedSizeVirtualScrollStrategy;
+  private readonly virtualScrollStrategy: ClrDatagridVirtualScrollStrategy;
   private virtualScrollViewport: CdkVirtualScrollViewport;
   private cdkVirtualFor: CdkVirtualForOf<T>;
   private subscriptions: Subscription[] = [];
   private topIndex = 0;
 
   /**
-   * ResizeObserver watching the datagrid rows container. When any row expands or
-   * collapses its detail content the container height changes. We use that signal
-   * to tell the CDK viewport to re-measure itself so it recalculates the total
-   * scrollable content size with the correct height.
-   *
-   * This avoids having to hook into each individual row's IfExpandService and works
-   * regardless of how the height change originates (CSS animations, dynamic content, etc.).
+   * ResizeObserver watching every currently rendered row individually (rather than the rows
+   * container as a whole), so any DOM change that makes a row taller or shorter than itemSize -
+   * expandable detail content, dynamically sized cell content, anything - is reported to
+   * virtualScrollStrategy. That keeps its total-content-size and scroll-offset math correct for
+   * the real (variable) row heights instead of assuming every row is exactly itemSize.
    */
   private rowsResizeObserver: ResizeObserver | null = null;
 
@@ -157,7 +155,11 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
       attributeOldValue: true,
     });
 
-    this.virtualScrollStrategy = new FixedSizeVirtualScrollStrategy(this.itemSize, this.minBufferPx, this.maxBufferPx);
+    this.virtualScrollStrategy = new ClrDatagridVirtualScrollStrategy(
+      this.itemSize,
+      this.minBufferPx,
+      this.maxBufferPx
+    );
   }
 
   get totalContentHeight() {
@@ -277,32 +279,18 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
 
     this.gridRoleElement = this.datagridElementRef.nativeElement.querySelector<HTMLElement>('[role="grid"]');
 
-    // Attach a ResizeObserver to the rows container so that when any row expands
-    // or collapses (changing the total height of the rows container), we notify
-    // the CDK viewport to recalculate the total scrollable content size.
-    // We skip the very first observation (initial render) by ignoring entries
-    // whose blockSize matches the current scrollHeight of the element.
-    const datagridRowsElement = this.datagridElementRef.nativeElement.querySelector<HTMLElement>('.datagrid-rows');
-    if (datagridRowsElement && typeof ResizeObserver !== 'undefined') {
-      let initialHeight: number | null = null;
+    // A single ResizeObserver instance observes every rendered row individually (rows are added
+    // to it as they render, see observeRenderedRows()). ResizeObserver fires once immediately per
+    // element on observe(), so this also measures rows that start out already taller than
+    // itemSize - no separate "first fire" handling needed.
+    if (typeof ResizeObserver !== 'undefined') {
       this.rowsResizeObserver = new ResizeObserver(entries => {
-        for (const entry of entries) {
-          const newHeight = entry.borderBoxSize?.[0]?.blockSize ?? entry.contentRect.height;
-          if (initialHeight === null) {
-            // Record the height on first fire (initial layout) — do not trigger a
-            // re-measure because the viewport has just been initialised.
-            initialHeight = newHeight;
-          } else if (newHeight !== initialHeight) {
-            initialHeight = newHeight;
-            // Run inside NgZone so Angular change detection and the CDK viewport
-            // layout cycle are triggered correctly.
-            this.ngZone.run(() => {
-              this.virtualScrollViewport?.checkViewportSize();
-            });
-          }
-        }
+        // Run inside NgZone so Angular change detection and the CDK viewport layout cycle are
+        // triggered correctly for any total-content-size / rendered-range change this causes.
+        this.ngZone.run(() => {
+          this.updateRowHeightsForEntries(entries);
+        });
       });
-      this.rowsResizeObserver.observe(datagridRowsElement);
     }
 
     this.updateCdkVirtualForInputs();
@@ -336,6 +324,7 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
     this.cdkVirtualFor?.ngDoCheck();
     if (this.shouldUpdateAriaRowIndexes) {
       this.updateAriaRowIndexes();
+      this.observeRenderedRows();
 
       this.shouldUpdateAriaRowIndexes = false;
     }
@@ -404,10 +393,7 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
   private updateAriaRowIndexes() {
     for (let i = 0; i < this.viewContainerRef.length; i++) {
       const viewRef = this.viewContainerRef.get(i) as EmbeddedViewRef<CdkVirtualForOfContext<T>>;
-
-      const rootElements: HTMLElement[] = viewRef.rootNodes;
-      const datagridRowElement = rootElements.find(rowElement => rowElement.tagName === 'CLR-DG-ROW');
-      const rowRoleElement = datagridRowElement?.querySelector('[role="row"]');
+      const rowRoleElement = this.getRowMasterElement(viewRef);
 
       const newAriaRowIndex = (viewRef.context.index + 1).toString();
       if (rowRoleElement?.getAttribute('aria-rowindex') !== newAriaRowIndex) {
@@ -415,6 +401,54 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
         rowRoleElement?.setAttribute('aria-rowindex', newAriaRowIndex);
       }
     }
+  }
+
+  // Registers every currently rendered row with rowsResizeObserver. observe() is a no-op for a
+  // target that's already being observed, so this is safe to call on every rendered-range change
+  // without tracking which rows we've already seen.
+  private observeRenderedRows() {
+    if (!this.rowsResizeObserver) {
+      return;
+    }
+    for (let i = 0; i < this.viewContainerRef.length; i++) {
+      const viewRef = this.viewContainerRef.get(i) as EmbeddedViewRef<CdkVirtualForOfContext<T>>;
+      const rowMasterElement = this.getRowMasterElement(viewRef);
+      if (rowMasterElement) {
+        this.rowsResizeObserver.observe(rowMasterElement);
+      }
+    }
+  }
+
+  private updateRowHeightsForEntries(entries: ResizeObserverEntry[]) {
+    const indexByRowMasterElement = new Map<Element, number>();
+    for (let i = 0; i < this.viewContainerRef.length; i++) {
+      const viewRef = this.viewContainerRef.get(i) as EmbeddedViewRef<CdkVirtualForOfContext<T>>;
+      const rowMasterElement = this.getRowMasterElement(viewRef);
+      if (rowMasterElement) {
+        indexByRowMasterElement.set(rowMasterElement, viewRef.context.index);
+      }
+    }
+
+    // Collect the whole batch before touching virtualScrollStrategy, so a resize that affects
+    // several rows at once (e.g. a bulk expand, or a window resize reflowing every row) triggers
+    // one total-content-size/rendered-range recompute instead of one per row.
+    const extraHeightsByIndex = new Map<number, number>();
+    for (const entry of entries) {
+      const index = indexByRowMasterElement.get(entry.target);
+      if (index === undefined) {
+        // The row this element used to belong to has since scrolled out and been recycled for a
+        // different index (or destroyed); its real height doesn't affect anything we can act on.
+        continue;
+      }
+      extraHeightsByIndex.set(index, (entry.target as HTMLElement).offsetHeight - this.itemSize);
+    }
+    this.virtualScrollStrategy.setItemExtraHeights(extraHeightsByIndex);
+  }
+
+  private getRowMasterElement(viewRef: EmbeddedViewRef<CdkVirtualForOfContext<T>>): HTMLElement | null {
+    const rootElements: HTMLElement[] = viewRef.rootNodes;
+    const datagridRowElement = rootElements.find(rowElement => rowElement.tagName === 'CLR-DG-ROW');
+    return datagridRowElement?.querySelector<HTMLElement>('[role="row"]') ?? null;
   }
 
   private createVirtualScrollViewportForDatagrid(
@@ -425,7 +459,7 @@ export class ClrDatagridVirtualScrollDirective<T> implements AfterViewInit, DoCh
     scrollDispatcher: ScrollDispatcher,
     viewportRuler: ViewportRuler,
     datagridElementRef: ElementRef<HTMLElement>,
-    virtualScrollStrategy: FixedSizeVirtualScrollStrategy
+    virtualScrollStrategy: ClrDatagridVirtualScrollStrategy
   ) {
     const datagridContentElement = datagridElementRef.nativeElement.querySelector<HTMLElement>('.datagrid-content');
     const datagridRowsElement = datagridElementRef.nativeElement.querySelector<HTMLElement>('.datagrid-rows');


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix

## What is the current behavior?

The datagrid virtual scroll uses CDK `FixedSizeVirtualScrollStrategy` which assumes a constant item height. When rows are expanded (revealing variable-height detail content), the total scroll height is miscalculated, causing items to jump, overlap, or repeat while scrolling.

Issue Number: CDE-3126

## What is the new behavior?

A `ResizeObserver` is attached to the `.datagrid-rows` container. When the container's height changes (e.g. due to row expansion), `checkViewportSize()` is called on the CDK scroll viewport inside `NgZone.run()`, prompting CDK to recalculate the scroll layout. The observer is disconnected in `ngOnDestroy` to prevent memory leaks.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information