### PR TITLE
fix(appfx-datagrid-filters): initialize searchTerm to prevent error on empty filter enter

### DIFF
--- a/projects/addons/datagrid-filters/datagrid-filters.component.ts
+++ b/projects/addons/datagrid-filters/datagrid-filters.component.ts
@@ -43,7 +43,7 @@ export class DataGridFiltersComponent implements OnDestroy, AfterViewInit {
 
   mode: FilterMode = FilterMode.Quick;
   selectedFilterMode: FilterMode = FilterMode.Quick;
-  searchTerm: string;
+  searchTerm: string = '';
 
   /**
    * Array of filterable properties


### PR DESCRIPTION
fix(datagrid-filters): initialize searchTerm to prevent error on empty filter enter

The searchTerm was undefined until the user typed a character, so calling .trim() in doSearch() threw when pressing Enter on an empty filter input.

## PR Checklist

- [X] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type



- [X] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?
The user press enter in empty search input leads to error


Issue Number: N/A

## What is the new behavior?
The filter has default value and the error is not repraducible.
## Does this PR introduce a breaking change?

- [ ] Yes
- [X] No