### PR TITLE
fix(datagrid): avoid double "dialog" announcement in filter popover

### DIFF
--- a/projects/angular/data/datagrid/datagrid-filter.spec.ts
+++ b/projects/angular/data/datagrid/datagrid-filter.spec.ts
@@ -144,7 +144,7 @@ export default function (): void {
         context.detectChanges();
         const popoverContent = document.querySelector('.datagrid-filter');
         expect(popoverContent.getAttribute('role')).toBe('dialog');
-        expect(popoverContent.getAttribute('aria-label')).toBe('Filter dialog');
+        expect(popoverContent.getAttribute('aria-label')).toBe('Filter');
       });
 
       it('projects content into the dropdown', function () {

--- a/projects/angular/utils/i18n/common-strings.default.ts
+++ b/projects/angular/utils/i18n/common-strings.default.ts
@@ -60,7 +60,7 @@ export const commonStringsDefault: ClrCommonStrings = {
   detailExpandableAriaLabel: 'Toggle more row content',
   datagridFilterAriaLabel: '{COLUMN} filter',
   datagridFilterLabel: '{COLUMN} filter',
-  datagridFilterDialogAriaLabel: 'Filter dialog',
+  datagridFilterDialogAriaLabel: 'Filter',
   columnSeparatorAriaLabel: 'Column resize handle',
   columnSeparatorDescription: 'Use left or right key to resize the column',
   fromLabel: 'From',

--- a/projects/angular/utils/i18n/common-strings.interface.ts
+++ b/projects/angular/utils/i18n/common-strings.interface.ts
@@ -158,7 +158,9 @@ export interface ClrCommonStrings {
    */
   datagridFilterLabel: string;
   /**
-   * Datagrid filter dialog
+   * Datagrid filter dialog.
+   * The popover already has `role="dialog"`, so this label should not include the word "dialog"
+   * to avoid screen readers announcing it twice.
    */
   datagridFilterDialogAriaLabel: string;
   /**


### PR DESCRIPTION
## PR Checklist

Please check if your PR fulfills the following requirements:

- [x] Tests for the changes have been added (for bug fixes / features)
- [x] Docs have been added / updated (for bug fixes / features)
- [ ] If applicable, have a visual design approval

## PR Type

What kind of change does this PR introduce?

- [x] Bugfix
- [ ] Feature
- [ ] Code style update (formatting, local variables)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Build related changes
- [ ] CI related changes
- [ ] Documentation content changes
- [ ] Other... Please describe:

## What is the current behavior?

Issue Number: N/A

The datagrid filter popover (`clr-dg-filter`) has `role="dialog"` and takes its accessible name from the `datagridFilterDialogAriaLabel` common string, whose default value is `Filter dialog`. Screen readers append the element's role to its accessible name, so opening any column filter is announced as "Filter dialog, dialog".

## What is the new behavior?

- The default `datagridFilterDialogAriaLabel` string is now `Filter`, so the popover is announced as "Filter, dialog" (the role is read once).
- The `ClrCommonStrings` interface doc comment for the key now notes that the popover already carries `role="dialog"`, so translations should not repeat the word "dialog".
- The existing `datagrid-filter.spec.ts` assertion is updated to the new default label.

The `role="dialog"` attribute is kept on the popover so focus-trap/dialog semantics for assistive technology are unchanged. Applications that already override `datagridFilterDialogAriaLabel` with their own string are unaffected.

## Does this PR introduce a breaking change?

- [ ] Yes
- [x] No

## Other information

Verified locally: prettier and eslint pass on the changed files, and the full datagrid Karma suite (`projects/angular/data/datagrid/all.spec.ts`) passes (680/680).
