### PR TITLE
chore(release): recognize N.N.x maintenance branches in semantic-release config

### DIFF
--- a/.releaserc.base.js
+++ b/.releaserc.base.js
@@ -6,7 +6,13 @@
  */
 
 module.exports = {
-  branches: ['main', '+([0-9]).x', { name: 'beta', prerelease: true }, { name: 'next', prerelease: true }],
+  branches: [
+    'main',
+    '+([0-9]).x',
+    '+([0-9]).+([0-9]).x',
+    { name: 'beta', prerelease: true },
+    { name: 'next', prerelease: true },
+  ],
   plugins: [
     [
       '@semantic-release/commit-analyzer',


### PR DESCRIPTION
## What is the current behavior?

`.releaserc.base.js`'s `branches` config only includes `+([0-9]).x`, which matches single-level maintenance branches like `18.x` but not two-level ones like `18.2.x`. This means semantic-release doesn't recognize branches such as `18.2.x` as valid release branches, so triggering the release workflow from one (e.g. to cut a patch release like 18.2.2) would fail.

## What is the new behavior?

Added `+([0-9]).+([0-9]).x` to the `branches` array so two-level maintenance branches (`N.N.x`) are recognized alongside the existing `N.x` pattern.