### PR TITLE
feat(addons): add workflow module aggregator

### DIFF
--- a/projects/addons/workflow/appfx-workflows.module.spec.ts
+++ b/projects/addons/workflow/appfx-workflows.module.spec.ts
@@ -1,0 +1,18 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { WorkflowConfigurationService } from '@clr/addons/var';
+
+import { workflowConfigurationServiceFactory } from './appfx-workflows.module';
+
+describe('#workflowConfigurationServiceFactory()', () => {
+  it('returns the existing service', () => {
+    const existingConfigService = new WorkflowConfigurationService();
+    expect(workflowConfigurationServiceFactory(existingConfigService)).toBe(existingConfigService);
+    expect(workflowConfigurationServiceFactory(undefined as any)).not.toBe(existingConfigService);
+  });
+});

--- a/projects/addons/workflow/appfx-workflows.module.ts
+++ b/projects/addons/workflow/appfx-workflows.module.ts
@@ -1,0 +1,48 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { NgModule, Optional, SkipSelf } from '@angular/core';
+import { AppfxMultiPageDialogModule } from '@clr/addons/dialog';
+import { AppfxStepperModule } from '@clr/addons/stepper';
+import { AppfxTabsModule } from '@clr/addons/tabs';
+import { AppfxWorkflowCoreModule, WorkflowConfigurationService } from '@clr/addons/var';
+import { AppfxWizardModule } from '@clr/addons/wizard';
+import { WorkflowStrings } from '@clr/addons/workflow/strings';
+
+export function workflowConfigurationServiceFactory(existing: WorkflowConfigurationService) {
+  return existing || new WorkflowConfigurationService();
+}
+
+export function workflowStringsServiceFactory(existing: WorkflowStrings) {
+  return existing || new WorkflowStrings();
+}
+
+@NgModule({
+  imports: [
+    AppfxMultiPageDialogModule,
+    AppfxStepperModule,
+    AppfxTabsModule,
+    AppfxWizardModule,
+    AppfxWorkflowCoreModule,
+  ],
+  providers: [
+    {
+      // This pattern allows the importer of this module to specify its own WorkflowConfigurationService.
+      provide: WorkflowConfigurationService,
+      useFactory: workflowConfigurationServiceFactory,
+      deps: [[new Optional(), new SkipSelf(), WorkflowConfigurationService]],
+    },
+    {
+      // This pattern allows the importer of this module to specify its own WorkflowStrings.
+      provide: WorkflowStrings,
+      useFactory: workflowStringsServiceFactory,
+      deps: [[new Optional(), new SkipSelf(), WorkflowStrings]],
+    },
+  ],
+  exports: [AppfxMultiPageDialogModule, AppfxStepperModule, AppfxTabsModule, AppfxWizardModule],
+})
+export class AppfxWorkflowsModule {}

--- a/projects/addons/workflow/index.ts
+++ b/projects/addons/workflow/index.ts
@@ -5,5 +5,4 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
-// No exports, use secondary entry points.
-export {};
+export { AppfxWorkflowsModule } from './appfx-workflows.module';

--- a/projects/addons/workflow/workflow.api.md
+++ b/projects/addons/workflow/workflow.api.md
@@ -4,6 +4,80 @@
 
 ```ts
 
+import { AfterContentChecked } from '@angular/core';
+import { AfterContentInit } from '@angular/core';
+import { AfterViewChecked } from '@angular/core';
+import { AfterViewInit } from '@angular/core';
+import * as _angular_animations from '@angular/animations';
+import { AnimationBuilder } from '@angular/animations';
+import { AnimationEvent as AnimationEvent_2 } from '@angular/animations';
+import { AnimationMetadata } from '@angular/animations';
+import { BehaviorSubject } from 'rxjs';
+import { CdkDrag } from '@angular/cdk/drag-drop';
+import { CdkTrapFocus } from '@angular/cdk/a11y';
+import { ChangeDetectorRef } from '@angular/core';
+import { ComponentFactoryResolver } from '@angular/core';
+import { ConnectedPosition } from '@angular/cdk/overlay';
+import { Directionality } from '@angular/cdk/bidi';
+import { DoCheck } from '@angular/core';
+import { DomSanitizer } from '@angular/platform-browser';
+import { DragDrop } from '@angular/cdk/drag-drop';
+import { DragDropConfig } from '@angular/cdk/drag-drop';
+import { ElementRef } from '@angular/core';
+import { EventEmitter } from '@angular/core';
+import { FactoryProvider } from '@angular/core';
+import { FlexibleConnectedPositionStrategyOrigin } from '@angular/cdk/overlay';
+import { FocusTrapFactory } from '@angular/cdk/a11y';
+import { FormGroup } from '@angular/forms';
+import { FormGroupDirective } from '@angular/forms';
+import { FormGroupName } from '@angular/forms';
+import * as i0 from '@angular/core';
+import * as i8 from '@angular/common';
+import * as i9 from '@angular/forms';
+import { InjectionToken } from '@angular/core';
+import { Injector } from '@angular/core';
+import { IterableDiffers } from '@angular/core';
+import { NgControl } from '@angular/forms';
+import { NgForm } from '@angular/forms';
+import { NgModelGroup } from '@angular/forms';
+import { NgZone } from '@angular/core';
+import { Observable } from 'rxjs';
+import { Observer } from 'rxjs';
+import { OnChanges } from '@angular/core';
+import { OnDestroy } from '@angular/core';
+import { OnInit } from '@angular/core';
+import { Overlay } from '@angular/cdk/overlay';
+import { OverlayContainer } from '@angular/cdk/overlay';
+import { PipeTransform } from '@angular/core';
+import { QueryList } from '@angular/core';
+import { Renderer2 } from '@angular/core';
+import { SafeHtml } from '@angular/platform-browser';
+import { SimpleChange } from '@angular/core';
+import { SimpleChanges } from '@angular/core';
+import { Subject } from 'rxjs';
+import { Subscription } from 'rxjs';
+import { TemplateRef } from '@angular/core';
+import { Type } from '@angular/core';
+import { UntypedFormBuilder } from '@angular/forms';
+import { UntypedFormGroup } from '@angular/forms';
+import { ViewContainerRef } from '@angular/core';
+
+// @public (undocumented)
+export class AppfxWorkflowsModule {
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<AppfxWorkflowsModule, never>;
+    // (undocumented)
+    static ɵinj: i0.ɵɵInjectorDeclaration<AppfxWorkflowsModule>;
+    // Warning: (ae-forgotten-export) The symbol "i1" needs to be exported by the entry point clr-addons-workflow.d.ts
+    // Warning: (ae-forgotten-export) The symbol "i2" needs to be exported by the entry point clr-addons-workflow.d.ts
+    // Warning: (ae-forgotten-export) The symbol "i3" needs to be exported by the entry point clr-addons-workflow.d.ts
+    // Warning: (ae-forgotten-export) The symbol "i4" needs to be exported by the entry point clr-addons-workflow.d.ts
+    // Warning: (ae-forgotten-export) The symbol "i5" needs to be exported by the entry point clr-addons-workflow.d.ts
+    //
+    // (undocumented)
+    static ɵmod: i0.ɵɵNgModuleDeclaration<AppfxWorkflowsModule, never, [typeof i1.AppfxMultiPageDialogModule, typeof i2.AppfxStepperModule, typeof i3.AppfxTabsModule, typeof i4.AppfxWizardModule, typeof i5.AppfxWorkflowCoreModule], [typeof i1.AppfxMultiPageDialogModule, typeof i2.AppfxStepperModule, typeof i3.AppfxTabsModule, typeof i4.AppfxWizardModule]>;
+}
+
 // (No @packageDocumentation comment for this package)
 
 ```


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [x] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

N/A — this adds a new addon, no existing behavior is modified.

## What is the new behavior?

Adds a new top-level `@clr/addons/workflow` entry point containing `AppfxWorkflowsModule`: a convenience aggregator `NgModule` that bundles the Dialog, Stepper, Tabs, Wizard, and Var addons' modules into a single import, and provides factory-based overrides for `WorkflowConfigurationService`/`WorkflowStrings` so a consuming app can supply its own instance. This is distinct from the existing `@clr/addons/workflow/strings` nested entry point. Library-only, no dedicated demo/docs page of its own (matching the `var` and `workflow/strings` addons).

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Depends on `var` (#2522), `stepper` (#2523), `wizard` (#2524), `tabs` (#2525), and `dialog` (#2526) — base branch is set to `addon/dialog`; this PR's diff will shrink to just this addon's own changes once the full chain merges.