### PR TITLE
chore: raise dependabot PR limit and group dev-dependency updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,6 +5,11 @@ updates:
     target-branch: 'next'
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 20
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+        update-types: ['minor', 'patch']
     # Ignore major version bumps for all dependencies
     ignore:
       - dependency-name: '*'
@@ -15,6 +20,11 @@ updates:
     target-branch: 'main'
     schedule:
       interval: 'weekly'
+    open-pull-requests-limit: 20
+    groups:
+      dev-dependencies:
+        dependency-type: 'development'
+        update-types: ['minor', 'patch']
     # Ignore major version bumps for all dependencies
     ignore:
       - dependency-name: '*'


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [ ] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [x] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

`.github/dependabot.yml` has two independent npm update configs, one targeting `main` and one targeting `next`, neither of which sets `open-pull-requests-limit` or `groups`. That means:

- Each branch defaults to a cap of 5 open Dependabot PRs at a time.
- Every dependency gets its own separate PR (no grouping), so the 5-slot budget fills up quickly.
- A PR that's held back (e.g. pending human review of a CI failure) occupies a slot indefinitely, blocking Dependabot from opening PRs for other, unrelated packages on that branch.
- Since `main` and `next` are scanned and capped completely independently, they end up in different states depending on which slots happen to be free/held on each — causing `package.json` to drift between the two branches over time (confirmed via diff: 20+ dev-dependencies currently differ between `main` and `next`, in both directions).

## What is the new behavior?

- Raises `open-pull-requests-limit` to 20 on both the `main` and `next` update configs, so held/slow PRs no longer starve out unrelated updates.
- Adds a `groups.dev-dependencies` rule (minor/patch dev-dependency updates) so related bumps land as fewer, combined PRs per branch per week instead of one PR per package.

This doesn't retroactively fix the current drift between `main` and `next` — it stops the config from causing further drift going forward.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

N/A

---
_Generated by [Claude Code](https://claude.ai/code/session_01WuErWB3abmNJffWCHQH4FJ)_