### PR TITLE
fix(datagrid): reset Items provider when *clrDgItems view is destroyed

### DIFF
--- a/projects/angular/data/datagrid/datagrid-items.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-items.spec.ts
@@ -5,6 +5,7 @@
  * The full license information can be found in LICENSE in the root directory of this project.
  */
 
+import { CommonModule } from '@angular/common';
 import { Component, TrackByFunction, ViewChild } from '@angular/core';
 import { TestBed } from '@angular/core/testing';
 
@@ -30,6 +31,22 @@ class FullTest {
   numbers = [1, 2, 3, 4, 5];
 
   trackBy: (index: number, item: number) => any;
+}
+
+@Component({
+  template: `
+    <ul *ngIf="showItems">
+      <li *clrDgItems="let n of numbers; trackBy: trackBy">{{ n }}</li>
+    </ul>
+  `,
+  standalone: false,
+})
+class DestroyTest {
+  numbers = [1, 2, 3, 4, 5];
+
+  trackBy: (index: number, item: number) => any;
+
+  showItems = true;
 }
 
 @Component({
@@ -99,6 +116,45 @@ export default function (): void {
         this.testComponent.numbers = undefined;
         this.fixture.detectChanges();
         expect(this.clarityDirective._rawItems).toEqual([]);
+      });
+    });
+
+    describe('cleans up on destroy', () => {
+      beforeEach(function () {
+        TestBed.configureTestingModule({
+          imports: [CommonModule, ClrDatagridModule],
+          declarations: [DestroyTest],
+          providers: [Items, FiltersProvider, Sort, Page, StateDebouncer],
+        });
+        this.fixture = TestBed.createComponent(DestroyTest);
+        this.fixture.detectChanges();
+        this.testComponent = this.fixture.componentInstance;
+        this.itemsProvider = TestBed.inject(Items);
+      });
+
+      afterEach(function () {
+        this.fixture.destroy();
+      });
+
+      it('smartens the Items provider back down when the *clrDgItems view is destroyed', function () {
+        expect(this.itemsProvider.smart).toBe(true);
+
+        this.testComponent.showItems = false;
+        this.fixture.detectChanges();
+
+        expect(this.itemsProvider.smart).toBe(false);
+      });
+
+      it('stops reacting to page changes once destroyed, instead of slicing stale data', function () {
+        this.testComponent.showItems = false;
+        this.fixture.detectChanges();
+
+        const page: Page = TestBed.inject(Page);
+        page.size = 2;
+        page.current = 2;
+
+        // With the provider no longer smart, page changes must not touch `displayed`.
+        expect(this.itemsProvider.displayed).toEqual([1, 2, 3, 4, 5]);
       });
     });
 

--- a/projects/angular/data/datagrid/datagrid-items.ts
+++ b/projects/angular/data/datagrid/datagrid-items.ts
@@ -84,5 +84,6 @@ export class ClrDatagridItems<T> implements DoCheck, OnDestroy {
 
   ngOnDestroy() {
     this.subscriptions.forEach(sub => sub.unsubscribe());
+    this.items.smartenDown();
   }
 }


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

`ClrDatagridItems` (`*clrDgItems`) unconditionally calls `items.smartenUp()` in its
constructor, which flips the shared `Items` provider into "smart" mode and wires up
live `_filtersSub` / `_sortSub` / `_pageSub` subscriptions on it. When the
`*clrDgItems` view is later destroyed, `ngOnDestroy()` only unsubscribes its own two
local subscriptions — it never calls `items.smartenDown()` / `items.destroy()`. The
`Items` provider is scoped to the whole `<clr-datagrid>` and can be shared by more
than one template branch (e.g. a datagrid with both a server-driven `*ngFor` row path
and a client-side `*clrDgItems` row path gated by an `@if`), so once that shared
provider is stuck `smart = true`, its stale `_pageSub` subscription keeps firing on
every page change.

Concretely, on a server-driven, paginated grid this means:
- `Items._all` / `_filtered` stop being refreshed with newly-fetched server pages,
  because the `!items.smart` guard in `ClrDatagrid` that normally applies new data
  no longer fires.
- The leaked `_pageSub` still triggers `_changePage()` on every page change, which
  slices the **stale** page-1 data using the **new** page's `firstItem`/`lastItem`
  (e.g. `10`/`19` against a 10-item array) — always out of range, so `displayed`
  becomes `[]`.
- `clr-dg-placeholder`'s `emptyDatagrid` check (`items.displayed.length === 0`) then
  incorrectly shows "No items found" over the grid, even though the correct page
  data was fetched and rendered underneath.

## What is the new behavior?

`ClrDatagridItems.ngOnDestroy()` now calls `this.items.smartenDown()` after
unsubscribing its own subscriptions, so tearing down a `*clrDgItems` view always
puts the shared `Items` provider back into "dumb" mode and clears out the
filter/sort/page subscriptions it created. This prevents the leaked pagination
subscription from slicing stale data against a new page's offsets.

Added regression tests in `datagrid-items.spec.ts` covering:
- The `Items` provider going back to `smart === false` once the `*clrDgItems` view
  is destroyed.
- `displayed` no longer reacting to `Page` changes after destroy, instead of
  slicing stale data with new offsets.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Repro path: a datagrid whose template briefly instantiates a `*clrDgItems` view
(directly or via a conditional template branch) alongside another row-rendering
path that manages `Items.all` itself (e.g. server-driven pagination). Once that
transient view is destroyed, the shared `Items` provider was left permanently
"smart" with a dangling page-change subscription, corrupting pagination on
subsequent page navigations.