### PR TITLE
fix(datagrid): break long unbreakable words in cells instead of overflowing

### DIFF
--- a/.storybook/stories/datagrid/datagrid.stories.ts
+++ b/.storybook/stories/datagrid/datagrid.stories.ts
@@ -69,6 +69,7 @@ export default {
     expandable: false,
     compact: false,
     overflowEllipsis: false,
+    longWordWrap: false,
     hidableColumns: false,
     showActions: false,
     height: 0,
@@ -170,6 +171,11 @@ const DatagridTemplate: StoryFn = args => ({
           <ng-container ${args.hidableColumns ? '*clrDgHideableColumn' : ''}>Long text width 250px</ng-container>
         </clr-dg-column>
       }
+      @if (longWordWrap) {
+        <clr-dg-column [style.width.px]="100">
+          <ng-container ${args.hidableColumns ? '*clrDgHideableColumn' : ''}>Narrow column, long word</ng-container>
+        </clr-dg-column>
+      }
       <clr-dg-column>
         <ng-container ${args.hidableColumns ? '*clrDgHideableColumn' : ''}>Electronegativity</ng-container>
       </clr-dg-column>
@@ -185,6 +191,9 @@ const DatagridTemplate: StoryFn = args => ({
             sed arcu. Vivamus in dui lectus. Suspendisse cursus est ac nisl imperdiet viverra. Aenean sagittis nibh lacus,
             in eleifend urna ultrices et. Mauris porttitor nisi nec velit pharetra porttitor. Vestibulum
           </clr-dg-cell>
+        }
+        @if (longWordWrap) {
+          <clr-dg-cell>pneumonoultramicroscopicsilicovolcanoconiosis</clr-dg-cell>
         }
         <clr-dg-cell class="electronegativity-container">
           {{ element.electronegativity }}
@@ -292,6 +301,14 @@ export const CompactOverflowEllipsis: StoryObj = {
     overflowEllipsis: true,
   },
 };
+
+export const LongWordWrap: StoryObj = {
+  render: DatagridTemplate,
+  args: {
+    longWordWrap: true,
+  },
+};
+
 export const ActionsBar: StoryObj = {
   render: DatagridTemplate,
   args: {

--- a/projects/angular/data/datagrid/_datagrid.clarity.scss
+++ b/projects/angular/data/datagrid/_datagrid.clarity.scss
@@ -603,6 +603,8 @@
       text-align: left;
       min-width: tokens.$cds-global-space-15;
       border: none;
+      overflow-wrap: anywhere;
+      word-break: normal;
 
       &.datagrid-fixed-width {
         flex: 0 0 auto;


### PR DESCRIPTION
## Summary
- Fixes CDE-2953: a datagrid cell containing a long word with no natural break point (no spaces/hyphens) overflows into neighboring cells once its column is resized narrower than the word, when `datagrid-overflow-ellipsis` is not used.
- Root cause: `.datagrid-cell` sets no `overflow-wrap`/`word-break` of its own, so it falls back to the browser default, which never breaks mid-word.
- Fix: add `overflow-wrap: anywhere; word-break: normal;` to the base `.datagrid-cell` rule — the same pairing already used for long-word wrapping in `combobox`, `wizard`, `stack-view`, and `timeline`. It only breaks a word mid-way as a last resort, when that single word alone is wider than the cell; ordinary multi-word content keeps wrapping at spaces exactly as before.
- Scoped to `.datagrid-table .datagrid-cell`, confirmed this does not reach the separate, hidden `.datagrid-calculation-table` used for auto-sizing column widths (they're sibling elements, not nested).
- Remains mutually exclusive with the opt-in `.datagrid-overflow-ellipsis` class: that class's `white-space: nowrap` suppresses all wrapping (including this fallback), so single-line truncation still works as before when explicitly requested.

Note: this was originally going to depend on CDE-2952 (a `cds-text` `break-word` modifier, see #2606) — but `clr-dg-cell` never applies `cds-text` to its content, so that alone wouldn't have fixed default cell content. This PR fixes the datagrid cell directly instead; #2606 ships the `cds-text` utility separately for consumers who want it on their own markup.

## Test plan
- [x] Added a `LongWordWrap` Storybook story (`Datagrid/Datagrid`) with a narrow 100px column containing a long unbroken word, demonstrating it wraps inside the cell instead of overflowing
- [x] Ran the full `clr-angular` datagrid test suite: 635/635 passing
- [x] `stylelint`, `eslint`, `prettier --check`, and the story-template formatter all clean on changed files

🤖 Generated with [Claude Code](https://claude.com/claude-code)