### PR TITLE
chore(website): prefix Wizard/Stepper/Tabs addon nav labels with "Advanced"

### DIFF
--- a/projects/website/src/settings/componentlist.json
+++ b/projects/website/src/settings/componentlist.json
@@ -358,19 +358,19 @@
     },
     {
       "url": "stepper-addon",
-      "text": "Stepper",
+      "text": "Advanced Stepper",
       "type": "addons",
       "storybookPath": "addons-stepper"
     },
     {
       "url": "wizard-addon",
-      "text": "Wizard",
+      "text": "Advanced Wizard",
       "type": "addons",
       "storybookPath": "addons-wizard"
     },
     {
       "url": "tabs-addon",
-      "text": "Tabs",
+      "text": "Advanced Tabs",
       "type": "addons",
       "storybookPath": "addons-tabs"
     },


### PR DESCRIPTION
## Summary
- Renames the `wizard-addon`, `stepper-addon`, and `tabs-addon` entries in `componentlist.json` to "Advanced Wizard", "Advanced Stepper", and "Advanced Tabs" respectively, so they no longer share an identical sidebar label with the base Clarity `Wizard`, `Stepper`, and `Tabs` components.
- Follow-up to the naming feedback raised on #2525 (comment on `componentlist.json`), agreed to be handled as a single separate PR covering all three addons instead of piecemeal.

This is the 5th PR in the addon-migration stack, based on top of #2527 (`addon/workflow-module`):
`next` ← #2525 (`addon/tabs`) ← #2526 (`addon/dialog`) ← #2527 (`addon/workflow-module`) ← this PR

## Test plan
- [x] Verified `componentlist.json` remains valid JSON
- [x] Confirmed no other file (docs, storybook titles, tests) references the old "Wizard"/"Stepper"/"Tabs" addon nav labels — page titles/breadcrumbs are derived from this file
- [ ] Reviewer to confirm no other addon docs page references the sidebar label directly

🤖 Generated with [Claude Code](https://claude.com/claude-code)