### PR TITLE
chore(addons): migrate card-container test files (backport to main)

### DIFF
--- a/projects/addons/card-container/card/appfx-card.component.spec.ts
+++ b/projects/addons/card-container/card/appfx-card.component.spec.ts
@@ -1,0 +1,204 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { CommonModule } from '@angular/common';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { a11ykeys, ZoomLevel, ZoomLevelService } from '@clr/addons/a11y';
+import { DragAndDropGroupService } from '@clr/addons/drag-and-drop';
+import {
+  MockA11yService,
+  MockDragDropService,
+  MockLayoutService,
+  SampleCardComponent,
+  sampleCards,
+  ZoomLevelServiceMock,
+} from '@clr/addons/testing';
+import { AppfxTranslateModule } from '@clr/addons/translate';
+import { ClrIcon } from '@clr/angular/icon';
+
+import { AppfxCardInternal } from '../appfx-card-container.interface';
+import { AppfxCardComponent } from './appfx-card.component';
+import { A11yService } from '../services/a11y.service';
+import { DragDropService } from '../services/dnd.service';
+import { LayoutService } from '../services/layout.service';
+
+const sampleCardId = 'sample-card-1';
+
+describe('AppfxCardComponent', () => {
+  let fixture: ComponentFixture<AppfxCardComponent>;
+  let component: AppfxCardComponent;
+  let layoutService: LayoutService;
+  let a11yService: A11yService;
+  let dragDropService: DragDropService;
+  let zoomLevelService: ZoomLevelService;
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CommonModule, ClrIcon, NoopAnimationsModule, DragDropModule, AppfxTranslateModule],
+      declarations: [AppfxCardComponent],
+      providers: [
+        DragAndDropGroupService,
+        { provide: LayoutService, useClass: MockLayoutService },
+        { provide: DragDropService, useClass: MockDragDropService },
+        { provide: A11yService, useClass: MockA11yService },
+        { provide: ZoomLevelService, useClass: ZoomLevelServiceMock },
+      ],
+    });
+    fixture = TestBed.createComponent(AppfxCardComponent);
+    component = fixture.componentInstance;
+    layoutService = TestBed.inject(LayoutService);
+    a11yService = TestBed.inject(A11yService);
+    dragDropService = TestBed.inject(DragDropService);
+    component.card = sampleCards[0];
+    component.dropGroup = 'container-1';
+    zoomLevelService = TestBed.inject(ZoomLevelService);
+  });
+
+  it('should create component', () => {
+    expect(component).toBeDefined();
+  });
+
+  it('should throw error when card id is missing', () => {
+    component.card = {} as AppfxCardInternal;
+    expect(() => {
+      component.ngOnInit();
+    }).toThrowError('Missing Input property for card - id');
+  });
+
+  it('should create component card when id and componentClass is present', () => {
+    const cardViewContainer = (component as any).cardViewContainer;
+    spyOn(cardViewContainer, 'createComponent').and.callThrough();
+
+    component.card = {
+      id: sampleCardId,
+      componentClass: SampleCardComponent,
+      context: {},
+    } as unknown as AppfxCardInternal;
+    component.ngOnInit();
+
+    expect(cardViewContainer.createComponent).toHaveBeenCalledWith(SampleCardComponent);
+  });
+
+  it('should not create component card when id and componentClass is not present', () => {
+    const cardViewContainer = (component as any).cardViewContainer;
+    spyOn(cardViewContainer, 'createComponent').and.callThrough();
+
+    component.card = { id: sampleCardId } as AppfxCardInternal;
+    component.ngOnInit();
+
+    expect(cardViewContainer.createComponent).not.toHaveBeenCalled();
+  });
+
+  it('when called isSelectedCard should call a11yService isSelectedCard', () => {
+    spyOn(a11yService, 'isSelected').and.callThrough();
+    const isSelected = component.isSelected;
+    expect(isSelected).toBeFalsy();
+    expect(a11yService.isSelected).toHaveBeenCalledWith(sampleCardId);
+  });
+
+  it('when called isDraggableOver should call a11yService isDraggableOver', () => {
+    spyOn(a11yService, 'isDraggableOver').and.callThrough();
+    const isDraggableOver = component.isDraggableOver;
+    expect(isDraggableOver).toBeFalsy();
+    expect(a11yService.isDraggableOver).toHaveBeenCalledWith(sampleCardId);
+  });
+
+  it('when called ngAfterViewInit should call layoutService updateCardSize to update card sizes', () => {
+    spyOn(layoutService, 'updateCardSize').and.callThrough();
+    component.ngAfterViewInit();
+    expect(layoutService.updateCardSize).toHaveBeenCalled();
+  });
+
+  it('when zoom level is change and cardZoomSize is define the updateCardSize method of layoutService is called', () => {
+    component.card = {
+      id: sampleCardId,
+      componentClass: SampleCardComponent,
+      context: {},
+      unitWidth: 1,
+      unitHeight: 7,
+      cardZoomSizes: {
+        zoom2x: {
+          unitWidth: 2,
+          unitHeight: 5,
+        },
+      },
+    } as unknown as AppfxCardInternal;
+    component.ngOnInit();
+    spyOn(layoutService, 'updateCardSize').and.callThrough();
+    zoomLevelService['resizeSubject'].next(ZoomLevel.x2);
+    expect(layoutService.updateCardSize).toHaveBeenCalled();
+  });
+
+  it('when zoom level is change and cardZoomSize is not define the updateCardSize method of layoutService is not called', () => {
+    component.card = {
+      id: sampleCardId,
+      componentClass: SampleCardComponent,
+      context: {},
+      unitWidth: 1,
+      unitHeight: 7,
+      cardZoomSizes: {
+        zoom4x: {
+          unitWidth: 1,
+          unitHeight: 1,
+        },
+      },
+    } as unknown as AppfxCardInternal;
+    component.ngOnInit();
+    spyOn(layoutService, 'updateCardSize').and.callThrough();
+    zoomLevelService['resizeSubject'].next(ZoomLevel.x2);
+    expect(layoutService.updateCardSize).not.toHaveBeenCalled();
+  });
+
+  it('when called onDragStart should call dragDropService onDragStart', () => {
+    spyOn(dragDropService, 'onDragStart').and.callThrough();
+    component.onDragStart();
+    expect(dragDropService.onDragStart).toHaveBeenCalledWith(sampleCardId);
+  });
+
+  it('when called onDrop should call dragDropService onDragDrop', () => {
+    spyOn(dragDropService, 'onDragDrop').and.callThrough();
+    component.onDrop();
+    expect(dragDropService.onDragDrop).toHaveBeenCalledWith(sampleCardId);
+  });
+
+  it('when called selectCard should call a11yService selectCard', () => {
+    spyOn(a11yService, 'selectCard').and.callThrough();
+    const keyEvent: any = document.createEvent('CustomEvent');
+    keyEvent.key = a11ykeys.enter; // Enter Key
+    keyEvent.initEvent('keyup', true, true);
+    component.selectCard(keyEvent);
+    expect(a11yService.selectCard).toHaveBeenCalledWith(sampleCardId);
+  });
+
+  it('when called moveDropPositionBackwards should call a11yService moveDropPosition', () => {
+    spyOn(a11yService, 'moveDropPosition').and.callThrough();
+    const keyEvent: any = document.createEvent('CustomEvent');
+    keyEvent.key = a11ykeys.arrowLeft; // Enter Key
+    keyEvent.initEvent('keyup', true, true);
+    component.moveDropPositionBackwards(keyEvent);
+    expect(a11yService.moveDropPosition).toHaveBeenCalledWith(a11ykeys.arrowLeft);
+  });
+
+  it('when called moveDropPositionForwards should call a11yService moveDropPosition', () => {
+    spyOn(a11yService, 'moveDropPosition').and.callThrough();
+    const keyEvent: any = document.createEvent('CustomEvent');
+    keyEvent.key = a11ykeys.arrowRight; // Enter Key
+    keyEvent.initEvent('keyup', true, true);
+    component.moveDropPositionForwards(keyEvent);
+    expect(a11yService.moveDropPosition).toHaveBeenCalledWith(a11ykeys.arrowRight);
+  });
+
+  it('when called onDropHandleKeyUp should call a11yService selectCard', () => {
+    spyOn(a11yService, 'selectCard').and.callFake(() => {});
+    const keyEvent = new KeyboardEvent('keyup', {
+      key: 'Enter',
+    });
+    component.onDropHandleKeyUp(keyEvent);
+    expect(a11yService.selectCard).toHaveBeenCalled();
+  });
+});

--- a/projects/addons/card-container/container/appfx-card-container.component.spec.ts
+++ b/projects/addons/card-container/container/appfx-card-container.component.spec.ts
@@ -1,0 +1,113 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { DragDropModule } from '@angular/cdk/drag-drop';
+import { CommonModule } from '@angular/common';
+import { Renderer2 } from '@angular/core';
+import { ComponentFixture, fakeAsync, TestBed, tick } from '@angular/core/testing';
+import { NoopAnimationsModule } from '@angular/platform-browser/animations';
+import { DragAndDropGroupService } from '@clr/addons/drag-and-drop';
+import { MockRenderer2, sampleCards } from '@clr/addons/testing';
+import { AppfxTranslateModule } from '@clr/addons/translate';
+import { ClrDropdownModule } from '@clr/angular/popover/dropdown';
+import { of } from 'rxjs';
+
+import { AppfxCardContainerComponent } from './appfx-card-container.component';
+import { AppfxCardComponent } from '../card/appfx-card.component';
+import { ContainerService } from '../services/container.service';
+import { PersistenceService } from '../services/persistence.service';
+import { AppfxCardContainerSettingsComponent } from '../settings/appfx-card-container-settings.component';
+
+const mockContainerService = {
+  initialize: () => {},
+  getContainerId: () => 'sample-container',
+  getCardById: () => sampleCards[0],
+  getCardOrder: () => {},
+  getCardsWithOrder: () => of(sampleCards),
+  getCardWithOrder: () => of(sampleCards),
+  getContainerCards: () => [sampleCards],
+  addCard: () => {},
+  updateCardsOrder: () => {},
+  updateCard: () => {},
+  removeCard: () => {},
+  toggleCardVisibility: () => sampleCards[0],
+};
+
+describe('AppfxCardContainerComponent', () => {
+  let fixture: ComponentFixture<AppfxCardContainerComponent>;
+  let component: AppfxCardContainerComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [CommonModule, NoopAnimationsModule, ClrDropdownModule, DragDropModule, AppfxTranslateModule],
+      declarations: [AppfxCardComponent, AppfxCardContainerComponent, AppfxCardContainerSettingsComponent],
+      providers: [
+        DragAndDropGroupService,
+        { provide: PersistenceService, useValue: {} },
+        { provide: Renderer2, useClass: MockRenderer2 },
+      ],
+    }).overrideProvider(ContainerService, { useValue: mockContainerService });
+
+    fixture = TestBed.createComponent(AppfxCardContainerComponent);
+    component = fixture.componentInstance;
+    component.containerId = 'container-summary';
+  });
+
+  it('should create component', () => {
+    expect(component).toBeDefined();
+  });
+
+  it('should throw error when container id is missing', () => {
+    try {
+      component.ngOnInit();
+    } catch (err) {
+      expect(err).toMatch('Missing Input property - containerId');
+    }
+  });
+
+  it('should insert card to container', fakeAsync(() => {
+    const card = sampleCards[0];
+    spyOn(component, 'insertCardToContainer' as any).and.returnValue({});
+    spyOn(mockContainerService, 'addCard');
+    component.cards.push(card);
+    fixture.detectChanges();
+    component.ngDoCheck();
+    tick();
+
+    expect((component as any).insertCardToContainer).toHaveBeenCalled();
+  }));
+
+  describe('#onToggleCardVisibility', () => {
+    it('should remove card from container view when card is hidden', () => {
+      const card = {
+        ...sampleCards[0],
+        hidden: true,
+        id: 'card-1',
+      };
+      spyOn(mockContainerService, 'toggleCardVisibility').and.returnValue(card);
+      spyOn(component, <never>'removeCardFromContainer').and.callThrough();
+
+      component.onToggleCardVisibility('card-1');
+
+      expect((component as any).removeCardFromContainer).toHaveBeenCalled();
+    });
+
+    it('should insert card from container view when card is not hidden', () => {
+      const card = {
+        ...sampleCards[0],
+        hidden: false,
+        id: 'card-1',
+      };
+      spyOn(mockContainerService, 'toggleCardVisibility').and.returnValue(card);
+      spyOn(component, <never>'insertCardToContainer').and.callThrough();
+
+      component.onToggleCardVisibility('card-1');
+
+      expect((component as any).insertCardToContainer).toHaveBeenCalled();
+    });
+  });
+});

--- a/projects/addons/card-container/services/a11y.service.spec.ts
+++ b/projects/addons/card-container/services/a11y.service.spec.ts
@@ -1,0 +1,170 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Renderer2 } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { a11ykeys } from '@clr/addons/a11y';
+import { cardIdToOrder, MockContainerService, MockRenderer2, sampleCards } from '@clr/addons/testing';
+
+import { A11yService } from './a11y.service';
+import { ContainerService } from './container.service';
+
+describe('#A11yService', () => {
+  let a11yService: A11yService;
+  let containerService: ContainerService;
+
+  beforeEach(() => {
+    TestBed.overrideProvider(ContainerService, { useValue: new MockContainerService() });
+
+    TestBed.configureTestingModule({
+      providers: [
+        { provide: ContainerService, useClass: MockContainerService },
+        { provide: Renderer2, useClass: MockRenderer2 },
+        A11yService,
+      ],
+    });
+    a11yService = TestBed.inject(A11yService);
+    containerService = TestBed.inject(ContainerService);
+  });
+
+  it('should create an instance', () => {
+    expect(a11yService).toBeDefined();
+  });
+
+  describe('when call selectCard', () => {
+    it('then should not select card if card order is default one', () => {
+      spyOn(containerService, 'getCardOrder').and.callFake((id: string) => cardIdToOrder[id]);
+      spyOn(a11yService, 'getOutOfA11yMode');
+      // try to select card with default order
+      a11yService.selectCard('cardWithDefaultOrder');
+      // should not select default order card
+      expect(a11yService.isSelected('cardWithDefaultOrder')).toBeFalsy();
+      // drop element is same as use has not touch any arrow keys yet
+      expect(a11yService.isDraggableOver('cardWithDefaultOrder')).toBeFalsy();
+      // should call getCardOrder
+      expect(containerService.getCardOrder).toHaveBeenCalledWith('cardWithDefaultOrder');
+      // should not call get out of a11y mode
+      expect(a11yService.getOutOfA11yMode).not.toHaveBeenCalled();
+    });
+
+    it('then should enter in a11y mode on first enter', () => {
+      spyOn(containerService, 'getCardOrder').and.returnValue(2);
+      spyOn(a11yService, 'getOutOfA11yMode');
+      a11yService.selectCard(sampleCards[0].id);
+      // current drag element order
+      expect(a11yService.isSelected(sampleCards[0].id)).toBeTruthy();
+      // drop element is same as use has not touch any arrow keys yet
+      expect(a11yService.isDraggableOver(sampleCards[0].id)).toBeTruthy();
+      // should not call get out of a11y mode
+      expect(a11yService.getOutOfA11yMode).not.toHaveBeenCalled();
+      // should not call get out of a11y mode
+      expect(a11yService.getOutOfA11yMode).not.toHaveBeenCalled();
+      // should call getCardOrder
+      expect(containerService.getCardOrder).toHaveBeenCalledWith(sampleCards[0].id);
+    });
+
+    it('then should move card in a11y mode on second enter', () => {
+      spyOn(containerService, 'getCardOrder').and.callFake((id: string) => cardIdToOrder[id]);
+      spyOn(containerService, 'moveCard').and.callThrough();
+      spyOn(containerService, 'getVisibleCardsCount').and.returnValue(4);
+      spyOn(a11yService, 'getOutOfA11yMode');
+
+      // first select card with order 0
+      a11yService.selectCard(sampleCards[0].id);
+      // current drag element order
+      expect(a11yService.isSelected(sampleCards[0].id)).toBeTruthy();
+      // drop element is same as use has not touch any arrow keys yet
+      expect(a11yService.isDraggableOver(sampleCards[0].id)).toBeTruthy();
+      // should not call get out of a11y mode
+      expect(a11yService.getOutOfA11yMode).not.toHaveBeenCalled();
+      // should call getCardOrder
+      expect(containerService.getCardOrder).toHaveBeenCalledWith(sampleCards[0].id);
+
+      // set hit right arrow key to move card to position 1
+      a11yService.moveDropPosition(a11ykeys.arrowRight);
+
+      // drop element should be updated
+      expect(a11yService.isDraggableOver(sampleCards[0].id)).toBeFalsy();
+
+      // hit enter again to drop element
+      a11yService.selectCard(sampleCards[1].id);
+
+      expect(containerService.moveCard).toHaveBeenCalledWith(0, 1);
+      // should call getOutOfA11yMode
+      expect(a11yService.getOutOfA11yMode).toHaveBeenCalled();
+      // should call getCardOrder
+      expect(containerService.getCardOrder).toHaveBeenCalledWith(sampleCards[1].id);
+    });
+  });
+
+  describe('when call moveDropPosition', () => {
+    it('with rightKey then should move drop element forward', () => {
+      spyOn(containerService, 'getCardOrder').and.callFake((id: string) => cardIdToOrder[id]);
+      // set total 3 cards in container
+      spyOn(containerService, 'getVisibleCardsCount').and.returnValue(3);
+
+      // first select card with order 0
+      a11yService.selectCard(sampleCards[0].id);
+      // current drag element order
+      expect(a11yService.isSelected(sampleCards[0].id)).toBeTruthy();
+      // drop element is same as use has not touch any arrow keys yet
+      expect(a11yService.isDraggableOver(sampleCards[0].id)).toBeTruthy();
+
+      // hit right arrow key to move card to position 1
+      a11yService.moveDropPosition(a11ykeys.arrowRight);
+      expect(a11yService.isDraggableOver(sampleCards[1].id)).toBeTruthy();
+
+      // next hit on right arrow key to move card to position 2
+      a11yService.moveDropPosition(a11ykeys.arrowRight);
+      expect(a11yService.isDraggableOver(sampleCards[2].id)).toBeTruthy();
+
+      // next hit on right arrow key to move card back to position 0 as its after last card
+      a11yService.moveDropPosition(a11ykeys.arrowRight);
+      expect(a11yService.isDraggableOver(sampleCards[0].id)).toBeTruthy();
+    });
+
+    it('with left ArrowKey then should move drop element forward', () => {
+      spyOn(containerService, 'getCardOrder').and.callFake((id: string) => cardIdToOrder[id]);
+      // set total 3 cards in container
+      spyOn(containerService, 'getVisibleCardsCount').and.returnValue(3);
+
+      // first select card with order 0
+      a11yService.selectCard(sampleCards[0].id);
+      // current drag element order
+      expect(a11yService.isSelected(sampleCards[0].id)).toBeTruthy();
+      // drop element is same as use has not touch any arrow keys yet
+      expect(a11yService.isDraggableOver(sampleCards[0].id)).toBeTruthy();
+
+      // hit left arrow key to move card to last position as 0 was first card and total 3 cards
+      a11yService.moveDropPosition(a11ykeys.arrowLeft);
+      expect(a11yService.isDraggableOver(sampleCards[2].id)).toBeTruthy();
+
+      // next hit on left arrow key to move card to position 1
+      a11yService.moveDropPosition(a11ykeys.arrowLeft);
+      expect(a11yService.isDraggableOver(sampleCards[1].id)).toBeTruthy();
+
+      // next hit on left arrow key to move card to position 0
+      a11yService.moveDropPosition(a11ykeys.arrowLeft);
+      expect(a11yService.isDraggableOver(sampleCards[0].id)).toBeTruthy();
+
+      // hit left arrow key to move card to last position as 0 was fist card
+      a11yService.moveDropPosition(a11ykeys.arrowLeft);
+      expect(a11yService.isDraggableOver(sampleCards[2].id)).toBeTruthy();
+    });
+
+    it('with a11yMode false should not call getVisibleCardsCount', () => {
+      spyOn(containerService, 'getVisibleCardsCount').and.returnValue(3);
+
+      // set a11yMode false
+      a11yService.getOutOfA11yMode();
+
+      a11yService.moveDropPosition(a11ykeys.arrowLeft);
+
+      expect(containerService.getVisibleCardsCount).not.toHaveBeenCalledWith();
+    });
+  });
+});

--- a/projects/addons/card-container/services/container.service.spec.ts
+++ b/projects/addons/card-container/services/container.service.spec.ts
@@ -1,0 +1,206 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { EmbeddedViewRef, Renderer2, ViewContainerRef, ViewRef } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  MockCardContainerComponent,
+  MockRenderer2,
+  SampleCardComponent,
+  sampleCardsSettings,
+} from '@clr/addons/testing';
+import { of } from 'rxjs';
+
+import { AppfxCardInternal } from '../appfx-card-container.interface';
+import { ContainerService } from './container.service';
+import { PersistenceService } from './persistence.service';
+
+enum CardIds {
+  first = 'sample-card-1',
+  second = 'sample-card-2',
+  third = 'sample-card-3',
+}
+
+describe('#ContainerService', () => {
+  let containerService: ContainerService;
+  let persistenceService: PersistenceService;
+  let fixture: ComponentFixture<MockCardContainerComponent>;
+  let containerComponent: MockCardContainerComponent;
+  let cardContainer: ViewContainerRef;
+  let sampleContainerCards: AppfxCardInternal[];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockCardContainerComponent],
+      providers: [
+        { provide: Renderer2, useClass: MockRenderer2 },
+        {
+          provide: PersistenceService,
+          useValue: {
+            initialize: () => {},
+            retrieve: () => of([]),
+            save: () => {},
+          },
+        },
+        ContainerService,
+      ],
+    });
+    containerService = TestBed.inject(ContainerService);
+    persistenceService = TestBed.inject(PersistenceService);
+    fixture = TestBed.createComponent(MockCardContainerComponent);
+    containerComponent = fixture.componentInstance;
+    cardContainer = containerComponent.cardContainer;
+    sampleContainerCards = [
+      {
+        id: CardIds.first,
+        title: 'Sample Card 1',
+        componentClass: SampleCardComponent,
+        hidden: false,
+        order: 0,
+        view: undefined as unknown as EmbeddedViewRef<void>,
+      },
+      {
+        id: CardIds.second,
+        title: 'Sample Card 2',
+        componentClass: SampleCardComponent,
+        hidden: false,
+        canHide: false,
+        order: 1,
+        view: undefined as unknown as EmbeddedViewRef<void>,
+      },
+      {
+        id: CardIds.third,
+        title: 'Sample Card 3',
+        componentClass: SampleCardComponent,
+        hidden: false,
+        canHide: false,
+        order: 5,
+        view: undefined as unknown as EmbeddedViewRef<void>,
+      },
+    ];
+    containerService.initialize(cardContainer, sampleContainerCards);
+  });
+
+  it('should create an instance', () => {
+    expect(containerService).toBeDefined();
+  });
+
+  it('when call getCardsWithOrder then should return cards with sorted order and by filtering hidden cards', (done: DoneFn) => {
+    spyOn(persistenceService, 'retrieve').and.returnValue(of(sampleCardsSettings));
+    const expectedCards = [sampleContainerCards[0], { ...sampleContainerCards[2], order: 1 }];
+    containerService.getCardsWithOrder().subscribe((cards: AppfxCardInternal[]) => {
+      expect(cards).toEqual(expectedCards);
+      done();
+    });
+  });
+
+  it('when call getCardWithOrder then should return card with order and hidden properties', (done: DoneFn) => {
+    spyOn(persistenceService, 'retrieve').and.returnValue(of(sampleCardsSettings));
+    const expectedCard = { ...sampleContainerCards[2], order: 5 };
+    containerService.getCardWithOrder(sampleContainerCards[2]).subscribe((card: AppfxCardInternal) => {
+      expect(card).toEqual(expectedCard);
+      done();
+    });
+  });
+
+  it('when call toggleCardVisibility then should return card with hidden property flipped', () => {
+    spyOn(persistenceService, 'retrieve').and.returnValue(of(sampleCardsSettings));
+    const expectedCard = { ...sampleContainerCards[2], order: 5, hidden: true };
+    const card = containerService.toggleCardVisibility(CardIds.third);
+    expect(card).toEqual(expectedCard);
+  });
+
+  describe('when call moveCard', () => {
+    it('then should detach and attach card to move position', () => {
+      spyOn(cardContainer, 'get').and.returnValue(<ViewRef>{});
+      spyOn(cardContainer, 'detach').and.returnValue(<ViewRef>{});
+      spyOn(cardContainer, 'insert').and.returnValue(<ViewRef>{});
+      spyOn(containerService, 'updateCardsOrder').and.callThrough();
+      containerService.moveCard(0, 1);
+      expect(cardContainer.get).toHaveBeenCalledWith(0);
+      expect(cardContainer.detach).toHaveBeenCalledWith(0);
+      expect(cardContainer.insert).toHaveBeenCalledWith(<ViewRef>{}, 1);
+    });
+
+    it('then should not perform move operation if fromIndex === toIndex', () => {
+      spyOn(cardContainer, 'get').and.returnValue(<ViewRef>{});
+      spyOn(cardContainer, 'detach').and.returnValue(<ViewRef>{});
+      spyOn(cardContainer, 'insert').and.returnValue(<ViewRef>{});
+      spyOn(containerService, 'updateCardsOrder').and.callThrough();
+      containerService.moveCard(0, 0);
+      expect(cardContainer.get).not.toHaveBeenCalled();
+      expect(cardContainer.detach).not.toHaveBeenCalled();
+      expect(cardContainer.insert).not.toHaveBeenCalled();
+    });
+  });
+
+  it('when call removeCard then should remove card from list', () => {
+    const cards = containerService.getContainerCards();
+    expect(cards.length).toEqual(3);
+    expect(cards[0].id).toEqual(CardIds.first);
+    expect(cards[1].id).toEqual(CardIds.second);
+    expect(cards[2].id).toEqual(CardIds.third);
+    containerService.removeCard(CardIds.second);
+    const updatedCards = containerService.getContainerCards();
+    expect(updatedCards.length).toEqual(2);
+    expect(updatedCards[0].id).toEqual(CardIds.first);
+    expect(updatedCards[1].id).toEqual(CardIds.third);
+  });
+
+  it('when call updateCard then should update specific card with new properties', () => {
+    const cards = containerService.getContainerCards();
+    expect(cards.length).toEqual(3);
+    expect(cards[2].order).toEqual(5);
+    const updatedCard = { ...cards[2], order: 99 };
+    containerService.updateCard(updatedCard);
+    const updatedCards = containerService.getContainerCards();
+    expect(updatedCards.length).toEqual(3);
+    expect(updatedCards[2].order).toEqual(99);
+  });
+
+  it('when call getVisibleCardsCount then should return visible cards', () => {
+    const cards = containerService.getContainerCards();
+    expect(cards.length).toEqual(3);
+    expect(cards[0].hidden).toBeFalsy();
+    expect(cards[1].hidden).toBeFalsy();
+    expect(cards[2].hidden).toBeFalsy();
+    const updatedCard = { ...cards[1], hidden: true };
+    containerService.updateCard(updatedCard);
+    const count = containerService.getVisibleCardsCount();
+    expect(count).toEqual(2);
+  });
+
+  it('when call updateCardsOrder then should update card order and save in persistence service', () => {
+    spyOn(persistenceService, 'save').and.callThrough();
+    containerService.updateCardsOrder();
+    const cards = containerService.getContainerCards();
+    expect(persistenceService.save).toHaveBeenCalledWith(cards);
+  });
+
+  describe('when call addCard', () => {
+    it('then should not add card if same card id already exist', () => {
+      const cards = containerService.getContainerCards();
+      expect(cards.length).toEqual(3);
+      const expectedError = "Card with id 'sample-card-1' already exist";
+      try {
+        containerService.addCard(cards[0]);
+      } catch (err) {
+        expect(err).toMatch(expectedError);
+        expect(cards.length).toEqual(3);
+      }
+    });
+
+    it('then should add card if card id is different', () => {
+      const cards = containerService.getContainerCards();
+      expect(cards.length).toEqual(3);
+      const newCard = { ...cards[0], id: 'new-card', title: 'New Card' };
+      containerService.addCard(newCard);
+      const newCards = containerService.getContainerCards();
+      expect(newCards.length).toEqual(4);
+    });
+  });
+});

--- a/projects/addons/card-container/services/dnd.service.spec.ts
+++ b/projects/addons/card-container/services/dnd.service.spec.ts
@@ -1,0 +1,80 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Renderer2 } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import {
+  cardIdToOrder,
+  MockCardContainerComponent,
+  MockContainerService,
+  MockRenderer2,
+  sampleCards,
+} from '@clr/addons/testing';
+
+import { ContainerService } from './container.service';
+import { DragDropService } from './dnd.service';
+
+describe('#DragDropService', () => {
+  let dragDropService: DragDropService;
+  let containerService: ContainerService;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockCardContainerComponent],
+      providers: [
+        { provide: Renderer2, useClass: MockRenderer2 },
+        { provide: ContainerService, useClass: MockContainerService },
+        DragDropService,
+      ],
+    });
+    dragDropService = TestBed.inject(DragDropService);
+    containerService = TestBed.inject(ContainerService);
+  });
+
+  it('should create an instance', () => {
+    expect(dragDropService).toBeDefined();
+  });
+
+  describe('when call onDragStart', () => {
+    it(' with default order then should not set dragOrder order', () => {
+      spyOn(containerService, 'getCardOrder').and.callFake((id: string) => cardIdToOrder[id]);
+      spyOn(containerService, 'moveCard');
+      dragDropService.onDragStart('cardWithDefaultOrder');
+      dragDropService.onDragDrop(sampleCards[1].id);
+      expect(containerService.moveCard).toHaveBeenCalledWith(undefined as any, 1);
+      expect(containerService.getCardOrder).toHaveBeenCalled();
+    });
+
+    it(' with order then should set dragOrder order', () => {
+      spyOn(containerService, 'getCardOrder').and.callFake((id: string) => cardIdToOrder[id]);
+      spyOn(containerService, 'moveCard');
+      dragDropService.onDragStart(sampleCards[0].id);
+      dragDropService.onDragDrop(sampleCards[1].id);
+      expect(containerService.moveCard).toHaveBeenCalledWith(0, 1);
+      expect(containerService.getCardOrder).toHaveBeenCalled();
+    });
+  });
+
+  describe('when call onDragDrop', () => {
+    it(' with default order then should not move card', () => {
+      spyOn(containerService, 'getCardOrder').and.callFake((id: string) => cardIdToOrder[id]);
+      spyOn(containerService, 'moveCard');
+      dragDropService.onDragDrop('cardWithDefaultOrder');
+      expect(containerService.moveCard).not.toHaveBeenCalled();
+      expect(containerService.getCardOrder).toHaveBeenCalled();
+    });
+
+    it(' with order then should move card', () => {
+      spyOn(containerService, 'getCardOrder').and.callFake((id: string) => cardIdToOrder[id]);
+      spyOn(containerService, 'moveCard');
+      dragDropService.onDragStart(sampleCards[1].id);
+      dragDropService.onDragDrop(sampleCards[2].id);
+      expect(containerService.moveCard).toHaveBeenCalledWith(1, 2);
+      expect(containerService.getCardOrder).toHaveBeenCalled();
+    });
+  });
+});

--- a/projects/addons/card-container/services/layout.service.spec.ts
+++ b/projects/addons/card-container/services/layout.service.spec.ts
@@ -1,0 +1,213 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ElementRef, Renderer2 } from '@angular/core';
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import {
+  MockElementRef,
+  MockRenderer2,
+  SampleCardComponent,
+  SampleCardWithoutFooterComponent,
+  SampleCardWithoutHeaderComponent,
+} from '@clr/addons/testing';
+
+import { cardSize } from '../appfx-card-container-constants';
+import { LayoutService } from './layout.service';
+
+const getCardElements = (cardHtmlElement: HTMLElement) => {
+  const cardElement = cardHtmlElement.querySelector('.card') as HTMLElement;
+  const cardHeaderElement = cardHtmlElement.querySelector('.card-header') as HTMLElement;
+  const cardBlockElement = cardHtmlElement.querySelector('.card-block') as HTMLElement;
+  const cardFooterElement = cardHtmlElement.querySelector('.card-footer') as HTMLElement;
+  return [cardElement, cardHeaderElement, cardBlockElement, cardFooterElement];
+};
+
+const calculateCardWidth = (unitWidth: number): number =>
+  unitWidth * cardSize.unitWidthInPixels + (unitWidth - 1) * cardSize.unitGutterSizeInPixels;
+
+const calculateCardHeight = (unitHeight: number): number =>
+  unitHeight * cardSize.unitHeightInPixels + (unitHeight - 1) * cardSize.unitGutterSizeInPixels;
+
+const overflowStyle = 'overflow-y';
+
+describe('#LayoutService', () => {
+  let layoutService: LayoutService;
+  let fixture: ComponentFixture<SampleCardComponent>;
+  let component: SampleCardComponent;
+  let mockRenderer: Renderer2;
+  let cardElement: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SampleCardComponent],
+      providers: [
+        { provide: Renderer2, useClass: MockRenderer2 },
+        { provide: ElementRef, useClass: MockElementRef },
+        LayoutService,
+      ],
+    });
+    layoutService = TestBed.inject(LayoutService);
+    mockRenderer = TestBed.inject(Renderer2);
+    fixture = TestBed.createComponent(SampleCardComponent);
+    component = fixture.componentInstance;
+    cardElement = component.eleRef.nativeElement;
+  });
+
+  it('should create an instance', () => {
+    expect(layoutService).toBeDefined();
+  });
+
+  describe('when all card-block, card-header and card-footer is present ', () => {
+    it('then should set card size and scrolling properties accordingly  ', () => {
+      const rendererSpy = spyOn(mockRenderer, 'setStyle').and.callThrough();
+
+      //  1 unit width -> 258px
+      //  5 unit height -> 58*5 + 18*4 -> 362px
+      layoutService.updateCardSize(cardElement, 1, 5);
+
+      expect(rendererSpy).toHaveBeenCalledTimes(5);
+      const [cardEl, cardHeaderEl, cardBlockEl, cardFooterEl] = getCardElements(cardElement);
+
+      expect(rendererSpy.calls.all()[0].args).toEqual([cardEl, 'width', `${calculateCardWidth(1)}px`]);
+      expect(rendererSpy.calls.all()[1].args).toEqual([cardHeaderEl, 'height', `${cardSize.headerHeightInPixels}px`]);
+      expect(rendererSpy.calls.all()[2].args).toEqual([cardFooterEl, 'height', `${cardSize.footerHeightInPixels}px`]);
+      expect(rendererSpy.calls.all()[3].args).toEqual([
+        cardBlockEl,
+        'height',
+        `${calculateCardHeight(5) - cardSize.headerHeightInPixels - cardSize.footerHeightInPixels}px`,
+      ]);
+      expect(rendererSpy.calls.all()[4].args).toEqual([cardBlockEl, overflowStyle, 'auto']);
+    });
+
+    it('then should set card size with adjusting gutter with and scrolling properties accordingly  ', () => {
+      const rendererSpy = spyOn(mockRenderer, 'setStyle').and.callThrough();
+
+      //  2 unit width -> 258*2 + 18 -> 534px
+      //  5 unit height -> 58*5 + 18*4 -> 362px
+      layoutService.updateCardSize(cardElement, 2, 5);
+
+      expect(rendererSpy).toHaveBeenCalledTimes(5);
+      const [cardEl, cardHeaderEl, cardBlockEl, cardFooterEl] = getCardElements(cardElement);
+
+      expect(rendererSpy.calls.all()[0].args).toEqual([cardEl, 'width', `${calculateCardWidth(2)}px`]);
+      expect(rendererSpy.calls.all()[1].args).toEqual([cardHeaderEl, 'height', `${cardSize.headerHeightInPixels}px`]);
+      expect(rendererSpy.calls.all()[2].args).toEqual([cardFooterEl, 'height', `${cardSize.footerHeightInPixels}px`]);
+      expect(rendererSpy.calls.all()[3].args).toEqual([
+        cardBlockEl,
+        'height',
+        `${calculateCardHeight(5) - cardSize.headerHeightInPixels - cardSize.footerHeightInPixels}px`,
+      ]);
+      expect(rendererSpy.calls.all()[4].args).toEqual([cardBlockEl, overflowStyle, 'auto']);
+    });
+
+    it('then should remove card style width and height if -1 unitWidth and unitHeight are provided ', () => {
+      spyOn(mockRenderer, 'setStyle').and.callThrough();
+      const rendererSpy = spyOn(mockRenderer, 'removeStyle').and.callThrough();
+      layoutService.updateCardSize(cardElement, -1, -1);
+
+      expect(rendererSpy).toHaveBeenCalledTimes(2);
+      const [cardEl, cardHeaderEl, cardBlockEl, cardFooterEl] = getCardElements(cardElement);
+      expect(cardHeaderEl).toBeTruthy();
+      expect(cardFooterEl).toBeTruthy();
+      expect(rendererSpy.calls.all()[0].args).toEqual([cardEl, 'width']);
+      expect(rendererSpy.calls.all()[1].args).toEqual([cardBlockEl, 'height']);
+    });
+  });
+});
+
+describe('#LayoutService SampleCardWithoutFooter', () => {
+  let layoutService: LayoutService;
+  let fixture: ComponentFixture<SampleCardWithoutFooterComponent>;
+  let component: SampleCardWithoutFooterComponent;
+  let mockRenderer: Renderer2;
+  let cardElement: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SampleCardWithoutFooterComponent],
+      providers: [
+        { provide: Renderer2, useClass: MockRenderer2 },
+        { provide: ElementRef, useClass: MockElementRef },
+        LayoutService,
+      ],
+    });
+    layoutService = TestBed.inject(LayoutService);
+    mockRenderer = TestBed.inject(Renderer2);
+    fixture = TestBed.createComponent(SampleCardWithoutFooterComponent);
+    component = fixture.componentInstance;
+    cardElement = component.eleRef.nativeElement;
+  });
+
+  describe('when only card-block and card-header is present', () => {
+    it('then should set card block height accordingly and should add scroll to block', () => {
+      const rendererSpy = spyOn(mockRenderer, 'setStyle').and.callThrough();
+
+      //  1 unit width -> 258px
+      //  5 unit height -> 58*5 + 18*4 -> 362px
+      layoutService.updateCardSize(cardElement, 1, 5);
+
+      expect(rendererSpy).toHaveBeenCalledTimes(4);
+      const [cardEl, cardHeaderEl, cardBlockEl] = getCardElements(cardElement);
+
+      expect(rendererSpy.calls.all()[0].args).toEqual([cardEl, 'width', `${calculateCardWidth(1)}px`]);
+      expect(rendererSpy.calls.all()[1].args).toEqual([cardHeaderEl, 'height', `${cardSize.headerHeightInPixels}px`]);
+      expect(rendererSpy.calls.all()[2].args).toEqual([
+        cardBlockEl,
+        'height',
+        `${calculateCardHeight(5) - cardSize.headerHeightInPixels}px`,
+      ]);
+      expect(rendererSpy.calls.all()[3].args).toEqual([cardBlockEl, 'overflow-y', 'auto']);
+    });
+  });
+});
+
+describe('#LayoutService SampleCardWithoutHeader', () => {
+  let layoutService: LayoutService;
+  let fixture: ComponentFixture<SampleCardWithoutHeaderComponent>;
+  let component: SampleCardWithoutHeaderComponent;
+  let mockRenderer: Renderer2;
+  let cardElement: HTMLElement;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [SampleCardWithoutHeaderComponent],
+      providers: [
+        { provide: Renderer2, useClass: MockRenderer2 },
+        { provide: ElementRef, useClass: MockElementRef },
+        LayoutService,
+      ],
+    });
+    layoutService = TestBed.inject(LayoutService);
+    mockRenderer = TestBed.inject(Renderer2);
+    fixture = TestBed.createComponent(SampleCardWithoutHeaderComponent);
+    component = fixture.componentInstance;
+    cardElement = component.eleRef.nativeElement;
+  });
+
+  describe('when only card-block and card-footer is present', () => {
+    it('then should set card block height accordingly and should add scroll to block', () => {
+      const rendererSpy = spyOn(mockRenderer, 'setStyle').and.callThrough();
+
+      //  1 unit width -> 258px
+      //  5 unit height -> 58*5 + 18*4 -> 362px
+      layoutService.updateCardSize(cardElement, 1, 5);
+
+      expect(rendererSpy).toHaveBeenCalledTimes(3);
+      const [cardEl, cardHeaderEl, cardBlockEl, cardFooterEl] = getCardElements(cardElement);
+
+      expect(rendererSpy.calls.all()[0].args).toEqual([cardEl, 'width', `${calculateCardWidth(1)}px`]);
+      expect(rendererSpy.calls.all()[1].args).toEqual([cardFooterEl, 'height', `${cardSize.footerHeightInPixels}px`]);
+      expect(rendererSpy.calls.all()[2].args).toEqual([
+        cardBlockEl,
+        'height',
+        `${calculateCardHeight(5) - cardSize.headerHeightInPixels}px`,
+      ]);
+
+      expect(cardHeaderEl).toBeNull();
+    });
+  });
+});

--- a/projects/addons/card-container/services/persistence.service.spec.ts
+++ b/projects/addons/card-container/services/persistence.service.spec.ts
@@ -1,0 +1,111 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { EmbeddedViewRef } from '@angular/core';
+import { TestBed } from '@angular/core/testing';
+import { SampleCardComponent, sampleCards } from '@clr/addons/testing';
+import { of } from 'rxjs';
+
+import { AppfxCardInternal, AppfxCardSettings } from '../appfx-card-container.interface';
+import { PersistenceService } from './persistence.service';
+import { AppfxCardContainerStore } from '../utils/appfx-card-container-store';
+
+describe('#PersistenceService', () => {
+  const containerStore = new AppfxCardContainerStore().getLocalStore('containerId');
+  let persistenceService: PersistenceService;
+  let cards: AppfxCardInternal[];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      providers: [PersistenceService],
+    });
+    persistenceService = TestBed.inject(PersistenceService);
+    persistenceService.initialize(containerStore);
+    cards = [...sampleCards];
+  });
+
+  it('should create an instance', () => {
+    expect(persistenceService).toBeDefined();
+  });
+
+  describe('when called retrieve', () => {
+    it('then should fetch settings from container', () => {
+      spyOn(containerStore, 'retrieve').and.returnValue(of([]));
+      persistenceService.retrieve().subscribe((cardSettings: AppfxCardSettings[]) => {
+        expect(cardSettings).toEqual([]);
+      });
+      expect(containerStore.retrieve).toHaveBeenCalled();
+    });
+  });
+
+  describe('when called save', () => {
+    let expectedSettings: AppfxCardSettings[];
+
+    beforeEach(() => {
+      expectedSettings = cards.map((card: AppfxCardInternal) => ({
+        id: card.id,
+        order: card.order,
+        hidden: card.hidden,
+      }));
+    });
+
+    it('then should generate and save card settings properly', () => {
+      spyOn(containerStore, 'save').and.callThrough();
+      persistenceService.save(cards);
+      expect(containerStore.save).toHaveBeenCalledWith(expectedSettings);
+    });
+
+    it('then should merge and update settings if cardSettings for card is already available', () => {
+      // save cards settings before
+      persistenceService.save(cards);
+      persistenceService.retrieve().subscribe((cardSettings: AppfxCardSettings[]) => {
+        expect(cardSettings).toEqual(expectedSettings);
+      });
+      // update settings of card 1
+      const sampleCardOne = {
+        ...sampleCards[1],
+        hidden: false,
+      };
+      spyOn(containerStore, 'save').and.callThrough();
+      persistenceService.save([sampleCardOne]);
+      const expectedMergedCardSettings = expectedSettings.map((cardSetting: AppfxCardSettings) => {
+        if (cardSetting.id === sampleCardOne.id) {
+          return { ...cardSetting, hidden: false };
+        }
+        return cardSetting;
+      });
+      expect(containerStore.save).toHaveBeenCalledWith(expectedMergedCardSettings);
+      persistenceService.retrieve().subscribe((cardSettings: AppfxCardSettings[]) => {
+        expect(cardSettings).toEqual(expectedMergedCardSettings);
+      });
+    });
+
+    it('then should append new card settings to existing settings', () => {
+      // save cards settings before
+      persistenceService.save(cards);
+      persistenceService.retrieve().subscribe((cardSettings: AppfxCardSettings[]) => {
+        expect(cardSettings).toEqual(expectedSettings);
+      });
+      // update settings of card 1
+      const newCard = {
+        id: 'custom-attributes',
+        title: 'Custom Attributes',
+        componentClass: SampleCardComponent,
+        order: 3,
+        hidden: false,
+        view: undefined as unknown as EmbeddedViewRef<void>,
+      };
+      spyOn(containerStore, 'save').and.callThrough();
+      persistenceService.save([newCard]);
+      const expectedMergedCardSettings = [...expectedSettings, { id: 'custom-attributes', order: 3, hidden: false }];
+      expect(containerStore.save).toHaveBeenCalledWith(expectedMergedCardSettings);
+      persistenceService.retrieve().subscribe((cardSettings: AppfxCardSettings[]) => {
+        expect(cardSettings).toEqual(expectedMergedCardSettings);
+      });
+    });
+  });
+});

--- a/projects/addons/card-container/settings/appfx-card-container-settings.component.spec.ts
+++ b/projects/addons/card-container/settings/appfx-card-container-settings.component.spec.ts
@@ -1,0 +1,64 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { sampleCards, sortCardsFn } from '@clr/addons/testing';
+import { AppfxTranslateModule } from '@clr/addons/translate';
+import { ClrCheckboxModule } from '@clr/angular/forms/checkbox';
+import { ClrDropdownModule } from '@clr/angular/popover/dropdown';
+
+import { AppfxCardInternal } from '../appfx-card-container.interface';
+import { AppfxCardContainerSettingsComponent } from './appfx-card-container-settings.component';
+
+describe('AppfxCardContainerSettingsComponent', () => {
+  let fixture: ComponentFixture<AppfxCardContainerSettingsComponent>;
+  let component: AppfxCardContainerSettingsComponent;
+  let sampleContainerCards: AppfxCardInternal[];
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      imports: [ClrDropdownModule, ClrCheckboxModule, AppfxTranslateModule],
+      declarations: [AppfxCardContainerSettingsComponent],
+    });
+    fixture = TestBed.createComponent(AppfxCardContainerSettingsComponent);
+    component = fixture.componentInstance;
+    sampleContainerCards = [...sampleCards];
+  });
+
+  beforeEach(() => {
+    component.containerCards = [...sampleContainerCards];
+    fixture.detectChanges();
+  });
+
+  it('should create component', () => {
+    expect(component).toBeDefined();
+  });
+
+  describe('when pass card list to settings component', () => {
+    it('then should sort cards according to title', () => {
+      const sortedCards = [...sampleContainerCards];
+      const expectedSortedCards = sortedCards.sort(sortCardsFn);
+      expect(component.cards).toEqual(expectedSortedCards);
+    });
+  });
+
+  describe('when call toggleShowHide', () => {
+    it('then emit event with cardId', () => {
+      spyOn(component.toggleCardVisibility, 'emit').and.callThrough();
+      component.toggleShowHide(sampleContainerCards[0]);
+      fixture.detectChanges();
+      expect(component.toggleCardVisibility.emit).toHaveBeenCalledWith(sampleContainerCards[0].id);
+    });
+
+    it('then should not emit event when canHide property of the card is false', () => {
+      spyOn(component.toggleCardVisibility, 'emit').and.callThrough();
+      component.toggleShowHide(sampleContainerCards[2]);
+      fixture.detectChanges();
+      expect(component.toggleCardVisibility.emit).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/projects/addons/testing/card-container/appfx-card-container.component.mock.spec.ts
+++ b/projects/addons/testing/card-container/appfx-card-container.component.mock.spec.ts
@@ -1,0 +1,29 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { MockAppfxCardContainerComponent } from './appfx-card-container.component.mock';
+
+describe('MockAppfxCardContainerComponent', () => {
+  let fixture: ComponentFixture<MockAppfxCardContainerComponent>;
+  let component: MockAppfxCardContainerComponent;
+
+  beforeEach(() => {
+    TestBed.configureTestingModule({
+      declarations: [MockAppfxCardContainerComponent],
+    });
+
+    fixture = TestBed.createComponent(MockAppfxCardContainerComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create an instance of MockAppfxCardContainerComponent', () => {
+    expect(component).toBeDefined();
+  });
+});

--- a/projects/addons/testing/card-container/appfx-card-container.component.mock.ts
+++ b/projects/addons/testing/card-container/appfx-card-container.component.mock.ts
@@ -1,0 +1,32 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, Input } from '@angular/core';
+
+@Component({
+  selector: 'appfx-card-container',
+  standalone: false,
+  template: '',
+})
+export class MockAppfxCardContainerComponent {
+  @Input() containerId: string;
+
+  @Input() cards: unknown[] = [];
+
+  @Input() persistenceStore?: unknown;
+
+  @Input() showCardContainerSettings: boolean = true;
+
+  @Input() dragDropEnabled: boolean = true;
+}
+
+@Component({
+  selector: 'appfx-card-container',
+  standalone: true,
+  template: '',
+})
+export class MockAppfxCardContainerStandaloneComponent extends MockAppfxCardContainerComponent {}

--- a/projects/addons/testing/card-container/appfx-card-container.mock.ts
+++ b/projects/addons/testing/card-container/appfx-card-container.mock.ts
@@ -1,0 +1,203 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+import { Component, ElementRef, EmbeddedViewRef, ViewChild, ViewContainerRef } from '@angular/core';
+import { AppfxCard } from '@clr/addons/card-container';
+
+// mock for container service
+export class MockContainerService {
+  getCardOrder() {}
+
+  moveCard() {}
+
+  getVisibleCardsCount() {}
+}
+
+// mock for A11y service
+export class MockA11yService {
+  isSelected() {}
+
+  isDraggableOver() {}
+
+  selectCard() {}
+
+  moveDropPosition() {}
+}
+
+// mock for DragDrop service
+export class MockDragDropService {
+  onDragStart() {}
+
+  onDragDrop() {}
+}
+
+// mock for Layout service
+export class MockLayoutService {
+  updateCardSize() {}
+}
+
+// Renderer2 Mock
+export class MockRenderer2 {
+  setStyle(el: any, name: string, style: string): void {
+    el[name] = style;
+  }
+
+  removeStyle(el: any, name: string): void {
+    el[name] = null;
+  }
+}
+
+// Mock Card Container for ViewContainerRef
+@Component({
+  standalone: false,
+  template: `
+    <div class="scrollable">
+      <div>
+        <ng-template #cardContainer></ng-template>
+      </div>
+    </div>
+  `,
+  styles: [
+    '.scrollable { overflow: auto; position: absolute; left: 0; right: 0; top: 0; bottom: 0; max-height: 20px; }',
+  ],
+})
+export class MockCardContainerComponent {
+  @ViewChild('cardContainer', { read: ViewContainerRef, static: true }) cardContainer: ViewContainerRef;
+}
+
+// Sample Card to test scenarios
+@Component({
+  standalone: false,
+  template: `
+    <div class="card">
+      <div class="card-header">
+        <div class="card-title">Sample Card</div>
+      </div>
+      <div class="card-block"></div>
+      <div class="card-footer"></div>
+    </div>
+  `,
+})
+export class SampleCardComponent {
+  eleRef: ElementRef;
+
+  constructor(el: ElementRef) {
+    this.eleRef = el;
+  }
+}
+
+// Sample Card to without footer test scenarios
+@Component({
+  standalone: false,
+  template: `
+    <div class="card">
+      <div class="card-header">
+        <div class="card-title">Sample Card</div>
+      </div>
+      <div class="card-block"></div>
+    </div>
+  `,
+})
+export class SampleCardWithoutFooterComponent {
+  eleRef: ElementRef;
+
+  constructor(el: ElementRef) {
+    this.eleRef = el;
+  }
+}
+
+// Sample Card to without header test scenarios
+@Component({
+  standalone: false,
+  template: `
+    <div class="card">
+      <div class="card-block">
+        <div class="card-title">Sample Card</div>
+      </div>
+      <div class="card-footer"></div>
+    </div>
+  `,
+})
+export class SampleCardWithoutHeaderComponent {
+  eleRef: ElementRef;
+
+  constructor(el: ElementRef) {
+    this.eleRef = el;
+  }
+}
+
+// mock element ref
+export class MockElementRef extends ElementRef {
+  nativeElement = {
+    querySelector: () => {},
+  };
+}
+
+// sort function to display cards by sorted titles
+export const sortCardsFn = (a: AppfxCard, b: AppfxCard) => {
+  if (a.title && b.title) {
+    return a.title.localeCompare(b.title);
+  }
+  return 0;
+};
+
+// sample cards for unit tests
+export const sampleCards = [
+  {
+    id: 'sample-card-1',
+    title: 'Sample Card 1',
+    componentClass: SampleCardComponent,
+    hidden: false,
+    order: 0,
+    view: undefined as unknown as EmbeddedViewRef<void>,
+  },
+  {
+    id: 'sample-card-2',
+    title: 'Sample Card 2',
+    componentClass: SampleCardComponent,
+    hidden: false,
+    canHide: false,
+    order: 1,
+    view: undefined as unknown as EmbeddedViewRef<void>,
+  },
+  {
+    id: 'sample-card-3',
+    title: 'Sample Card 3',
+    componentClass: SampleCardComponent,
+    hidden: false,
+    canHide: false,
+    order: 5,
+    view: undefined as unknown as EmbeddedViewRef<void>,
+  },
+];
+
+// sample card settings
+export const sampleCardsSettings = [
+  {
+    id: 'sample-card-1',
+    hidden: false,
+    order: 0,
+  },
+  {
+    id: 'sample-card-2',
+    hidden: true,
+    order: 2,
+  },
+  {
+    id: 'sample-card-3',
+    hidden: false,
+    order: 5,
+  },
+];
+
+// card to order mapping
+export const cardIdToOrder = {
+  cardWithDefaultOrder: Infinity,
+  [sampleCards[0].id]: 0,
+  [sampleCards[1].id]: 1,
+  [sampleCards[2].id]: 2,
+};

--- a/projects/addons/testing/card-container/index.ts
+++ b/projects/addons/testing/card-container/index.ts
@@ -1,0 +1,27 @@
+/*
+ * Copyright (c) 2016-2026 Broadcom. All Rights Reserved.
+ * The term "Broadcom" refers to Broadcom Inc. and/or its subsidiaries.
+ * This software is released under MIT license.
+ * The full license information can be found in LICENSE in the root directory of this project.
+ */
+
+export {
+  MockAppfxCardContainerComponent,
+  MockAppfxCardContainerStandaloneComponent,
+} from './appfx-card-container.component.mock';
+export {
+  cardIdToOrder,
+  MockA11yService,
+  MockCardContainerComponent,
+  MockContainerService,
+  MockDragDropService,
+  MockElementRef,
+  MockLayoutService,
+  MockRenderer2,
+  sampleCards,
+  sampleCardsSettings,
+  SampleCardComponent,
+  SampleCardWithoutFooterComponent,
+  SampleCardWithoutHeaderComponent,
+  sortCardsFn,
+} from './appfx-card-container.mock';

--- a/projects/addons/testing/index.ts
+++ b/projects/addons/testing/index.ts
@@ -6,5 +6,6 @@
  */
 
 export * from './a11y';
+export * from './card-container';
 export * from './datagrid';
 export * from './datagrid-filters';

--- a/projects/addons/testing/testing.api.md
+++ b/projects/addons/testing/testing.api.md
@@ -73,6 +73,12 @@ import { ViewContainerRef } from '@angular/core';
 import { ViewportRuler } from '@angular/cdk/scrolling';
 
 // @public (undocumented)
+export const cardIdToOrder: {
+    [x: string]: number;
+    cardWithDefaultOrder: number;
+};
+
+// @public (undocumented)
 export class FilterInputTestHelper {
     constructor(inputElement: HTMLInputElement);
     // (undocumented)
@@ -249,6 +255,44 @@ export class GridRowTestHelper {
 }
 
 // @public (undocumented)
+export class MockA11yService {
+    // (undocumented)
+    isDraggableOver(): void;
+    // (undocumented)
+    isSelected(): void;
+    // (undocumented)
+    moveDropPosition(): void;
+    // (undocumented)
+    selectCard(): void;
+}
+
+// @public (undocumented)
+export class MockAppfxCardContainerComponent {
+    // (undocumented)
+    cards: unknown[];
+    // (undocumented)
+    containerId: string;
+    // (undocumented)
+    dragDropEnabled: boolean;
+    // (undocumented)
+    persistenceStore?: unknown;
+    // (undocumented)
+    showCardContainerSettings: boolean;
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<MockAppfxCardContainerComponent, "appfx-card-container", never, { "containerId": { "alias": "containerId"; "required": false; }; "cards": { "alias": "cards"; "required": false; }; "persistenceStore": { "alias": "persistenceStore"; "required": false; }; "showCardContainerSettings": { "alias": "showCardContainerSettings"; "required": false; }; "dragDropEnabled": { "alias": "dragDropEnabled"; "required": false; }; }, {}, never, never, false, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<MockAppfxCardContainerComponent, never>;
+}
+
+// @public (undocumented)
+export class MockAppfxCardContainerStandaloneComponent extends MockAppfxCardContainerComponent {
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<MockAppfxCardContainerStandaloneComponent, "appfx-card-container", never, {}, {}, never, never, true, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<MockAppfxCardContainerStandaloneComponent, never>;
+}
+
+// @public (undocumented)
 export class MockAppfxDatagridComponent {
     // (undocumented)
     actionBarActions: any[];
@@ -342,6 +386,26 @@ export class MockAppfxDatagridComponent {
     static ɵcmp: i0.ɵɵComponentDeclaration<MockAppfxDatagridComponent, "appfx-datagrid", never, { "gridItems": { "alias": "gridItems"; "required": false; }; "columns": { "alias": "columns"; "required": false; }; "layoutModel": { "alias": "layoutModel"; "required": false; }; "footerModel": { "alias": "footerModel"; "required": false; }; "pageSize": { "alias": "pageSize"; "required": false; }; "pageSizeOptions": { "alias": "pageSizeOptions"; "required": false; }; "totalItems": { "alias": "totalItems"; "required": false; }; "selectionType": { "alias": "selectionType"; "required": false; }; "selectedItems": { "alias": "selectedItems"; "required": false; }; "datagridLabels": { "alias": "datagridLabels"; "required": false; }; "preSelectFirstItem": { "alias": "preSelectFirstItem"; "required": false; }; "rowSelectionMode": { "alias": "rowSelectionMode"; "required": false; }; "actionBarActions": { "alias": "actionBarActions"; "required": false; }; "showFooter": { "alias": "showFooter"; "required": false; }; "singleRowActions": { "alias": "singleRowActions"; "required": false; }; "noItemsFoundPlaceholder": { "alias": "noItemsFoundPlaceholder"; "required": false; }; "loading": { "alias": "loading"; "required": false; }; "serverDrivenDatagrid": { "alias": "serverDrivenDatagrid"; "required": false; }; "filterMode": { "alias": "filterMode"; "required": false; }; "listItemsCount": { "alias": "listItemsCount"; "required": false; }; "trackByGridItemProperty": { "alias": "trackByGridItemProperty"; "required": false; }; "isRowLocked": { "alias": "isRowLocked"; "required": false; }; "detailHeader": { "alias": "detailHeader"; "required": false; }; "detailBody": { "alias": "detailBody"; "required": false; }; "rowDetailContent": { "alias": "rowDetailContent"; "required": false; }; "rowsExpandedByDefault": { "alias": "rowsExpandedByDefault"; "required": false; }; "vscPersistDatagridSettings": { "alias": "vscPersistDatagridSettings"; "required": false; }; "detailState": { "alias": "detailState"; "required": false; }; "trackByFunction": { "alias": "trackByFunction"; "required": false; }; "virtualScrolling": { "alias": "virtualScrolling"; "required": false; }; "dataRange": { "alias": "dataRange"; "required": false; }; }, { "selectedItemsChange": "selectedItemsChange"; "gridItemsChange": "gridItemsChange"; "selectionChange": "selectionChange"; "searchTermChange": "searchTermChange"; "refreshGridData": "refreshGridData"; "refreshVirtualGridData": "refreshVirtualGridData"; "actionClick": "actionClick"; "rowActionMenuOpenChange": "rowActionMenuOpenChange"; "exportDataEvent": "exportDataEvent"; "detailStateChange": "detailStateChange"; }, never, never, false, never>;
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MockAppfxDatagridComponent, never>;
+}
+
+// @public (undocumented)
+export class MockCardContainerComponent {
+    // (undocumented)
+    cardContainer: ViewContainerRef;
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<MockCardContainerComponent, "ng-component", never, {}, {}, never, never, false, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<MockCardContainerComponent, never>;
+}
+
+// @public (undocumented)
+export class MockContainerService {
+    // (undocumented)
+    getCardOrder(): void;
+    // (undocumented)
+    getVisibleCardsCount(): void;
+    // (undocumented)
+    moveCard(): void;
 }
 
 // @public (undocumented)
@@ -446,6 +510,22 @@ export class MockDatagridPreserveSelectionDirective {
 }
 
 // @public (undocumented)
+export class MockDragDropService {
+    // (undocumented)
+    onDragDrop(): void;
+    // (undocumented)
+    onDragStart(): void;
+}
+
+// @public (undocumented)
+export class MockElementRef extends ElementRef {
+    // (undocumented)
+    nativeElement: {
+        querySelector: () => void;
+    };
+}
+
+// @public (undocumented)
 export class MockIsRowSelectablePipe implements PipeTransform {
     // (undocumented)
     transform(rowItem: any, isLocked?: (rowItem: any) => boolean, disabled?: boolean): boolean;
@@ -453,6 +533,20 @@ export class MockIsRowSelectablePipe implements PipeTransform {
     static ɵfac: i0.ɵɵFactoryDeclaration<MockIsRowSelectablePipe, never>;
     // (undocumented)
     static ɵpipe: i0.ɵɵPipeDeclaration<MockIsRowSelectablePipe, "isRowSelectable", false>;
+}
+
+// @public (undocumented)
+export class MockLayoutService {
+    // (undocumented)
+    updateCardSize(): void;
+}
+
+// @public (undocumented)
+export class MockRenderer2 {
+    // (undocumented)
+    removeStyle(el: any, name: string): void;
+    // (undocumented)
+    setStyle(el: any, name: string, style: string): void;
 }
 
 // @public (undocumented)
@@ -478,6 +572,70 @@ export class MockStandaloneDatagridComponent extends MockAppfxDatagridComponent 
     // (undocumented)
     static ɵfac: i0.ɵɵFactoryDeclaration<MockStandaloneDatagridComponent, never>;
 }
+
+// @public (undocumented)
+export class SampleCardComponent {
+    constructor(el: ElementRef);
+    // (undocumented)
+    eleRef: ElementRef;
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<SampleCardComponent, "ng-component", never, {}, {}, never, never, false, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<SampleCardComponent, never>;
+}
+
+// @public (undocumented)
+export const sampleCards: ({
+    id: string;
+    title: string;
+    componentClass: typeof SampleCardComponent;
+    hidden: boolean;
+    order: number;
+    view: EmbeddedViewRef<void>;
+    canHide?: undefined;
+} | {
+    id: string;
+    title: string;
+    componentClass: typeof SampleCardComponent;
+    hidden: boolean;
+    canHide: boolean;
+    order: number;
+    view: EmbeddedViewRef<void>;
+})[];
+
+// @public (undocumented)
+export const sampleCardsSettings: {
+    id: string;
+    hidden: boolean;
+    order: number;
+}[];
+
+// @public (undocumented)
+export class SampleCardWithoutFooterComponent {
+    constructor(el: ElementRef);
+    // (undocumented)
+    eleRef: ElementRef;
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<SampleCardWithoutFooterComponent, "ng-component", never, {}, {}, never, never, false, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<SampleCardWithoutFooterComponent, never>;
+}
+
+// @public (undocumented)
+export class SampleCardWithoutHeaderComponent {
+    constructor(el: ElementRef);
+    // (undocumented)
+    eleRef: ElementRef;
+    // (undocumented)
+    static ɵcmp: i0.ɵɵComponentDeclaration<SampleCardWithoutHeaderComponent, "ng-component", never, {}, {}, never, never, false, never>;
+    // (undocumented)
+    static ɵfac: i0.ɵɵFactoryDeclaration<SampleCardWithoutHeaderComponent, never>;
+}
+
+// Warning: (ae-forgotten-export) The symbol "AppfxCard" needs to be exported by the entry point clr-addons-testing.d.ts
+//
+// @public (undocumented)
+export const sortCardsFn: (a: AppfxCard, b: AppfxCard) => number;
 
 // @public (undocumented)
 export class ZoomLevelServiceMock {


### PR DESCRIPTION
Backport d048c2ef80aebf01ca990b27fc4afb2b83f5490a from #2549. <br> ## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [x] Other... Please describe: test migration

## What is the current behavior?

Issue Number: N/A

PR #2518 migrated the card-container addon's production code but did not migrate its unit test/spec files, leaving the addon without test coverage in this repo.

## What is the new behavior?

Migrates all card-container spec files and testing mocks/helpers, adapted to the `@clr/addons/card-container` module structure. Full addons test suite passes (475/475) with these tests included.

This is a manual backport of #2549 to `main` — the automated backport action failed because the generated `projects/addons/testing/testing.api.md` file conflicted during cherry-pick; that file has been regenerated against `main`'s current code instead of hand-resolving the diff.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

No production code was changed.