### PR TITLE
docs(website): add missing v18 breaking changes to update guide (backport to main)

### DIFF
--- a/projects/website/content/pages/update-to-v18.md
+++ b/projects/website/content/pages/update-to-v18.md
@@ -39,7 +39,7 @@ Clarity v18 upgrades to Angular 21. This is the minimum supported Angular versio
 ### Drop `@cds/core`
 
 `@clr/angular` no longer depends on `@cds/core`. All supported features have been migrated into `@clr/angular`
-directly, including `cds-icon`, CSS tokens, and CSS utilities (`cds-layout`, `cds-list`, `cds-text`).
+directly, including `cds-icon`, CSS tokens, and CSS utilities (`cds-layout`, `cds-list`, `cds-text`, `cds-divider`).
 
 - Remove `@cds/core` from your dependencies.
 - Change icon imports from `@cds/core/icon` to `@clr/angular/icon`.
@@ -126,6 +126,9 @@ instead of Stepper extending Accordion.
 - `AccordionPanelModel`, `AccordionStatus`, and `panelAnimation` are removed from `@clr/angular/accordion`. Use
   `CollapsiblePanelModel`, `StepperPanelStatus`, and `collapsiblePanelAnimation` from `@clr/angular/collapsible-panel`
   and `@clr/angular/stepper`.
+- `AccordionModel` and `AccordionService` remain in `@clr/angular/accordion` but now extend `CollapsiblePanelGroupModel`
+  and `CollapsiblePanelService` respectively. `AccordionStrategy` also remains in `@clr/angular/accordion`, as it is
+  accordion-specific (single-panel-at-a-time behavior).
 - `getAccordionContentId()` and `getAccordionHeaderId()` on `ClrAccordionPanel` are renamed to `getContentId()` and
   `getHeaderId()`.
 - The `clrAccordionPanelHeadingEnabled` feature flag is removed. All heading values must have explicit content assigned
@@ -148,11 +151,44 @@ The `clrBadgeColor` input is renamed to `clrColor`.
 
 ### Datagrid
 
+- The datagrid selection API has been unified:
+  - `clrDgSingleSelected` input and `clrDgSingleSelectedChange` output have been removed. Use `clrDgSelected` together
+    with a new, required `clrDgSelectionType` input (`"none"` | `"single"` | `"multi"`) instead, wrapping the selected
+    item in an array for single selection.
+  - `SelectionType` enum values changed from numeric (`0`, `1`, `2`) to string literals (`'none'`, `'single'`, `'multi'`).
+  - The addons `SelectionType` enum has been removed; import it from `@clr/angular/data/datagrid` instead.
+  - The `selection.change` Observable now always emits `T[]` (previously `T | T[]` for single selection).
+  - The `selection.currentSingle` setter has been removed; use `selection.current = [item]` instead.
+
+  ```html
+  <!-- Before: Single selection (implicit type) -->
+  <clr-datagrid [(clrDgSingleSelected)]="selectedUser"></clr-datagrid>
+  <!-- After: Single selection (explicit type) -->
+  <clr-datagrid [(clrDgSelected)]="selectedUsers" clrDgSelectionType="single"></clr-datagrid>
+  ```
+
 - `clrDgItemsTrackBy` on `ClrDatagrid` is renamed to `clrDgItemsIdentityFn` to reduce confusion with `clrDgItemsTrackBy` on `ClrDgItems`.
 - Columns now have an **unsorted** state which activates on the third click on a sortable column. It can be disabled
   per column through the `clrDgDisableUnsort` input. Unsorted sortable columns display a visible `two-way-arrows` icon.
 - The opened row detail anchor has been removed; a background color is now used to identify the open detail row. This is
   a visual style change that may affect visual regression tests.
+
+### Datagrid Filters (Addons)
+
+`@clr/addons/datagrid-filters` API changes:
+
+| Old API                                                           | New API                            | Notes                                                        |
+| ----------------------------------------------------------------- | ---------------------------------- | ------------------------------------------------------------ |
+| `EnumPropertyDefinition` constructor param `showKeyInParentheses` | `enableSelectAll` (default `true`) | Controls "Select All" checkbox visibility                    |
+| `UsersFilterComponent.formatUser()` method                        | _(removed)_                        | Delegate to your `DatagridFiltersUserService` implementation |
+| `UsersFilterComponent.userOperators` property                     | _(removed)_                        | Use `filterProperty.supportedOperators` in templates instead |
+
+```typescript
+// Before
+new EnumPropertyDefinition('status', statusOptions, { showKeyInParentheses: false });
+// After
+new EnumPropertyDefinition('status', statusOptions, { enableSelectAll: false });
+```
 
 ### Forms
 


### PR DESCRIPTION
> Backport of #2492 to `main`.

## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

<!-- Please check the one that applies to this PR using "x". -->

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [x] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

<!-- Please describe the current behavior that you are modifying, or link to a relevant issue. -->

The [Update v17 to v18](https://clarity.design/pages/update-to-v18) website guide is missing several breaking changes that are documented in the official [v18.0.0 GitHub release notes](https://github.com/vmware-clarity/ng-clarity/releases/tag/v18.0.0):

- The datagrid selection API unification (`clrDgSingleSelected`/`clrDgSingleSelectedChange` removal, new required `clrDgSelectionType` input, `SelectionType` enum going from numeric to string literals, addons `SelectionType` enum removal, `selection.change`/`selection.currentSingle` behavior changes) had no coverage at all, despite being one of the most consumer-impacting v18 changes.
- The Datagrid Filters (Addons) API changes (`EnumPropertyDefinition.showKeyInParentheses` → `enableSelectAll`, removal of `UsersFilterComponent.formatUser()`/`userOperators`) were completely absent.
- The `cds-divider` utility was missing from the list of CSS utilities migrated off `@cds/core`.
- `AccordionModel`/`AccordionService` now extending `CollapsiblePanelGroupModel`/`CollapsiblePanelService` wasn't mentioned.

Issue Number: N/A

## What is the new behavior?

Adds the missing content above to `projects/website/content/pages/update-to-v18.md`, matching the detail already present in the GitHub release notes.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

## Other information

Separately, while comparing sources: the v18.0.0 release notes on GitHub say *"`ClrLabel` is renamed to `ClrControlLabel`. `ClrLabel` now corresponds to the `<label>` Angular component."* Per the source at the v18.0.0 tag, the new `ClrLabel` component's selector is actually `clr-label` (the renamed `ClrControlLabel` is the one with selector `label`), so that sentence has it backwards. This guide already has the correct wording (`<clr-label>`); the GitHub release notes text itself may want a manual correction.
