### PR TITLE
chore(ci): cache npm deps and modernize actions across PR workflows

### DIFF
--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -13,11 +13,12 @@ jobs:
       GH_TOKEN: ${{ github.token }}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
       - name: Install Dependencies
         run: npm ci --ignore-scripts
       - name: Lint
@@ -61,11 +62,12 @@ jobs:
       CLARITY_VRT_DENSITY: ${{matrix.density}}
     steps:
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
       - name: Install Dependencies
         run: npm ci --ignore-scripts
       - name: Install Playwright Browsers

--- a/.github/workflows/pr-comment-bot.yml
+++ b/.github/workflows/pr-comment-bot.yml
@@ -9,7 +9,7 @@ jobs:
     steps:
       - name: Check For Artifacts
         id: check-for-artifacts
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           script: |
             const artifacts = await github.rest.actions.listWorkflowRunArtifacts({

--- a/.github/workflows/pr-preview.yml
+++ b/.github/workflows/pr-preview.yml
@@ -20,11 +20,16 @@ jobs:
           token: ${{secrets.GITHUB_TOKEN}}
           sourceRunId: ${{github.event.workflow_run.id}}
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{steps.get-pr-event.outputs.sourceHeadBranch}}
+          sparse-checkout: |
+            netlify-storybook.toml
+            netlify-website.toml
+            .nvmrc
+          sparse-checkout-cone-mode: false
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
       - name: Download Docs Artifact

--- a/.github/workflows/pr-visual-snapshot-update-bot.yml
+++ b/.github/workflows/pr-visual-snapshot-update-bot.yml
@@ -27,14 +27,15 @@ jobs:
               core.setFailed('No PR found');
             }
       - name: Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           repository: ${{ github.repository }}
           ref: ${{ github.event.workflow_run.head_sha }}
       - name: Setup Node.js
-        uses: actions/setup-node@v3
+        uses: actions/setup-node@v4
         with:
           node-version-file: '.nvmrc'
+          cache: 'npm'
       - name: Install Dependencies
         run: npm ci --ignore-scripts
       - name: Create Temp Directory for Diff Artifacts


### PR DESCRIPTION
## Summary

Reduces redundant, uncached work in the PR pipeline (found while auditing #2426 for a promised-but-unmeasured perf win):

- Add `cache: 'npm'` to `setup-node` in `pr-build.yml` (both jobs) and `pr-visual-snapshot-update-bot.yml` — every job currently re-downloads all npm packages from the registry with zero caching.
- Bump `actions/checkout` v3→v4 and `actions/setup-node` v3→v4 across `pr-build.yml`, `pr-preview.yml`, `pr-visual-snapshot-update-bot.yml` (fixes the Node 20 deprecation warnings currently showing on every run).
- Bump `actions/github-script` v6→v7 in `pr-comment-bot.yml` for consistency with the other bot workflow.
- Sparse-checkout in `pr-preview.yml` — it only ever reads `netlify-storybook.toml`, `netlify-website.toml`, and `.nvmrc`, but was doing a full repo clone.

Deliberately **not** included: consolidating the three `workflow_run`-triggered bot workflows into one file. Two of them resolve the source PR via `potiuk/get-workflow-origin`, the third via a different inline method — I can't verify without a live fork-PR run that they behave identically for external contributors, so didn't want to risk breaking preview deploys or the snapshot bot for outside contributors for a ~5-10s saving.

## Test plan

- [ ] `PR Build` still passes (lint/build/test/public-api-check + 8-way VRT matrix)
- [ ] `PR Preview` still deploys Storybook + website previews correctly with the sparse checkout
- [ ] `PR Visual Snapshot Update Bot` still runs correctly (clean-diff path, since this PR shouldn't produce visual changes)
- [ ] Compare `PR Build` job timings against baseline runs on `next` to confirm the npm cache actually helps